### PR TITLE
fix(release): build arm64 and ship desktop data files in archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
@@ -58,6 +59,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     mod_timestamp: "{{ .CommitTimestamp }}"
     flags:
       - -trimpath
@@ -69,6 +71,14 @@ archives:
   - files:
       - README.md
       - LICENSE
+      - config.yml
+      - data/chairlift-wrapper.sh
+      - data/org.frostyard.ChairLift.desktop
+      - data/icons/**/*
+      - data/org.frostyard.ChairLift.bootc.policy
+      - data/org.frostyard.ChairLift.bootc.rules
+      - data/org.frostyard.ChairLift.updex.policy
+      - data/org.frostyard.ChairLift.updex.rules
 
 
 checksum:


### PR DESCRIPTION
Bluefin is adopting ChairLift via a Homebrew cask in frostyard/homebrew-tap (as discussed). Two release gaps block that:

1. Only linux/amd64 is built; Bluefin ships arm64 images too.
2. Release tarballs contain only the binaries + README/LICENSE, so a cask has no desktop file, icons, wrapper, polkit policies, or default config to install.

This change:
- adds linux/arm64 to both build matrices. puregotk is pure Go with CGO_ENABLED=0, so cross-compilation needs no toolchain changes; nfpm rpm/deb/apk gain arm64 automatically.
- includes config.yml and the data/ desktop-integration files in the release archives. The nfpm packages already ship these; this brings the tarballs to parity.

A follow-up issue will cover the bootc-staging polkit integration questions for non-Snow distros.

cc @castrojo