### PR TITLE
Align source installation paths with Updex helper PolicyKit policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,11 @@ The app builds pure-Go (`CGO_ENABLED=0`); the race detector needs CGO.
   `go vet`, gofmt check, lint, unit tests, race detector, build). Run it before
   pushing; green locally means green in CI. The mill's deep gate calls this
   exact target.
+- `make install`'s default `PREFIX` is `/usr` — the only prefix under which
+  the installed PolicyKit policy/rules files land where `polkitd` reads them
+  (`/usr/share/polkit-1/{actions,rules.d}`) and the updex helper's installed
+  path matches its fixed `pkexec` exec-path annotation (see the privilege
+  boundary invariant below).
 
 CI (`.github/workflows/test.yml`) filters tests with `-run "^Test[^I]"
 -skip "Integration"`. Names beginning `TestI…` or containing `Integration` are
@@ -36,10 +41,13 @@ An agent must not break these:
 - **Privilege boundary.** State-changing operations that require root go
   through `pkexec` (PolicyKit) with fixed, installed polkit policies and fixed
   helper binaries only: `pkexec /usr/libexec/bootc-update-stage` (action
-  `org.frostyard.ChairLift.bootc.stage`) and the `chairlift-updex-helper` binary
-  (action for updex writes). Homebrew tap trust (`brew trust`) is deliberately
-  per-user and does **not** use pkexec. Do not add arbitrary privileged command
-  execution, broaden what pkexec runs, or route new mutations around the fixed
+  `org.frostyard.ChairLift.bootc.stage`) and `pkexec /usr/bin/chairlift-updex-helper`
+  (`internal/updex.HelperPath`, action for updex writes) — always that fixed
+  absolute path, matching the `org.freedesktop.policykit.exec.path` annotation
+  in `data/org.frostyard.ChairLift.updex.policy`, never a bare/`$PATH`-resolved
+  name. Homebrew tap trust (`brew trust`) is deliberately per-user and does
+  **not** use pkexec. Do not add arbitrary privileged command execution,
+  broaden what pkexec runs, or route new mutations around the fixed
   helper/policy pair.
 - **GTK main-thread safety.** All external tool calls run in goroutines; every
   UI update marshals back to the GTK main thread via

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,20 @@ HELPER_NAME=chairlift-updex-helper
 BUILD_DIR=build
 
 # Installation directories
-PREFIX ?= /usr/local
+#
+# PREFIX defaults to /usr, matching both the fixed absolute path pkexec
+# matches against PolicyKit's org.freedesktop.policykit.exec.path annotation
+# (data/org.frostyard.ChairLift.updex.policy, internal/updex.HelperPath) and
+# the layout .goreleaser.yaml's nFPM packages already install to. PolicyKit
+# itself only ever reads actions/rules from /usr/share/polkit-1/{actions,
+# rules.d} — it does not consult PREFIX or XDG_DATA_DIRS — so installing
+# under any other PREFIX means the .policy/.rules files land somewhere
+# polkit never looks. Override PREFIX for a non-privileged dev install (e.g.
+# `make install PREFIX=$$HOME/.local`), but understand that the
+# PolicyKit-authenticated updex helper path then no longer resolves to the
+# fixed exec.path annotation. DESTDIR (below) still layers under PREFIX
+# unchanged, for staged/packaged installs.
+PREFIX ?= /usr
 BINDIR = $(PREFIX)/bin
 DATADIR = $(PREFIX)/share
 ICONSDIR = $(DATADIR)/icons

--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ make build
 sudo make install
 ```
 
+`/usr` is the **only** supported `PREFIX` for an installation that
+participates in PolicyKit authentication (`sudo make install` uses it by
+default — no need to pass `PREFIX` explicitly). PolicyKit's `polkitd` reads
+`.policy`/`.rules` files only from the fixed system directories
+`/usr/share/polkit-1/actions` and `/usr/share/polkit-1/rules.d`, and `pkexec`
+matches the updex helper it's asked to run against the absolute path
+`/usr/bin/chairlift-updex-helper` recorded in
+`data/org.frostyard.ChairLift.updex.policy`'s
+`org.freedesktop.policykit.exec.path` annotation. Installing under any other
+prefix places those files where polkit never looks, so the privileged
+updex and bootc-staging features silently stop working (or fall back to a
+more restrictive, always-reprompting authentication rule). This also matches
+the layout used by ChairLift's own `.goreleaser.yaml` packages, so a source
+install and a packaged install end up identical.
+
+`PREFIX` can still be overridden (e.g. `make install PREFIX=$HOME/.local`)
+for a non-privileged, non-PolicyKit-integrated install — but the updex
+helper and bootc staging will not resolve to the fixed exec-path annotation
+in that case.
+
+`DESTDIR` layers underneath `PREFIX` as usual, unchanged by any of the
+above, for staged/packaged installs (`make install DESTDIR=/path/to/stage
+PREFIX=/usr`) — this is what `.goreleaser.yaml`'s nFPM packaging uses.
+
+**Migrating from a prior `/usr/local` source install:** `PREFIX` used to
+default to `/usr/local`. Before reinstalling at the new `/usr` default,
+remove the old install with `sudo make uninstall PREFIX=/usr/local`.
+
 Other useful targets: `make dev` (CGO-enabled build with `-race` for development), `make fmt`, `make lint`, `make build-linux-amd64` / `make build-linux-arm64` (cross-compilation), `make uninstall`.
 
 ### Dependencies

--- a/docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md
+++ b/docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md
@@ -1,0 +1,28 @@
+# "Verified by inspection" does not satisfy a spec's testing acceptance criterion
+
+**When it applies:** Drafting or revising a plan chunk where the spec's
+acceptance criteria say something must be "tested," "tested for consistency,"
+or otherwise verified — and part of that surface (a config file, a generated
+package layout, a second code path) is already correct today, tempting a plan
+to mark it as satisfied by manual inspection rather than by adding it to the
+gated check.
+
+**What to do:** If an acceptance criterion asks for a consistency check
+across multiple sources of truth (e.g. "the nFPM/package layout and the
+source-install layout must agree"), every part of that criterion needs a real
+executable, gated check — not a plan note like "`.goreleaser.yaml` is already
+correct, verified by inspection, not modified." Inspection notes don't run in
+CI and don't fail when the underlying file later drifts, so a reviewer will
+treat them as leaving the acceptance criterion uncovered and reject the plan.
+When part of the surface is already correct, that's a reason to write a check
+that currently passes without needing a code fix — not a reason to skip
+writing the check. Scope the chunk to add the automated assertion even for
+the "already fine" half of a consistency requirement.
+
+**Learned from:** issue #59's mill run, plan round 1 — the plan added an
+automated Makefile/DESTDIR install-path check but handled the nFPM package
+layout only by inspection, claiming `.goreleaser.yaml` was "already correct."
+The reviewer rejected the plan because the spec's nFPM consistency criterion
+had no concrete check behind it. Round 2 fixed it by adding
+`TestGoreleaserNfpmLayoutMatchesUsrPrefix`, a real gated test parsing the live
+`.goreleaser.yaml`.

--- a/docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md
+++ b/docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md
@@ -1,0 +1,29 @@
+# A chunk that changes what AGENTS.md asserts must list AGENTS.md itself in `files`
+
+**When it applies:** Planning or reviewing any chunk that changes a fixed
+path, default, or invariant that AGENTS.md's "Repository invariants" or
+"Build, test, lint" sections currently describe in prose — e.g. the
+`chairlift-updex-helper` install path, the `pkexec` targets, the default
+`make install` `PREFIX`, or any other fact AGENTS.md states as fact rather
+than pointing to code for.
+
+**What to do:** AGENTS.md's own documentation rule ("after any change to
+source code, update relevant documentation in AGENTS.md, README.md, and the
+`yeti/` folder") is enforced by plan review as a real, per-chunk acceptance
+criterion — not just a closing-checklist reminder. Updating README.md and
+`yeti/` while leaving AGENTS.md's prose making the old claim (a bare helper
+name, an unstated default prefix, etc.) will be rejected even though README
+and yeti were both updated, because AGENTS.md itself is now stale and it is
+one of the three named locations. When drafting a chunk's `files` list, check
+each changed invariant against AGENTS.md's current wording specifically (not
+just "did I update docs somewhere") and add AGENTS.md whenever the chunk
+changes a fact AGENTS.md states — but don't pad an unrelated chunk with an
+AGENTS.md edit it doesn't need just to be safe; "relevant" is the bar, not
+"every chunk touches every doc."
+
+**Learned from:** issue #59's mill run, plan round 2 — a chunk changed the
+updex helper invocation to a fixed `/usr/bin/chairlift-updex-helper` path and
+changed the supported source-install prefix, updating README.md and yeti/ but
+omitting AGENTS.md from its `files`/acceptance criteria. The reviewer rejected
+the plan because AGENTS.md's privilege-boundary and build/install text were
+now directly stale, even though the other two doc locations were current.

--- a/docs/agents/skills/regression-tests-must-cover-every-collection-entry.md
+++ b/docs/agents/skills/regression-tests-must-cover-every-collection-entry.md
@@ -1,0 +1,32 @@
+# Consistency-check tests must iterate every entry, not just index 0
+
+**When it applies:** Writing or revising any regression test that asserts a
+property against a real config file or generated collection with a slice/list
+field — e.g. `.goreleaser.yaml`'s `nfpms[]`, `contents[]`, or any other
+`[]T` parsed from a repo asset — where the spec's acceptance criterion is a
+consistency invariant ("layout matches `/usr`", "all entries agree with X")
+rather than a single fixed value.
+
+**What to do:** Index into element `[0]` only as a first draft, then
+immediately generalize before submitting for review: loop over the whole
+slice (`for i, n := range cfg.Nfpms { ... }`) and assert the property on every
+entry, not just the first. A test that hard-codes `cfg.Nfpms[0]` (or
+equivalent) passes today but silently stops protecting anything the moment a
+second entry is added or an existing one is reordered — which is exactly the
+gap a reviewer checking the acceptance criterion will flag. If a review
+objection says "only checks the first/one instance, iterate all", treat that
+as a request to change the loop bound, not to add a comment or an extra
+single-index assertion next to the existing one — a partial fix that still
+special-cases index 0 will read as the same bug on the next review pass and
+costs a full extra review round for no progress. When the collection could
+legitimately be empty, also assert `len(...) > 0` (or otherwise fail loudly)
+so the loop can't silently no-op.
+
+**Learned from:** issue #59's mill run — `TestGoreleaserNfpmLayoutMatchesUsrPrefix`
+in `internal/installcheck/goreleaser_test.go` checked only `cfg.Nfpms[0]`
+against the acceptance criterion "the nFPM layout is tested for consistency
+across all packages." The reviewer raised the identical objection across
+three consecutive revision rounds (medium, then medium, then escalated to
+high) because each revision left the single-index check in place instead of
+looping over `cfg.Nfpms`; the chunk exhausted its review-round budget and the
+run was terminated as failed without ever generalizing the loop.

--- a/docs/agents/skills/regression-tests-must-cover-every-collection-entry.md
+++ b/docs/agents/skills/regression-tests-must-cover-every-collection-entry.md
@@ -28,5 +28,8 @@ against the acceptance criterion "the nFPM layout is tested for consistency
 across all packages." The reviewer raised the identical objection across
 three consecutive revision rounds (medium, then medium, then escalated to
 high) because each revision left the single-index check in place instead of
-looping over `cfg.Nfpms`; the chunk exhausted its review-round budget and the
-run was terminated as failed without ever generalizing the loop.
+looping over `cfg.Nfpms`. The chunk only converged — generalizing to a
+`for i, nfpm := range cfg.Nfpms` loop with a per-entry `t.Run` — after
+burning all three rounds on the same feedback; treat "only checks the
+first/one instance" as a signal to generalize the loop bound on the *first*
+revision, not to patch around index 0 again.

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -1,6 +1,7 @@
 package installcheck
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,12 +49,17 @@ func nfpmDst(t *testing.T, nfpm NfpmConfig, srcSuffix string) string {
 // and the fixed PolicyKit read locations, so a future edit to any one of
 // .goreleaser.yaml, internal/updex.HelperPath, or the polkit directories
 // fails this test instead of silently drifting.
+//
+// It iterates every nfpms[] entry rather than only nfpms[0]: the acceptance
+// criterion is a consistency invariant across the whole nFPM block, so adding
+// or reordering a second package with the wrong bindir or polkit destinations
+// must fail here too (per
+// docs/agents/skills/regression-tests-must-cover-every-collection-entry.md).
 func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 	cfg := loadGoreleaserConfig(t)
 	if len(cfg.Nfpms) == 0 {
 		t.Fatal(".goreleaser.yaml has no nfpms entries")
 	}
-	nfpm := cfg.Nfpms[0]
 
 	// nFPM auto-packages both build ids' binaries (chairlift,
 	// chairlift-updex-helper) into bindir, so bindir alone determines where
@@ -62,11 +68,9 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 	// against the PolicyKit policy's exec.path annotation — not just a
 	// hardcoded "/usr/bin" literal, so this fails if either side changes
 	// without the other.
-	if wantBindir := filepath.Dir(updex.HelperPath); nfpm.Bindir != wantBindir {
-		t.Errorf("nfpms[0].bindir = %q, want %q (must match the directory of internal/updex.HelperPath)", nfpm.Bindir, wantBindir)
-	}
+	wantBindir := filepath.Dir(updex.HelperPath)
 
-	tests := []struct {
+	contentChecks := []struct {
 		name      string
 		srcSuffix string
 		want      string
@@ -76,11 +80,20 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 		{"bootc policy", "org.frostyard.ChairLift.bootc.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy")},
 		{"bootc rules", "org.frostyard.ChairLift.bootc.rules", filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.bootc.rules")},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := nfpmDst(t, nfpm, tt.srcSuffix)
-			if got != tt.want {
-				t.Errorf("nfpm contents dst for %s = %q, want %q (fixed PolicyKit read location)", tt.srcSuffix, got, tt.want)
+
+	for i, nfpm := range cfg.Nfpms {
+		t.Run(fmt.Sprintf("nfpms[%d]", i), func(t *testing.T) {
+			if nfpm.Bindir != wantBindir {
+				t.Errorf("nfpms[%d].bindir = %q, want %q (must match the directory of internal/updex.HelperPath)", i, nfpm.Bindir, wantBindir)
+			}
+
+			for _, cc := range contentChecks {
+				t.Run(cc.name, func(t *testing.T) {
+					got := nfpmDst(t, nfpm, cc.srcSuffix)
+					if got != cc.want {
+						t.Errorf("nfpms[%d] contents dst for %s = %q, want %q (fixed PolicyKit read location)", i, cc.srcSuffix, got, cc.want)
+					}
+				})
 			}
 		})
 	}

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -1,0 +1,87 @@
+package installcheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/chairlift/internal/updex"
+	"gopkg.in/yaml.v3"
+)
+
+// loadGoreleaserConfig parses the real, repo-root .goreleaser.yaml — not a
+// fixture or copy that could drift from the file goreleaser actually reads
+// — using the yaml.v3 dependency already vendored for internal/config.
+func loadGoreleaserConfig(t *testing.T) GoreleaserConfig {
+	t.Helper()
+
+	path := filepath.Join(RepoRoot(), ".goreleaser.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	var cfg GoreleaserConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	return cfg
+}
+
+// nfpmDst finds the contents[] entry whose src ends in srcSuffix and returns
+// its dst, failing the test if no such entry exists.
+func nfpmDst(t *testing.T, nfpm NfpmConfig, srcSuffix string) string {
+	t.Helper()
+
+	for _, c := range nfpm.Contents {
+		if strings.HasSuffix(c.Src, srcSuffix) {
+			return c.Dst
+		}
+	}
+	t.Fatalf("no nfpm contents entry with src ending in %q", srcSuffix)
+	return ""
+}
+
+// TestGoreleaserNfpmLayoutMatchesUsrPrefix parses the real .goreleaser.yaml
+// and asserts its nFPM package layout agrees with internal/updex.HelperPath
+// and the fixed PolicyKit read locations, so a future edit to any one of
+// .goreleaser.yaml, internal/updex.HelperPath, or the polkit directories
+// fails this test instead of silently drifting.
+func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
+	cfg := loadGoreleaserConfig(t)
+	if len(cfg.Nfpms) == 0 {
+		t.Fatal(".goreleaser.yaml has no nfpms entries")
+	}
+	nfpm := cfg.Nfpms[0]
+
+	// nFPM auto-packages both build ids' binaries (chairlift,
+	// chairlift-updex-helper) into bindir, so bindir alone determines where
+	// the packaged updex helper lands. It must match the directory of
+	// internal/updex.HelperPath — the fixed absolute path pkexec matches
+	// against the PolicyKit policy's exec.path annotation — not just a
+	// hardcoded "/usr/bin" literal, so this fails if either side changes
+	// without the other.
+	if wantBindir := filepath.Dir(updex.HelperPath); nfpm.Bindir != wantBindir {
+		t.Errorf("nfpms[0].bindir = %q, want %q (must match the directory of internal/updex.HelperPath)", nfpm.Bindir, wantBindir)
+	}
+
+	tests := []struct {
+		name      string
+		srcSuffix string
+		want      string
+	}{
+		{"updex policy", "org.frostyard.ChairLift.updex.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy")},
+		{"updex rules", "org.frostyard.ChairLift.updex.rules", filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.updex.rules")},
+		{"bootc policy", "org.frostyard.ChairLift.bootc.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy")},
+		{"bootc rules", "org.frostyard.ChairLift.bootc.rules", filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.bootc.rules")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nfpmDst(t, nfpm, tt.srcSuffix)
+			if got != tt.want {
+				t.Errorf("nfpm contents dst for %s = %q, want %q (fixed PolicyKit read location)", tt.srcSuffix, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/installcheck/installcheck.go
+++ b/internal/installcheck/installcheck.go
@@ -1,0 +1,55 @@
+// Package installcheck contains headless, gate-enforced regression tests
+// that verify the repository's two installation paths — a source `make
+// install` and the packaged nFPM (deb/rpm/apk) layout produced from
+// .goreleaser.yaml — stay in agreement with each other and with
+// internal/updex.HelperPath, the fixed absolute path PolicyKit's
+// org.freedesktop.policykit.exec.path annotation requires (see
+// internal/updex/updex.go and data/org.frostyard.ChairLift.updex.policy).
+//
+// This package holds no logic reachable from cmd/ or any other internal/
+// package — only shared test-time helpers used by makefile_test.go and
+// goreleaser_test.go. It imports no puregotk, directly or transitively, so a
+// _test.go living here never trips the gtk-headless-tests.md constraint
+// (docs/agents/skills/gtk-headless-tests.md), and it lives under
+// internal/... so it is actually exercised by gates_chunk, make ci, and CI's
+// `go test ./internal/...` filter, per
+// docs/agents/skills/gate-test-scope-is-internal-only.md.
+package installcheck
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// RepoRoot returns the absolute path to the repository root. It is computed
+// from this source file's own location (via runtime.Caller) rather than the
+// test binary's working directory: `go test` runs each package's tests with
+// the package directory as cwd, not the repo root, and internal/installcheck
+// sits two directories below the repo root
+// (<root>/internal/installcheck/installcheck.go).
+func RepoRoot() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+}
+
+// GoreleaserConfig is a minimal, forward-compatible subset of the fields in
+// .goreleaser.yaml this package's tests care about. yaml.v3's default
+// unmarshaling silently ignores every field not named here, so this struct
+// does not need to (and deliberately does not) mirror the whole schema.
+type GoreleaserConfig struct {
+	Nfpms []NfpmConfig `yaml:"nfpms"`
+}
+
+// NfpmConfig is the subset of an nfpms[] entry relevant to install-location
+// consistency: where packaged binaries land (Bindir) and where explicitly
+// listed files (policy/rules, wrapper script, icons, ...) land (Contents).
+type NfpmConfig struct {
+	Bindir   string        `yaml:"bindir"`
+	Contents []NfpmContent `yaml:"contents"`
+}
+
+// NfpmContent is one nfpm contents[] entry's source/destination pair.
+type NfpmContent struct {
+	Src string `yaml:"src"`
+	Dst string `yaml:"dst"`
+}

--- a/internal/installcheck/makefile_test.go
+++ b/internal/installcheck/makefile_test.go
@@ -1,0 +1,90 @@
+package installcheck
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/frostyard/chairlift/internal/updex"
+)
+
+// PolicyKit's polkitd is compiled with a fixed actions/rules directory and
+// does not consult PREFIX or XDG_DATA_DIRS (see the Makefile's PREFIX
+// comment and yeti/OVERVIEW.md's "Privileged operations" section), so these
+// two locations must never move regardless of what PREFIX resolves to.
+const (
+	polkitActionsDir = "/usr/share/polkit-1/actions"
+	polkitRulesDir   = "/usr/share/polkit-1/rules.d"
+)
+
+// runMakeInstallDryRun runs `make -n install DESTDIR=<destDir> [extraArgs...]`
+// from the repo root and returns its combined output. `-n` is a dry run:
+// make prints the recipe's shell command lines without executing them, so
+// this never compiles anything, writes outside destDir, or requires root
+// (confirmed by hand during planning and again here: the real `install`
+// target's first two recipe lines are `go build` invocations that a dry run
+// only prints).
+func runMakeInstallDryRun(t *testing.T, destDir string, extraArgs ...string) string {
+	t.Helper()
+
+	args := append([]string{"-n", "install", "DESTDIR=" + destDir}, extraArgs...)
+	cmd := exec.Command("make", args...)
+	cmd.Dir = RepoRoot()
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("make %s failed: %v\noutput:\n%s", strings.Join(args, " "), err, out.String())
+	}
+	return out.String()
+}
+
+// assertInstallsHelperAndPolicies checks that a `make -n install` dry-run's
+// output places the updex helper binary at DESTDIR+updex.HelperPath (cross-
+// referencing internal/updex.HelperPath as the single source of truth for
+// both the helper's installed directory and file name, per c1) and both
+// PolicyKit policy/rules pairs under DESTDIR + the fixed polkit-1
+// directories.
+func assertInstallsHelperAndPolicies(t *testing.T, output, destDir string) {
+	t.Helper()
+
+	wantHelper := filepath.Join("build", filepath.Base(updex.HelperPath)) +
+		" " + filepath.Join(destDir, updex.HelperPath)
+	if !strings.Contains(output, wantHelper) {
+		t.Errorf("make -n install output does not install the updex helper at DESTDIR+HelperPath\nwant substring: %q\noutput:\n%s", wantHelper, output)
+	}
+
+	for _, rel := range []string{
+		filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy"),
+		filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.updex.rules"),
+		filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy"),
+		filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.bootc.rules"),
+	} {
+		want := filepath.Join(destDir, rel)
+		if !strings.Contains(output, want) {
+			t.Errorf("make -n install output does not target %q (fixed PolicyKit read location)\noutput:\n%s", want, output)
+		}
+	}
+}
+
+// TestMakefileInstallUsesUsrPrefix is a real, gated consistency check
+// between the Makefile's install recipe and internal/updex.HelperPath: it
+// fails if either changes without the other, or if the Makefile's PREFIX
+// default (or an explicit PREFIX=/usr) stops deriving the helper and
+// policy/rules destinations from /usr.
+func TestMakefileInstallUsesUsrPrefix(t *testing.T) {
+	t.Run("default PREFIX", func(t *testing.T) {
+		destDir := t.TempDir()
+		out := runMakeInstallDryRun(t, destDir)
+		assertInstallsHelperAndPolicies(t, out, destDir)
+	})
+
+	t.Run("explicit PREFIX=/usr", func(t *testing.T) {
+		destDir := t.TempDir()
+		out := runMakeInstallDryRun(t, destDir, "PREFIX=/usr")
+		assertInstallsHelperAndPolicies(t, out, destDir)
+	})
+}

--- a/internal/updex/updex.go
+++ b/internal/updex/updex.go
@@ -16,7 +16,21 @@ import (
 )
 
 const (
-	helperCommand  = "chairlift-updex-helper"
+	// HelperPath is the fixed, absolute installed path of the privileged
+	// updex helper binary. It must match the
+	// org.freedesktop.policykit.exec.path annotation on all three actions in
+	// data/org.frostyard.ChairLift.updex.policy exactly: pkexec resolves the
+	// program it is about to run to an absolute path and compares it
+	// textually against that annotation to pick the matching
+	// org.frostyard.ChairLift.updex.* action (and its no-reprompt
+	// sudo-group rule in data/org.frostyard.ChairLift.updex.rules). A
+	// mismatch (e.g. a bare, $PATH-resolved name) makes pkexec silently fall
+	// back to the generic, more restrictive
+	// org.freedesktop.policykit.pkexec.run-program action instead. This
+	// constant is installed at $(PREFIX)/bin/chairlift-updex-helper by the
+	// Makefile, which requires PREFIX=/usr (the default) to match.
+	HelperPath = "/usr/bin/chairlift-updex-helper"
+
 	pkexecCommand  = "pkexec"
 	DefaultTimeout = 5 * time.Minute
 )
@@ -119,32 +133,40 @@ func CheckFeatures(ctx context.Context) ([]FeatureCheck, error) {
 
 // EnableFeature enables a feature for download
 func EnableFeature(ctx context.Context, name string) error {
-	_, _, err := runHelper(ctx, "enable-feature", name)
+	_, _, err := runHelper(ctx, pkexecCommand, "enable-feature", name)
 	return err
 }
 
 // DisableFeature disables a feature
 func DisableFeature(ctx context.Context, name string) error {
-	_, _, err := runHelper(ctx, "disable-feature", name)
+	_, _, err := runHelper(ctx, pkexecCommand, "disable-feature", name)
 	return err
 }
 
 // UpdateFeatures downloads enabled features
 func UpdateFeatures(ctx context.Context) error {
-	_, _, err := runHelper(ctx, "update")
+	_, _, err := runHelper(ctx, pkexecCommand, "update")
 	return err
 }
 
-// runHelper executes the chairlift-updex-helper via pkexec for privileged operations
-func runHelper(ctx context.Context, args ...string) (string, string, error) {
+// runHelper executes HelperPath via pkexec for privileged operations. pkexecPath
+// is the pkexec binary to invoke — always pkexecCommand in production, but an
+// explicit parameter (mirroring internal/bootc/stage.go's
+// runStageStreaming(ctx, ch, name, args...) pattern) so tests can substitute a
+// fake pkexec stand-in without invoking the real pkexec/polkit stack or
+// requiring root. HelperPath itself is never overridden: it is the fixed
+// absolute path that must match the policy's exec.path annotation, so tests
+// assert it by inspecting the fake pkexec's captured argv rather than by
+// substituting a different one in.
+func runHelper(ctx context.Context, pkexecPath string, args ...string) (string, string, error) {
 	if dryRun {
 		args = append(args, "--dry-run")
-		log.Printf("[DRY-RUN] would execute: pkexec %s %v", helperCommand, args)
+		log.Printf("[DRY-RUN] would execute: %s %s %v", pkexecPath, HelperPath, args)
 		return "", "", nil
 	}
 
-	fullArgs := append([]string{helperCommand}, args...)
-	cmd := exec.CommandContext(ctx, pkexecCommand, fullArgs...)
+	fullArgs := append([]string{HelperPath}, args...)
+	cmd := exec.CommandContext(ctx, pkexecPath, fullArgs...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/updex/updex_test.go
+++ b/internal/updex/updex_test.go
@@ -1,0 +1,83 @@
+package updex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeFakePkexec writes an executable shell script standing in for pkexec:
+// it records its own argv (one element per line) to capturedArgsFile and
+// exits 0. It never execs the real pkexec or requires root.
+func writeFakePkexec(t *testing.T, capturedArgsFile string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-pkexec")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + capturedArgsFile + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("writing fake pkexec: %v", err)
+	}
+	return path
+}
+
+func TestRunHelperNonDryRunInvokesPkexecWithAbsoluteHelperPath(t *testing.T) {
+	SetDryRun(false)
+
+	capturedArgsFile := filepath.Join(t.TempDir(), "captured-args")
+	fakePkexec := writeFakePkexec(t, capturedArgsFile)
+
+	ctx := context.Background()
+	if _, _, err := runHelper(ctx, fakePkexec, "enable-feature", "demo"); err != nil {
+		t.Fatalf("runHelper: %v", err)
+	}
+
+	data, err := os.ReadFile(capturedArgsFile)
+	if err != nil {
+		t.Fatalf("reading captured pkexec argv: %v", err)
+	}
+	got := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	want := []string{HelperPath, "enable-feature", "demo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("pkexec argv = %v, want %v", got, want)
+	}
+	if got[0] != "/usr/bin/chairlift-updex-helper" {
+		t.Fatalf("helper path passed to pkexec = %q, want the fixed absolute path matching data/org.frostyard.ChairLift.updex.policy's exec.path annotation", got[0])
+	}
+}
+
+func TestRunHelperDryRunNeverInvokesPkexec(t *testing.T) {
+	SetDryRun(true)
+	defer SetDryRun(false)
+
+	// A path that does not exist: if runHelper failed to short-circuit and
+	// tried to actually run it, cmd.Run() would return an error and this
+	// test would fail loudly instead of silently passing.
+	nonexistentPkexec := filepath.Join(t.TempDir(), "pkexec-should-never-run")
+
+	ctx := context.Background()
+	stdout, stderr, err := runHelper(ctx, nonexistentPkexec, "enable-feature", "demo")
+	if err != nil {
+		t.Fatalf("runHelper dry-run returned error, want short-circuit with nil error: %v", err)
+	}
+	if stdout != "" || stderr != "" {
+		t.Fatalf("runHelper dry-run returned stdout=%q stderr=%q, want both empty", stdout, stderr)
+	}
+}
+
+func TestEnableDisableUpdateFeaturesDryRunNeverInvokePkexec(t *testing.T) {
+	SetDryRun(true)
+	defer SetDryRun(false)
+
+	ctx := context.Background()
+	if err := EnableFeature(ctx, "demo"); err != nil {
+		t.Errorf("EnableFeature dry-run: %v", err)
+	}
+	if err := DisableFeature(ctx, "demo"); err != nil {
+		t.Errorf("DisableFeature dry-run: %v", err)
+	}
+	if err := UpdateFeatures(ctx); err != nil {
+		t.Errorf("UpdateFeatures dry-run: %v", err)
+	}
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -143,7 +143,29 @@ The updates page tracks counts from bootc, Flatpak, and Homebrew separately (`bo
 
 ### Privileged operations
 
-bootc staging and updex require root for state-changing operations. They invoke commands through `pkexec` (PolicyKit). bootc runs `pkexec /usr/libexec/bootc-update-stage` directly (polkit action id `org.frostyard.ChairLift.bootc.stage`), while updex delegates to a separate `chairlift-updex-helper` binary via `pkexec`. Polkit policy files are installed for both: `data/org.frostyard.ChairLift.bootc.policy` and `data/org.frostyard.ChairLift.updex.policy`. Homebrew tap trust (`brew trust`) is explicitly per-user and does *not* go through pkexec — see [package-managers.md](./package-managers.md).
+bootc staging and updex require root for state-changing operations. They invoke commands through `pkexec` (PolicyKit). bootc runs `pkexec /usr/libexec/bootc-update-stage` directly (polkit action id `org.frostyard.ChairLift.bootc.stage`), while updex delegates to the fixed absolute path `internal/updex.HelperPath` (`/usr/bin/chairlift-updex-helper`) via `pkexec`. Polkit policy files are installed for both: `data/org.frostyard.ChairLift.bootc.policy` and `data/org.frostyard.ChairLift.updex.policy`. Homebrew tap trust (`brew trust`) is explicitly per-user and does *not* go through pkexec — see [package-managers.md](./package-managers.md).
+
+**Why the helper path must be absolute, and why `PREFIX=/usr`:** `pkexec`
+resolves the program it's asked to run to an absolute path and compares it
+textually against the `org.freedesktop.policykit.exec.path` annotation on
+each action in `data/org.frostyard.ChairLift.updex.policy` (all three
+actions annotate `/usr/bin/chairlift-updex-helper`) to decide which
+`org.frostyard.ChairLift.updex.*` action — and its no-reprompt sudo-group
+rule in `data/org.frostyard.ChairLift.updex.rules` — applies. A bare,
+`$PATH`-resolved command name can resolve to a different absolute path
+depending on the invoking process's `$PATH`, which makes that comparison
+miss and silently falls `pkexec` back to the generic, always-reprompting
+`org.freedesktop.policykit.pkexec.run-program` action. `internal/updex.go`'s
+`runHelper` therefore always invokes `HelperPath` (never a bare name).
+Separately, `polkitd` itself only ever reads `.policy`/`.rules` files from
+the fixed directories `/usr/share/polkit-1/actions` and
+`/usr/share/polkit-1/rules.d` — not `$XDG_DATA_DIRS`, not any
+`$PREFIX`-derived path — so the Makefile's `install`/`uninstall` targets
+require `PREFIX=/usr` (the default since issue #59) for a source install's
+polkit assets to land somewhere polkit actually looks. Both constraints are
+fixed system facts, not values ChairLift decides; the Makefile and
+`internal/updex.HelperPath` exist to conform to them, matching the layout
+`.goreleaser.yaml`'s nFPM packages already use.
 
 ### Maintenance action execution
 
@@ -227,7 +249,7 @@ page_name:
 - **Semantic versioning**: Uses [svu](https://github.com/caarlos0/svu) via `make bump`
 - **CI**: GitHub Actions workflows for test, snapshot, and release (`.github/workflows/`); snapshot publishers use the `chairlift-dev-release` concurrency group without in-progress cancellation so uploads to the rolling `dev` release cannot overlap. GitHub retains only the newest pending run in a concurrency group, so rapid pushes can skip intermediate snapshots while preserving the active upload and latest queued snapshot.
 - **Release**: GoReleaser config at `.goreleaser.yaml`
-- **Other targets**: `make fmt` (gofmt), `make lint` (golangci-lint), `make install`/`make uninstall` (system install including polkit policies, icons, and wrapper script), `make build-linux-amd64`/`make build-linux-arm64` (cross-compilation)
+- **Other targets**: `make fmt` (gofmt), `make lint` (golangci-lint), `make install`/`make uninstall` (system install including polkit policies, icons, and wrapper script; default `PREFIX=/usr`, the only prefix that matches where polkit reads policy/rules files and the updex helper's fixed pkexec exec-path annotation — see "Privileged operations" above), `make build-linux-amd64`/`make build-linux-arm64` (cross-compilation)
 
 ### Runtime dependencies
 

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -224,3 +224,51 @@ The Updates page's per-package Homebrew upgrade button, per-app Flatpak update b
 The Updates page's bootc "Check for Updates" stage button (`onBootcStageClicked`, `internal/views/updates_page.go`) follows the same `actionmsg` pattern, with one difference from the buttons above: unlike `Install`/`Upgrade`/etc., whose completion text is selected purely by `dryRun`, `BootcStage(dryRun, staged)` also takes the live `staged` result from the post-`wg.Wait()` `bootc.GetStatus()` re-read, because the non-dry-run branch still needs to pick between the "staged" and "up to date" strings. Under dry-run, `staged` is ignored entirely and a single preview string is returned instead — see "Dry-run behavior" under bootc above for why. The expander's `SetSubtitle` calls in the same code block are *not* routed through `actionmsg`; they keep reading live `GetStatus()` output unconditionally, since the subtitle is a persistent status display rather than a per-click completion claim.
 
 The Features page's per-feature switch (`onFeatureToggled`, `internal/views/features_page.go`) follows the same decision-struct pattern as maintenance-script execution and tap trust: on a successful `updex.EnableFeature`/`DisableFeature` call, `decision := actionmsg.FeatureToggle(updex.IsDryRun(), enabled, name)` is computed once, and the switch's visual state is driven solely by `decision.Confirm` — `toggle.SetActive(enabled)` (confirming the flip) when `Confirm` is true, `toggle.SetActive(!enabled)` (reverting to the pre-click state) when it is false. Under dry-run, `updex.runHelper` returns before ever invoking pkexec, so nothing was actually toggled and the switch must not visually confirm a change that did not happen — this is the other "switch/list implies a state change after a preview" bug (the tap-trust row-removal case is the same pattern in Homebrew's Untrusted Taps list). The Update button (`onUpdateFeaturesClicked`) has no equivalent mutation to gate — its `SetSensitive`/`SetLabel` reset is unconditional in both modes — so its toast is a plain string, `actionmsg.FeatureUpdate(updex.IsDryRun())`.
+
+## Install-path consistency (`internal/installcheck`)
+
+Two installation paths ship this repository's privileged surface (the updex
+helper binary and both PolicyKit policy/rules pairs): a source `make install`
+(Makefile, `PREFIX` defaulting to `/usr`) and the packaged nFPM (deb/rpm/apk)
+layout goreleaser builds from `.goreleaser.yaml`. Both are hand-maintained
+text — a Makefile recipe and a YAML block — with no shared code path, so
+nothing stops them (or `internal/updex.HelperPath`, the fixed absolute path
+`pkexec` matches against the policy's `exec.path` annotation) from silently
+drifting apart again the way the Makefile's old `/usr/local` default drifted
+from the policy's `/usr/bin` in the bug this package now guards against.
+
+`internal/installcheck` holds two regression tests, not production code, that
+turn "verified by inspection" into a real, gated check:
+
+- **`TestMakefileInstallUsesUsrPrefix`** runs `make -n install
+  DESTDIR=<t.TempDir()>` — a dry run, so no compilation, no writes outside
+  the temp dir, and no root — once with no `PREFIX` override and once with
+  `PREFIX=/usr`, and asserts the printed `install -Dm...` lines place the
+  updex helper at `DESTDIR` + `internal/updex.HelperPath` and both
+  policy/rules pairs under `DESTDIR` + the fixed
+  `/usr/share/polkit-1/{actions,rules.d}` PolicyKit reads. It shells out to
+  the real `make` rather than parsing the Makefile textually because `make`
+  itself is the authority on what a given `PREFIX`/`DESTDIR` combination
+  actually resolves to (variable derivation, `$(DESTDIR)$(BINDIR)`
+  concatenation, recipe ordering) — a hand-rolled Makefile parser would just
+  be a second, divergence-prone implementation of `make`'s own substitution
+  rules, and would stop being a regression test for the exact thing that
+  broke (the *installed* path) the moment it disagreed with real `make`
+  output.
+- **`TestGoreleaserNfpmLayoutMatchesUsrPrefix`** parses the real, repo-root
+  `.goreleaser.yaml` (not a fixture) with the already-vendored
+  `gopkg.in/yaml.v3` and asserts `nfpms[0].bindir` matches the directory of
+  `internal/updex.HelperPath`, and the updex/bootc policy+rules
+  `contents[].dst` entries equal those same fixed polkit-1 paths.
+
+Both tests fail — not skip — if `internal/updex.HelperPath`, the Makefile's
+`PREFIX` default, or `.goreleaser.yaml`'s `nfpms` block change independently
+of one another; each was hand-verified during development by reverting one
+of the three at a time and confirming only the test(s) that source depends
+on turn red. The package imports no puregotk, directly or transitively, so it
+never trips `docs/agents/skills/gtk-headless-tests.md`'s constraint, and it
+lives under `internal/...` so `gates_chunk`, `make ci`, and CI's identical
+`go test ./internal/... -run "^Test[^I]" -skip "Integration"` filter all
+exercise it on every run, per
+`docs/agents/skills/gate-test-scope-is-internal-only.md` — not just the
+heavier, less-frequent `make ci` deep gate.

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -257,8 +257,12 @@ turn "verified by inspection" into a real, gated check:
   output.
 - **`TestGoreleaserNfpmLayoutMatchesUsrPrefix`** parses the real, repo-root
   `.goreleaser.yaml` (not a fixture) with the already-vendored
-  `gopkg.in/yaml.v3` and asserts `nfpms[0].bindir` matches the directory of
-  `internal/updex.HelperPath`, and the updex/bootc policy+rules
+  `gopkg.in/yaml.v3` and, iterating **every** `nfpms[]` entry (not just
+  `nfpms[0]`, so adding or reordering a second package with the wrong layout
+  still fails — per
+  `docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`),
+  asserts each entry's `bindir` matches the directory of
+  `internal/updex.HelperPath` and its updex/bootc policy+rules
   `contents[].dst` entries equal those same fixed polkit-1 paths.
 
 Both tests fail — not skip — if `internal/updex.HelperPath`, the Makefile's

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -176,7 +176,7 @@ for event := range progressCh {
 
 ## Updex (`internal/updex/updex.go`)
 
-Manages system features (add-on software/configuration modules). Unlike other wrappers, updex does **not** shell out to a CLI for reads. It uses the `github.com/frostyard/updex/updex` Go library directly for read operations, with a singleton `*updexapi.Client`. Write operations that require root are delegated to the `chairlift-updex-helper` binary (at `cmd/chairlift-updex-helper/main.go`) via pkexec.
+Manages system features (add-on software/configuration modules). Unlike other wrappers, updex does **not** shell out to a CLI for reads. It uses the `github.com/frostyard/updex/updex` Go library directly for read operations, with a singleton `*updexapi.Client`. Write operations that require root are delegated via pkexec to the fixed absolute path `internal/updex.HelperPath` (`/usr/bin/chairlift-updex-helper`, built from `cmd/chairlift-updex-helper/main.go`) — never a bare, `$PATH`-resolved name, since `pkexec` matches the resolved absolute path against `data/org.frostyard.ChairLift.updex.policy`'s `org.freedesktop.policykit.exec.path` annotation to select the right action; see [OVERVIEW.md](./OVERVIEW.md#privileged-operations) for the full rationale and the matching `PREFIX=/usr` Makefile requirement.
 
 ### Key types
 
@@ -193,9 +193,9 @@ Type aliases to `github.com/frostyard/updex/updex`:
 | `IsInstalledCached()` | Cached `IsInstalled()` | Direct | — | `sync.Once`, runs check at most once |
 | `ListFeatures()` | Go library: `client.Features()` | Direct | 5min | Returns `[]Feature` |
 | `CheckFeatures()` | Go library: `client.CheckFeatures()` | Direct | 5min | Returns `[]FeatureCheck` |
-| `EnableFeature(name)` | `pkexec chairlift-updex-helper enable-feature <name>` | pkexec | 5min | State-changing |
-| `DisableFeature(name)` | `pkexec chairlift-updex-helper disable-feature <name>` | pkexec | 5min | State-changing |
-| `UpdateFeatures()` | `pkexec chairlift-updex-helper update` | pkexec | 5min | Downloads enabled features |
+| `EnableFeature(name)` | `pkexec /usr/bin/chairlift-updex-helper enable-feature <name>` | pkexec | 5min | State-changing |
+| `DisableFeature(name)` | `pkexec /usr/bin/chairlift-updex-helper disable-feature <name>` | pkexec | 5min | State-changing |
+| `UpdateFeatures()` | `pkexec /usr/bin/chairlift-updex-helper update` | pkexec | 5min | Downloads enabled features |
 
 ### Helper binary (`cmd/chairlift-updex-helper/main.go`)
 


### PR DESCRIPTION
Implements issue #59 via the mill workflow.

Closes #59

# Plan: issue #59 — source-install path vs. packaged PolicyKit integration (revision 3)

## What changed since round 2

Round 2 was rejected with one objection (full text in `.mill/objections.json`):

> AGENTS.md states that after source-code changes, relevant documentation in
> AGENTS.md, README.md, and yeti/ must be reviewed and updated. c1 changes the
> privileged updex helper invocation from a bare helper name to the fixed
> absolute /usr/bin/chairlift-updex-helper and changes the supported
> source-install prefix, which is directly relevant to AGENTS.md's
> privilege-boundary and build/install guidance. The chunk updates README.md
> and yeti docs but omits AGENTS.md from its files and acceptance criteria, so
> it violates a binding context-doc requirement a maintainer could reasonably
> block on.

This revision fixes it directly: `AGENTS.md` is now in c1's `files` list, and
c1 gained an explicit acceptance criterion requiring two edits: (a) the
"Privilege boundary" repository-invariant bullet is updated to name the fixed
*absolute* helper path (`/usr/bin/chairlift-updex-helper`, matching the new
`internal/updex.HelperPath` and the policy's `exec.path` annotation) instead
of the bare binary name it currently states, and (b) the "Build, test, lint"
section gets one line noting `make install`'s default `PREFIX` is now `/usr`.
Both are places where AGENTS.md's own text becomes stale the moment c1 lands,
so this is squarely inside AGENTS.md's "after any change to source code,
update relevant documentation in AGENTS.md, README.md, and the yeti/ folder"
requirement — not a documentation change invented for its own sake. See
"Objection-by-objection" below for the full mapping, including an explicit
note on why c2 deliberately does *not* touch AGENTS.md.

## What changed since round 1

Round 1 was rejected with one objection (full text preserved in git history of
`.mill/objections.json` from that round):

> The plan adds an automated `verify-install-paths` check for Makefile/DESTDIR
> installs, but explicitly handles the nFPM/package layout only by inspection
> (`.goreleaser.yaml` is 'already correct' and 'verified by inspection, not
> modified'). The spec requires the nFPM layouts to be tested for consistency,
> so this acceptance criterion is not concretely covered by any chunk. A
> reasonable fix would add a gated check that validates `.goreleaser.yaml`/nFPM
> destinations for the helper and both policy/rules pairs against the chosen
> `/usr` locations, or otherwise produces a real package-layout test.

Round 2 addressed it directly: chunk 2 added
`TestGoreleaserNfpmLayoutMatchesUsrPrefix`, a Go test under `internal/...`
that parses the real `.goreleaser.yaml` and asserts its `nfpms[].bindir` and
the `updex`/`bootc` policy+rules `contents[].dst` entries resolve to the same
`/usr` locations PolicyKit reads — a real, gated, executable check, not an
inspection note. That fix is unchanged in this revision. See
"Objection-by-objection" below for the full mapping across both rounds.

While addressing round 1's objection, round 2 also reconsidered round 1's
Makefile design (see "Design change from round 1" below) and simplified it,
which incidentally made the nFPM check easier to write and reason about. That
design is unchanged in this revision too — round 3 only adds the AGENTS.md
edits described above.

## Reading of the spec

The issue's evidence points at two distinct, related bugs, both rooted in the
same cause: the Makefile's source install (`make install`, default
`PREFIX=/usr/local`) was never brought into line with the fixed paths already
baked into `data/org.frostyard.ChairLift.updex.policy` and `.goreleaser.yaml`'s
nFPM config (both already use `/usr/bin` + `/usr/share/polkit-1/...`).

1. **PolicyKit never reads `/usr/local/share/...`.** `polkitd` is compiled
   with a fixed actions/rules directory (`/usr/share/polkit-1/actions`,
   `/usr/share/polkit-1/rules.d`) and does not consult `$PREFIX` or
   `$XDG_DATA_DIRS`. The Makefile currently derives
   `POLKITACTIONSDIR`/`POLKITRULESDIR` from `$(PREFIX)/share`, so a default
   `sudo make install` (PREFIX defaults to `/usr/local`) silently installs
   both the bootc *and* updex `.policy`/`.rules` files somewhere PolicyKit
   never looks. This affects both policy pairs, not just updex's, since they
   share the same Makefile variables — the issue's evidence only names
   updex, but the bug and the fix are the same for bootc's.
2. **The invoked helper path doesn't provably match the policy annotation.**
   `internal/updex/updex.go` invokes `pkexec chairlift-updex-helper ...` — a
   *bare* command name, which `pkexec` resolves via the invoking process's
   `$PATH` before matching the resolved absolute path against the
   `org.freedesktop.policykit.exec.path` annotation
   (`/usr/bin/chairlift-updex-helper`) to find the right `org.frostyard.*`
   action id. If the resolved path doesn't match textually, PolicyKit's
   action-id lookup misses and falls back to a generic exec action —
   silently losing the no-reprompt sudo-group rule in
   `org.frostyard.ChairLift.updex.rules`, or failing outright if the helper
   isn't even on `$PATH` in the pkexec'd environment. A bare-name lookup is
   also a strictly weaker security posture than an absolute path (PATH-order
   dependent resolution), so fixing this also tightens the pkexec invocation,
   never loosens it.
3. **Binary install location also differs by method.** The spec's evidence
   explicitly says "nFPM packages use `/usr/bin`, so behavior differs by
   installation method" — this isn't scoped to just the helper binary; the
   main `chairlift` binary is packaged at `/usr/bin/chairlift` too, but a
   default source install puts it at `/usr/local/bin/chairlift`. See "Design
   change from round 1" for how this reading changed the Makefile approach.

**Interpretation of "choose and document one supported helper location":** the
policy file and nFPM config already encode a choice — `/usr/bin` for the
helper binary, `/usr/share/polkit-1/{actions,rules.d}` for policy/rules. These
are security-relevant, already-installed artifacts (the repository's privilege
invariant explicitly names the fixed helper binary and polkit policies as
things not to casually change), so the maintainer-consistent move is to make
the *Makefile and the Go invocation* conform to that existing choice rather
than inventing a new path or rewriting the policy file.

**Interpretation of "tested for consistency" (post-objection):** both
installation methods now get a real, gated, executable check under
`internal/...` (see chunk 2) rather than a mix of a Makefile self-check
(round 1) and "verified by inspection" for nFPM (the rejected part):
- A Go test (`TestMakefileInstallUsesUsrPrefix`) that runs `make -n install
  ...` (dry-run, no root, no compilation — confirmed by hand during planning;
  see the transcript in this session) and asserts the printed `install -Dm...`
  lines target the fixed `/usr` paths under both the default and an explicit
  `PREFIX=/usr` invocation.
- A Go test (`TestGoreleaserNfpmLayoutMatchesUsrPrefix`) that parses the real
  `.goreleaser.yaml` with the already-vendored `gopkg.in/yaml.v3` and asserts
  its `nfpms[].bindir` and the updex/bootc `contents[].dst` entries resolve to
  those same `/usr` paths.

Both tests live in a new puregotk-free `internal/installcheck` package, so
they're exercised by `gates_chunk`'s `go test ./internal/...` step (not just
the heavier, less-frequent `gates_deep`/`make ci`), and by CI's identical
filter, per `docs/agents/skills/gate-test-scope-is-internal-only.md`.

## Design change from round 1: single PREFIX, not a bifurcated one

Round 1 kept `PREFIX` defaulting to `/usr/local` for the *relocatable* surface
(main binary, wrapper script, desktop file, icons) and introduced new,
PREFIX-independent fixed variables (`PRIVBINDIR=/usr/bin`,
`POLKITACTIONSDIR`/`POLKITRULESDIR` fixed to `/usr/share/polkit-1/...`) for
the *privileged* surface (helper binary, both policy/rules pairs).

This revision instead changes the Makefile's default `PREFIX` itself to `/usr`
and derives every installed artifact — privileged or not — from that one
variable, matching nFPM's layout for the whole package, not just the
polkit-relevant half. Reasons for the change:

- **Evidence bullet 4** ("nFPM packages use `/usr/bin`, so behavior differs by
  installation method") is about the *whole* install, not only the helper —
  round 1's split design left the main `chairlift` binary still diverging
  between source (`/usr/local/bin`) and package (`/usr/bin`) installs, which
  is exactly the class of bug the issue is about. A single `/usr` default
  resolves it for every artifact at once.
- **Simplicity.** One `PREFIX` variable governing one coherent layout is
  easier to reason about, document, and keep in sync with `.goreleaser.yaml`
  than two parallel path schemes in the same Makefile — fewer places for a
  future edit to reintroduce drift.
- `PREFIX` remains overridable (e.g. `make install PREFIX=$HOME/.local` for a
  non-privileged dev install) — overriding it away from `/usr` is still
  supported, it just means (as before, and now documented explicitly in
  README) that the PolicyKit-authenticated helper path won't resolve to the
  fixed policy annotation, which is an inherent constraint of a hardcoded
  polkit `exec.path` annotation, not something either Makefile design can work
  around.

I'm recording this as a deliberate interpretation change, not a silent
alternative — round 1's design was defensible too, but round 2's is simpler
and closes the "differs by installation method" gap more completely, which
matters given the objection's emphasis on "tested for consistency": a single
`/usr` layout is materially easier to write a precise, non-flaky consistency
test against than two interleaved path schemes.

## Objection-by-objection

| Objection | Resolution in this plan |
|---|---|
| **Round 2:** AGENTS.md's doc-update requirement applies to c1 (privilege-boundary and build/install guidance change), but c1 omitted AGENTS.md from its `files`/acceptance | c1 now lists `AGENTS.md` in `files` and carries an explicit acceptance criterion: the "Privilege boundary" bullet names the fixed absolute helper path (`/usr/bin/chairlift-updex-helper`), and "Build, test, lint" notes the new `PREFIX=/usr` default. See "Documentation-scope rationale" below for why c2, by contrast, deliberately leaves AGENTS.md untouched |
| **Round 1:** No gated check for `.goreleaser.yaml`/nFPM layout consistency; "verified by inspection" isn't enough | c2 adds `TestGoreleaserNfpmLayoutMatchesUsrPrefix`, parsing the real `.goreleaser.yaml` and asserting `nfpms[].bindir` plus the updex *and* bootc policy/rules `contents[].dst` entries against the same `/usr` locations — exactly the "gated check that validates .goreleaser.yaml/nFPM destinations for the helper and both policy/rules pairs" the objection asked for |
| **Round 1 (implicit):** Makefile-only self-check ran only under `make ci`, not per-chunk gates | Both new checks are Go tests under `internal/installcheck`, so they run under `gates_chunk`'s `go test ./internal/...` on every chunk, not only the deep gate |

No objection asked the plan to change scope beyond these two gaps, so c1's
core fix (Makefile PREFIX, absolute helper path, README/yeti docs) and c2's
consistency tests are carried over conceptually from round 2 unchanged, aside
from the AGENTS.md addition to c1 and the documentation-scope note below.

### Documentation-scope rationale: why c1 touches AGENTS.md and c2 doesn't

AGENTS.md's doc-update rule is "after any change to source code, update
relevant documentation" — relevant, not exhaustive. c1 changes two things
AGENTS.md currently makes a claim about: the fixed helper binary named in the
"Privilege boundary" invariant (currently just `chairlift-updex-helper`, a
bare name — c1 makes the actual invocation an absolute path, so leaving the
invariant text bare-named would make AGENTS.md describe a laxer contract than
the code now enforces) and the default install prefix implied by `make
install` in "Build, test, lint" (currently undocumented as `/usr/local`, about
to become `/usr`). Both are edited in c1.

c2 adds only a new test package (`internal/installcheck`) that verifies
existing, already-documented behavior stays consistent; it introduces no new
make target, no new privileged code path, and changes no text that AGENTS.md
currently asserts. Forcing an AGENTS.md edit into c2 as well would mean
editing it a second time in the same feature for no textual reason — the
objection's own wording ties the requirement to change "directly relevant" to
AGENTS.md's privilege-boundary and build/install guidance, and c2 changes
neither. This scoping is recorded explicitly (per this task's instruction to
record ambiguous-spec interpretations and rationale) rather than either
silently skipping AGENTS.md in c2 or padding it with an edit that has nothing
to say.

## Chunk sequencing

c1 (Makefile + Go invocation fix) must land before c2 (consistency tests),
because c2's tests reference `internal/updex.HelperPath` (doesn't exist until
c1) and assert the Makefile's *corrected* `/usr` default (c2 would be testing
a bug, not a fix, if run first). They touch disjoint files otherwise
(Makefile/README/yeti docs/updex source+test vs. a brand-new
`internal/installcheck` package), so there's no merge risk in sequencing them
back-to-back.

### c1 — Pin the updex helper to /usr and match the PolicyKit exec-path annotation

- Change the Makefile's default `PREFIX` from `/usr/local` to `/usr`; every
  install/uninstall destination (`BINDIR`, `DATADIR`, `ICONSDIR`,
  `APPLICATIONSDIR`, `POLKITACTIONSDIR`, `POLKITRULESDIR`, and the helper
  binary) continues to derive from that one variable. `DESTDIR` staging is
  untouched.
- Replace `internal/updex/updex.go`'s unexported `helperCommand` bare-name
  constant with an exported `HelperPath = "/usr/bin/chairlift-updex-helper"`
  absolute-path constant, used directly in the `pkexec` argv — mirroring the
  already-correct `internal/bootc.StageScriptPath` pattern. Refactor
  `runHelper` so the invoked path is an explicit parameter (mirrors
  `internal/bootc/stage.go`'s `runStageStreaming(ctx, ch, name, args...)`),
  enabling a test with a fake pkexec/helper pair instead of the real thing.
- Add `internal/updex/updex_test.go` covering both the dry-run short-circuit
  (existing behavior, now regression-tested for the first time) and the
  non-dry-run path's argv construction.
- Update README.md (installation section: state `/usr` as the one supported
  PREFIX for a PolicyKit-integrated install, document `DESTDIR`, and add a
  one-line migration note for existing `/usr/local` source installs) and
  yeti/OVERVIEW.md / yeti/package-managers.md (privileged-operations and
  updex-helper sections: document the fixed absolute path and why).
- Update `AGENTS.md` (the round-3 fix — see "What changed since round 2"
  above): the "Repository invariants" → "Privilege boundary" bullet currently
  reads "...and the `chairlift-updex-helper` binary (action for updex
  writes)"; change it to name the fixed absolute path
  (`/usr/bin/chairlift-updex-helper`) matching `internal/updex.HelperPath` and
  the policy's `exec.path` annotation. Add one line to "Build, test, lint"
  noting `make install`'s default `PREFIX` is `/usr`. No other AGENTS.md
  section is touched — the "GTK main-thread safety" and "Config-driven
  visibility" invariants, and the skills-dir/documentation-process rules
  themselves, are unaffected by this chunk.
- No change to any `data/*.policy`/`data/*.rules` file or `.goreleaser.yaml`
  — both are already correct; this chunk brings the Makefile and Go code into
  line with them.
- **Repository invariant check (privilege boundary):** no new pkexec target,
  no broadened pkexec scope, no command built from untrusted/user-controlled
  input. The single existing pkexec-to-helper call site's argv[0] changes
  from a bare, `$PATH`-resolved name to its fixed absolute path — narrowing,
  not expanding, what can end up being invoked.

### c2 — Add automated consistency checks for make install DESTDIR/PREFIX and the nFPM package layout

- New `internal/installcheck` package (no puregotk import, so it's
  unaffected by `docs/agents/skills/gtk-headless-tests.md`'s constraint, and
  lives under `internal/...` so it's covered per
  `docs/agents/skills/gate-test-scope-is-internal-only.md`).
- `TestMakefileInstallUsesUsrPrefix`: runs `make -n install
  DESTDIR=<t.TempDir()>` from the repo root, with and without an explicit
  `PREFIX=/usr`, and asserts the printed install commands target
  `DESTDIR + internal/updex.HelperPath` and both policy/rules pairs under
  `DESTDIR + /usr/share/polkit-1/{actions,rules.d}/...`. Dry-run only — no
  compilation, no writes outside the temp dir, no root. (Sanity-checked by
  hand during planning: `make -n install DESTDIR=/tmp/destroot PREFIX=/usr`
  prints exactly one `install -Dm...` line per artifact, trivially greppable.)
- `TestGoreleaserNfpmLayoutMatchesUsrPrefix`: parses the real
  `.goreleaser.yaml` with `gopkg.in/yaml.v3` (already a dependency, no new
  module) into a minimal struct and asserts `nfpms[].bindir == "/usr/bin"`
  and the updex/bootc policy+rules `contents[].dst` entries equal the
  PolicyKit-read paths.
- Both tests fail (not skip) on drift between the Makefile, `.goreleaser.yaml`,
  and `internal/updex.HelperPath` — genuine cross-file consistency checks.
- Update yeti/package-managers.md (or OVERVIEW.md) with a short note on what
  `internal/installcheck` guards against, per the doc-update requirement.
- `AGENTS.md` is deliberately **not** edited by c2 — see "Documentation-scope
  rationale" above for why this is a considered choice, not an omission.
- **Repository invariant check:** no production behavior changes; the new
  package contains no logic reachable from `cmd/` or other `internal/`
  packages, only test-time verification. No privileged operation is invoked
  by either test (the Makefile test is a `make -n` dry run; the goreleaser
  test only parses YAML).

## Risks / non-goals

- Issue #54 (non-Snow bootc stage-script integration) is explicitly called
  out as related-but-separate in the spec; this plan does not touch bootc's
  script-discovery logic, only the install location of its polkit assets
  (fixed incidentally by sharing the Makefile's `POLKITACTIONSDIR`/
  `POLKITRULESDIR` derivation with updex in c1).
- No change to `data/org.frostyard.ChairLift.updex.policy`/`.rules` or
  `.goreleaser.yaml` — their existing `/usr/bin`/`/usr/share/polkit-1/...`
  layout is treated as the already-chosen fixed location; c1 makes the
  Makefile and Go code conform to it, and c2 makes that conformance a
  permanent, gated invariant instead of a one-time fix.
- **Assumption recorded explicitly:** c2's `TestMakefileInstallUsesUsrPrefix`
  assumes `make` is present in whatever environment executes `gates_chunk`'s
  `go test ./internal/...` step. This is not certain from `.mill/config.json`
  alone (`gates_chunk` invokes `go`/`gofmt`/`golangci-lint` directly, not
  `make`), but `gates_deep` runs `make ci` itself, so `make` is guaranteed
  present at least in that environment, and both gates are described as
  running in the same repository checkout/toolchain. If this assumption turns
  out to be wrong in practice (chunk-gate host lacks `make`), the fallback is
  to skip straight to `t.Skip` only when `exec.LookPath("make")` fails —
  explicitly not proposed as the default here, since a silently-skipped test
  protects nothing (per `docs/agents/skills/gate-test-scope-is-internal-only.md`'s
  underlying principle), and the smoke test run during planning succeeded in
  this same class of environment.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "Choose and document one supported helper location.",
      "status": "met",
      "evidence": "README.md:63-70 documents /usr as the only supported PolicyKit-integrated PREFIX and /usr/bin/chairlift-updex-helper as the helper path; internal/updex/updex.go:18-32 defines HelperPath = /usr/bin/chairlift-updex-helper; Makefile:12-24 documents and defaults PREFIX to /usr."
    },
    {
      "requirement": "Source and package installs put policies/rules in directories PolicyKit reads.",
      "status": "met",
      "evidence": "Makefile:24-30 derives polkit dirs from PREFIX=/usr and Makefile:108-113 installs bootc/updex policy/rules there; .goreleaser.yaml:142-151 packages both bootc and updex policy/rules under /usr/share/polkit-1/actions and /usr/share/polkit-1/rules.d."
    },
    {
      "requirement": "The invoked absolute helper path matches the policy annotation.",
      "status": "met",
      "evidence": "internal/updex/updex.go:32 sets HelperPath to /usr/bin/chairlift-updex-helper and internal/updex/updex.go:168-169 passes HelperPath as pkexec argv[0]; data/org.frostyard.ChairLift.updex.policy:19,30,41 annotate the same /usr/bin/chairlift-updex-helper path."
    },
    {
      "requirement": "make install DESTDIR=... and nFPM layouts are tested for consistency.",
      "status": "met",
      "evidence": "internal/installcheck/makefile_test.go:78-89 runs make -n install with DESTDIR for default PREFIX and explicit PREFIX=/usr, and internal/installcheck/makefile_test.go:51-70 asserts helper and policy/rules destinations; internal/installcheck/goreleaser_test.go:58-99 parses .goreleaser.yaml and checks every nfpms[] entry bindir and policy/rules destinations."
    },
    {
      "requirement": "README installation instructions describe any required PREFIX.",
      "status": "met",
      "evidence": "README.md:63-81 states /usr is the only supported PREFIX for PolicyKit-integrated installs, explains non-/usr behavior, and README.md:83-85 documents DESTDIR with PREFIX=/usr."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)