### PR TITLE
Correct package and GoReleaser license metadata to GPLv3

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ project_name: chairlift
 metadata:
   description: chairlift - modern GTK4/Libadwaita system management tool
   homepage: "https://github.com/frostyard/chairlift"
-  license: MIT
+  license: GPL-3.0-or-later
   maintainers:
     - "Brian Ketelsen <bketelsen@gmail.com>"
 
@@ -122,7 +122,7 @@ nfpms:
     description: |-
       System management tool for bootc-based installations.
       Manage flatpaks, homebrew and system updates with a modern GTK4/Libadwaita interface.
-    license: MIT
+    license: GPL-3.0-or-later
     contents:
       # Wrapper script
       - src: ./data/chairlift-wrapper.sh

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ ChairLift is adapted from [Vanilla OS First Setup](https://github.com/Vanilla-OS
 
 ### License
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version — SPDX identifier `GPL-3.0-or-later`. This matches the in-app About dialog's license selection and the license declared in packaged (deb/rpm/apk) metadata.
 
 See [LICENSE](LICENSE) for details.
 

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -11,6 +11,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// wantSPDXLicense is the SPDX identifier the project's actual license (GPLv3
+// text in LICENSE, gtk.LicenseGpl30Value — puregotk's "GPL 3.0 or later"
+// enum value — in internal/window/window.go's about dialog) resolves to.
+// .goreleaser.yaml's top-level metadata.license and every nfpms[] entry's
+// license must agree with this constant; see
+// yeti/package-managers.md's "Install-path consistency" section for the
+// MIT/GPL drift bug this guards against.
+const wantSPDXLicense = "GPL-3.0-or-later"
+
 // loadGoreleaserConfig parses the real, repo-root .goreleaser.yaml — not a
 // fixture or copy that could drift from the file goreleaser actually reads
 // — using the yaml.v3 dependency already vendored for internal/config.
@@ -94,6 +103,37 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 						t.Errorf("nfpms[%d] contents dst for %s = %q, want %q (fixed PolicyKit read location)", i, cc.srcSuffix, got, cc.want)
 					}
 				})
+			}
+		})
+	}
+}
+
+// TestGoreleaserLicenseIsGPL parses the real .goreleaser.yaml and asserts
+// both the top-level metadata.license and every nfpms[] entry's license
+// equal wantSPDXLicense, so a future edit reverting either field back to
+// MIT (or any other value) — as happened before this test was added — fails
+// this test instead of silently shipping mislabeled deb/rpm/apk packages.
+//
+// It iterates every nfpms[] entry rather than only nfpms[0]: per
+// docs/agents/skills/regression-tests-must-cover-every-collection-entry.md,
+// a consistency check that only special-cases the first entry stops
+// protecting anything the moment a second nfpms[] entry is added or
+// reordered with the wrong license.
+func TestGoreleaserLicenseIsGPL(t *testing.T) {
+	cfg := loadGoreleaserConfig(t)
+
+	if cfg.Metadata.License != wantSPDXLicense {
+		t.Errorf("metadata.license = %q, want %q", cfg.Metadata.License, wantSPDXLicense)
+	}
+
+	if len(cfg.Nfpms) == 0 {
+		t.Fatal(".goreleaser.yaml has no nfpms entries")
+	}
+
+	for i, nfpm := range cfg.Nfpms {
+		t.Run(fmt.Sprintf("nfpms[%d]", i), func(t *testing.T) {
+			if nfpm.License != wantSPDXLicense {
+				t.Errorf("nfpms[%d].license = %q, want %q", i, nfpm.License, wantSPDXLicense)
 			}
 		})
 	}

--- a/internal/installcheck/installcheck.go
+++ b/internal/installcheck/installcheck.go
@@ -37,14 +37,23 @@ func RepoRoot() string {
 // unmarshaling silently ignores every field not named here, so this struct
 // does not need to (and deliberately does not) mirror the whole schema.
 type GoreleaserConfig struct {
-	Nfpms []NfpmConfig `yaml:"nfpms"`
+	Metadata MetadataConfig `yaml:"metadata"`
+	Nfpms    []NfpmConfig   `yaml:"nfpms"`
+}
+
+// MetadataConfig is the subset of the top-level metadata: block relevant to
+// license consistency.
+type MetadataConfig struct {
+	License string `yaml:"license"`
 }
 
 // NfpmConfig is the subset of an nfpms[] entry relevant to install-location
-// consistency: where packaged binaries land (Bindir) and where explicitly
-// listed files (policy/rules, wrapper script, icons, ...) land (Contents).
+// and license consistency: where packaged binaries land (Bindir), where
+// explicitly listed files (policy/rules, wrapper script, icons, ...) land
+// (Contents), and the package's declared license (License).
 type NfpmConfig struct {
 	Bindir   string        `yaml:"bindir"`
+	License  string        `yaml:"license"`
 	Contents []NfpmContent `yaml:"contents"`
 }
 

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -276,3 +276,24 @@ lives under `internal/...` so `gates_chunk`, `make ci`, and CI's identical
 exercise it on every run, per
 `docs/agents/skills/gate-test-scope-is-internal-only.md` — not just the
 heavier, less-frequent `make ci` deep gate.
+
+A third regression test, **`TestGoreleaserLicenseIsGPL`**, guards a related
+but distinct drift: `.goreleaser.yaml` briefly declared `license: MIT` in
+both its top-level `metadata:` block and its `nfpms[]` entry's `license`
+field, while the project's actual license is GPLv3-or-later (`LICENSE`, and
+`internal/window/window.go`'s about dialog, which sets
+`gtk.LicenseGpl30Value` — puregotk's "GPL 3.0 or later" enum value, distinct
+from `LicenseGpl30OnlyValue`). Like the layout test above, it parses the
+real, repo-root `.goreleaser.yaml` via the shared `loadGoreleaserConfig`
+helper (no fixture) and asserts `cfg.Metadata.License` and, iterating
+**every** `nfpms[]` entry with a per-index `t.Run` (not just `nfpms[0]`, per
+`docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`),
+each entry's `License` field equal the fixed SPDX identifier
+`GPL-3.0-or-later`. `GoreleaserConfig.Metadata` (`MetadataConfig.License`)
+and `NfpmConfig.License` (`internal/installcheck/installcheck.go`) exist
+specifically to give `yaml.Unmarshal` somewhere to put these two values;
+without those struct fields yaml.v3 silently drops them and the test would
+pass vacuously regardless of what the YAML says. This test exists so a
+future edit reintroducing MIT (or any other license) in either location —
+the exact regression that motivated it — fails the gate instead of shipping
+mislabeled deb/rpm/apk package metadata again.


### PR DESCRIPTION
Implements issue #61 via the mill workflow.

Closes #61

# Plan: fix GoReleaser/nFPM license metadata drift (GPLv3 vs declared MIT)

## Summary of the problem

- `LICENSE` is the GPLv3 text.
- `internal/window/window.go:447` sets `about.SetLicenseType(gtk.LicenseGpl30Value)`.
  puregotk's `gtk` package defines two distinct enum values —
  `LicenseGpl30Value = 3` ("GPL 3.0 or later") and
  `LicenseGpl30OnlyValue = 10` ("GPL 3.0 only") — and window.go already uses
  the *or-later* value. (Verified directly against
  `codeberg.org/puregotk/puregotk@.../v4/gtk/gtkaboutdialog.go` in the module
  cache, not just from the spec's say-so.)
- `.goreleaser.yaml` declares `license: MIT` in two places: the top-level
  `metadata.license` (line 17) and the single `nfpms[]` entry's `license`
  (line 125). That one `nfpms[]` entry's `formats:` list is `[deb, rpm, apk]`
  — all three packaged formats share this one license field, so fixing it
  once fixes all three.
- `README.md`'s License section says "version 3" with no "or later"
  language, which is ambiguous between GPL-3.0-only and GPL-3.0-or-later and
  doesn't clearly agree with the about dialog's choice either.

## Adopted interpretation (spec ambiguity)

The spec's own automated clarification (appended to `.mill/spec.md` from a
prior mill run on 2026-07-24) already resolved the one real ambiguity —
which SPDX identifier to standardize on — as **`GPL-3.0-or-later`**, with the
correct rationale (the about dialog's existing enum choice, cross-checked
above against the actual puregotk source rather than assumed). This plan
adopts that identifier without revisiting it.

Two secondary judgment calls this plan makes explicit:

1. **Where the "single source of truth" lives.** `.goreleaser.yaml` is a
   static YAML file; it cannot import a Go constant. So "prevent future
   license drift" (the third acceptance criterion) is implemented the same
   way `internal/installcheck`'s existing HelperPath/PolicyKit tests do it:
   a Go test asserts the YAML's literal values against a fixed expected
   string, and *that test* is the enforcement mechanism — not a shared
   runtime constant, since none can exist across a YAML/Go boundary. This
   matches `docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md`
   directly: a plan note saying "the license field is now correct, verified
   by inspection" would not satisfy "prevent future license drift" — only a
   gated test that fails on regression does.

2. **`internal/window/window.go` is not touched and gets no new test.** The
   spec's four acceptance criteria are about GoReleaser/package metadata and
   documentation agreeing with the project's actual (GPLv3-or-later)
   license — they are not "the about dialog must be tested," and the about
   dialog is already correct today (it's the reference point everything else
   is being brought into agreement with, not the drifting side). It also
   could not be tested headlessly even if the spec asked for it:
   `internal/window` imports puregotk, so per
   `docs/agents/skills/gtk-headless-tests.md` it can never host a `_test.go`
   — and `gtk.License` is an int-enum, not a string, so there's no SPDX-like
   value to assert on anyway. No action needed here beyond the read-only
   verification already done above.

3. **`AGENTS.md` is deliberately left unchanged.** Per
   `docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md`, AGENTS.md
   only needs to be touched when a chunk changes a fact AGENTS.md currently
   states as fact. Grepped AGENTS.md, `yeti/OVERVIEW.md`,
   `yeti/package-managers.md`, and `CONFIG.md` for any mention of the
   project's license — there is none. AGENTS.md's "Repository invariants"
   section is about the privilege boundary, GTK main-thread safety, and
   config-driven visibility; it says nothing about licensing today, so there
   is nothing there to go stale. Padding it with an unrelated invariant bullet
   would be exactly the "every chunk touches every doc" anti-pattern the skill
   warns against. (`README.md` and `yeti/package-managers.md` *do* need
   updates, since they either state the license terms directly, in README's
   case, or document the `internal/installcheck` package this chunk extends.)

## Chunks

### c1 — Fix license metadata + gate it against drift (single chunk)

This is scoped as one chunk because the whole fix is small and one cohesive
concern (~130-170 changed lines across five files): a 2-line YAML fix, a
small struct/test addition to an existing package, and doc updates that
directly follow from those two. Splitting the code fix from its doc updates
would leave an intermediate chunk whose own acceptance criteria ("docs and
metadata agree") were unmet, which is exactly what
`docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md` and the
inspection-vs-automated-check skill both flag as insufficient — better to
land the fix, its gate, and the docs describing it together.

**What changes:**

1. `.goreleaser.yaml`: change `license: MIT` → `license: GPL-3.0-or-later` at
   both the top-level `metadata:` block and the `nfpms[]` entry.
2. `internal/installcheck/installcheck.go`: extend `GoreleaserConfig` with a
   `Metadata MetadataConfig` field (new `MetadataConfig{ License string }`
   type) and extend `NfpmConfig` with a `License string` field, so the
   existing `yaml.v3`-based parsing actually captures both license values
   from the real file (today neither struct has a License field at all, so
   the values are silently dropped by unmarshaling).
3. `internal/installcheck/goreleaser_test.go`: add a new test function
   (e.g. `TestGoreleaserLicenseIsGPL`) that:
   - reuses the existing `loadGoreleaserConfig(t)` helper (parses the real,
     repo-root `.goreleaser.yaml`, same as `TestGoreleaserNfpmLayoutMatchesUsrPrefix`
     already does — no new fixture, no copy that could drift from what
     GoReleaser actually reads);
   - asserts `cfg.Metadata.License` equals a fixed `GPL-3.0-or-later`
     constant;
   - `t.Fatal`s if `cfg.Nfpms` is empty (so the loop below can't silently
     no-op);
   - iterates **every** entry in `cfg.Nfpms` with a per-index `t.Run`,
     asserting each entry's `License` field equals the same constant — not
     just `cfg.Nfpms[0]` — per
     `docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`,
     which is exactly the objection a reviewer raised repeatedly on the
     analogous nFPM layout test in issue #59's run. Today there is exactly
     one `nfpms[]` entry, but the loop must not hardcode that.
4. `README.md`: reword the License section to state the GPLv3-**or-later**
   grant explicitly ("...either version 3 of the License, or (at your
   option) any later version") and name the `GPL-3.0-or-later` SPDX
   identifier, so it textually agrees with both the about dialog's enum
   choice and the corrected package metadata instead of the current
   ambiguous "version 3."
5. `yeti/package-managers.md`: extend the existing "Install-path consistency
   (`internal/installcheck`)" section (added for issue #59) with a short
   paragraph describing the new license-consistency test — what it checks,
   that it iterates every `nfpms[]` entry, and the MIT/GPL drift bug it
   guards against — following that section's existing style of explaining
   *why* a regression test exists, for future AI readers of the package.

**Acceptance criteria:** see `.mill/plan.json`'s `c1.acceptance` array
(gofmt/vet/lint/build/test all green via `gates_chunk`; both YAML license
values fixed; the new struct fields actually populate from the real file;
the new test iterates all `nfpms[]` entries and is proven to fail on a
manually-reverted value; docs reworded/extended; `window.go` and `AGENTS.md`
left alone with rationale recorded above).

## Sequencing notes

There is only one chunk. No ordering dependencies beyond the chunk's own
internal ordering (fix the YAML and struct fields before writing the test
that depends on both — trivial within a single diff). `make ci` (the deep
gate) exercises the same `internal/installcheck` test via its identical
`go test ./internal/...` scope, so no separate deep-gate-only work is needed.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "GoReleaser metadata uses the correct GPL-3.0 SPDX identifier, clarified as GPL-3.0-or-later.",
      "status": "met",
      "evidence": ".mill/spec.md:14 and .mill/spec.md:22-26 define the requirement; .goreleaser.yaml:14-17 sets metadata.license to GPL-3.0-or-later."
    },
    {
      "requirement": "DEB, RPM, and APK metadata report the project license accurately.",
      "status": "met",
      "evidence": ".mill/spec.md:15 requires package metadata accuracy; .goreleaser.yaml:115-125 sets the nfpms[] license to GPL-3.0-or-later, and .goreleaser.yaml:152-155 shows that same nfpms[] entry emits deb, rpm, and apk packages."
    },
    {
      "requirement": "Release/config validation checks prevent future license drift.",
      "status": "met",
      "evidence": ".mill/spec.md:16 requires drift prevention; internal/installcheck/installcheck.go:39-57 captures metadata.license and nfpms[].license from the real GoReleaser config, and internal/installcheck/goreleaser_test.go:122-139 asserts metadata.license and every nfpms[] license equal GPL-3.0-or-later."
    },
    {
      "requirement": "Documentation and generated metadata agree.",
      "status": "met",
      "evidence": ".mill/spec.md:17 requires docs and generated metadata to agree; README.md:212-214 documents GPL-3.0-or-later and states it matches packaged deb/rpm/apk metadata, while .goreleaser.yaml:17 and .goreleaser.yaml:125 use GPL-3.0-or-later."
    },
    {
      "requirement": "Align nfpm/package license fields to GPL-3.0-or-later.",
      "status": "met",
      "evidence": ".mill/spec.md:26 explicitly requires nfpm/package license fields to be GPL-3.0-or-later; .goreleaser.yaml:125 sets the nfpms[] license field to GPL-3.0-or-later."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)