### PR TITLE
Merge partial configs with defaults and distinguish omitted enabled values

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -10,7 +10,8 @@ ChairLift searches for the configuration file in the following locations (in ord
 2. `/usr/share/chairlift/config.yml` (package maintainer defaults)
 3. `chairlift/config.yml` (development/source directory)
 
-If no configuration file is found, all features are enabled by default.
+If no configuration file is found, all features default to enabled, except
+`maintenance_cleanup_group`, which defaults to disabled.
 
 ## Configuration Format
 
@@ -52,7 +53,7 @@ page_name:
 
 ### Maintenance Page (`maintenance_page`)
 
-- `maintenance_cleanup_group`: System cleanup utilities
+- `maintenance_cleanup_group`: System cleanup utilities (disabled by default)
   - `actions`: Array of maintenance scripts that can be executed
     - `title`: Display name for the action
     - `script`: Absolute path to the script to execute
@@ -150,6 +151,17 @@ install -D -m 644 config.yml debian/tmp/etc/chairlift/config.yml
 ## Notes
 
 - Groups with `enabled: false` will be completely hidden from the UI
-- Missing entries default to `enabled: true`
-- Invalid or unreadable configuration files will fall back to all features enabled
+- A configuration file is applied as an overlay on top of the built-in
+  defaults, field by field, not as a full replacement:
+  - An omitted `enabled` key inherits that group's documented default
+    (`true` for every group except `maintenance_cleanup_group`, which
+    defaults to `false`)
+  - An omitted optional field (`app_id`, `website`, `issues`, `chat`,
+    `actions`, `bundles_paths`) inherits its documented default value
+  - An explicit empty list (e.g. `actions: []`) clears the field
+  - A non-empty list, or an explicitly set scalar value, replaces the
+    default outright
+- Invalid or unreadable configuration files fall back to the built-in
+  defaults in full (`maintenance_cleanup_group` stays disabled; every other
+  group stays enabled) — not "all features enabled"
 - Changes require restarting ChairLift to take effect

--- a/docs/agents/skills/doc-chunks-must-fix-existing-contradictions.md
+++ b/docs/agents/skills/doc-chunks-must-fix-existing-contradictions.md
@@ -1,0 +1,28 @@
+# A doc chunk must grep for and fix existing contradictory claims, not just add new prose
+
+**When it applies:** Planning or reviewing any chunk that documents new or
+changed behavior in a `.md` file (`CONFIG.md`, `README.md`, `yeti/*.md`,
+`AGENTS.md`) — especially when the behavior already has *some* prose written
+about it (an old default, an old fallback rule, an old "how this works"
+paragraph) that the change makes wrong or incomplete.
+
+**What to do:** Before scoping a doc chunk as "add a paragraph describing the
+new behavior," grep the target file (and any sibling doc that describes the
+same subsystem, e.g. `CONFIG.md` vs. `yeti/OVERVIEW.md`) for existing
+sentences that state the old, now-contradicted behavior — including
+restatements in a "Notes" or FAQ-style section, which tend to repeat a claim
+in different words rather than reference the primary description once. Add
+those exact locations to the chunk's acceptance criteria as concrete greps
+(e.g. `grep -n 'all features enabled' CONFIG.md` returning nothing) so the
+chunk is checkable rather than relying on a reviewer's careful re-read.
+Writing accurate new prose next to stale old prose still leaves the doc
+self-contradictory and will be rejected on plan review even though the
+acceptance criterion asked only for the new behavior to be "documented."
+
+**Learned from:** issue #60's mill run, plan round 1 — the plan added overlay
+prose to `CONFIG.md`'s Notes section but left three pre-existing sentences
+claiming "all features enabled" applies unconditionally (lines 13, 153-154),
+even though `defaultConfig()` ships `maintenance_cleanup_group` disabled. The
+reviewer rejected the plan (medium severity) because those exact-checkable
+factual errors were left untouched. Round 2 fixed it by widening the chunk to
+rewrite all three locations and adding grep-based acceptance criteria.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,38 @@ type ActionConfig struct {
 	Sudo   bool   `yaml:"sudo"`
 }
 
+// rawConfig mirrors Config for YAML parsing, but every optional field is a
+// pointer so yaml.v3 can distinguish "key omitted" (nil) from "key present,
+// possibly with the zero value" (non-nil). It is never exposed outside this
+// file; loadFromPath merges it onto defaultConfig() to produce the *Config
+// callers see.
+type rawConfig struct {
+	SystemPage       rawPageConfig `yaml:"system_page"`
+	UpdatesPage      rawPageConfig `yaml:"updates_page"`
+	ApplicationsPage rawPageConfig `yaml:"applications_page"`
+	MaintenancePage  rawPageConfig `yaml:"maintenance_page"`
+	FeaturesPage     rawPageConfig `yaml:"features_page"`
+	HelpPage         rawPageConfig `yaml:"help_page"`
+}
+
+// rawPageConfig mirrors PageConfig for YAML parsing.
+type rawPageConfig map[string]rawGroupConfig
+
+// rawGroupConfig mirrors GroupConfig for YAML parsing. A nil field means the
+// key was absent (or explicitly null) in the source file and the merge keeps
+// defaultConfig()'s value; a non-nil field, including a pointer to an empty
+// string/slice, means the file set that field explicitly and it replaces the
+// default outright.
+type rawGroupConfig struct {
+	Enabled      *bool           `yaml:"enabled"`
+	AppID        *string         `yaml:"app_id"`
+	Actions      *[]ActionConfig `yaml:"actions"`
+	Website      *string         `yaml:"website"`
+	Issues       *string         `yaml:"issues"`
+	Chat         *string         `yaml:"chat"`
+	BundlesPaths *[]string       `yaml:"bundles_paths"`
+}
+
 // configPaths are the locations to search for the config file
 var configPaths = []string{
 	"/etc/chairlift/config.yml",
@@ -81,12 +113,85 @@ func loadFromPath(path string) (*Config, error) {
 		return nil, err
 	}
 
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	var raw rawConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil, err
 	}
 
-	return &cfg, nil
+	return mergeConfig(defaultConfig(), &raw), nil
+}
+
+// mergeConfig overlays raw (a parsed config file) onto def (defaultConfig())
+// page by page, returning a new *Config. Every optional field on every group
+// follows the same rule: omitted in raw -> keep def's value; present in raw
+// (including an explicit empty string/slice) -> use raw's value, replacing
+// def's outright.
+func mergeConfig(def *Config, raw *rawConfig) *Config {
+	return &Config{
+		SystemPage:       mergePage(def.SystemPage, raw.SystemPage),
+		UpdatesPage:      mergePage(def.UpdatesPage, raw.UpdatesPage),
+		ApplicationsPage: mergePage(def.ApplicationsPage, raw.ApplicationsPage),
+		MaintenancePage:  mergePage(def.MaintenancePage, raw.MaintenancePage),
+		FeaturesPage:     mergePage(def.FeaturesPage, raw.FeaturesPage),
+		HelpPage:         mergePage(def.HelpPage, raw.HelpPage),
+	}
+}
+
+// mergePage overlays raw onto def for a single page. Groups present only in
+// def are kept as-is; groups present only in raw (a group name unknown to
+// defaultConfig() for this page) start from a zero GroupConfig that defaults
+// Enabled to true, matching IsGroupEnabled's existing "missing group ->
+// enabled" fallback for the wholly-absent case. Groups present in both are
+// merged field by field.
+func mergePage(def PageConfig, raw rawPageConfig) PageConfig {
+	result := make(PageConfig, len(def))
+	for name, group := range def {
+		result[name] = group
+	}
+
+	for name, rawGroup := range raw {
+		base, ok := def[name]
+		if !ok {
+			// Unknown group: omitted `enabled` still resolves to true.
+			base = GroupConfig{Enabled: true}
+		}
+		result[name] = mergeGroup(base, rawGroup)
+	}
+
+	return result
+}
+
+// mergeGroup overlays raw onto def for a single group, field by field. Each
+// assignment is guarded by the corresponding raw pointer's nil-check: nil
+// means the file omitted (or explicitly nulled) that key, so def's value is
+// kept; non-nil means the file set the key, so raw's value replaces def's,
+// including an explicit empty string or empty slice.
+func mergeGroup(def GroupConfig, raw rawGroupConfig) GroupConfig {
+	result := def
+
+	if raw.Enabled != nil {
+		result.Enabled = *raw.Enabled
+	}
+	if raw.AppID != nil {
+		result.AppID = *raw.AppID
+	}
+	if raw.Actions != nil {
+		result.Actions = *raw.Actions
+	}
+	if raw.Website != nil {
+		result.Website = *raw.Website
+	}
+	if raw.Issues != nil {
+		result.Issues = *raw.Issues
+	}
+	if raw.Chat != nil {
+		result.Chat = *raw.Chat
+	}
+	if raw.BundlesPaths != nil {
+		result.BundlesPaths = *raw.BundlesPaths
+	}
+
+	return result
 }
 
 // defaultConfig returns the default configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,377 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// pageNames lists every page key Config exposes, matching the switch
+// statements in IsGroupEnabled/GetGroupConfig. Tests loop over this slice
+// (and, within each page, every group defaultConfig() defines) instead of
+// sampling a single page/group, per the repo's
+// regression-tests-must-cover-every-collection-entry skill.
+var pageNames = []string{
+	"system_page",
+	"updates_page",
+	"applications_page",
+	"maintenance_page",
+	"features_page",
+	"help_page",
+}
+
+// pagesOf returns cfg's pages keyed by the same page-name strings
+// IsGroupEnabled/GetGroupConfig switch on, so tests can loop generically.
+func pagesOf(cfg *Config) map[string]PageConfig {
+	return map[string]PageConfig{
+		"system_page":       cfg.SystemPage,
+		"updates_page":      cfg.UpdatesPage,
+		"applications_page": cfg.ApplicationsPage,
+		"maintenance_page":  cfg.MaintenancePage,
+		"features_page":     cfg.FeaturesPage,
+		"help_page":         cfg.HelpPage,
+	}
+}
+
+func groupsEqual(t *testing.T, page, name string, got, want GroupConfig) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("page %q group %q: got %+v, want %+v", page, name, got, want)
+	}
+}
+
+func writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing test config file: %v", err)
+	}
+	return path
+}
+
+// withConfigPaths points the package-level configPaths search list at paths
+// (typically a single nonexistent path, to force the "no config file found"
+// fallback) for the duration of the calling test, restoring the original
+// list afterward. This exercises Load()'s real fallback logic rather than a
+// test-only stand-in.
+func withConfigPaths(t *testing.T, paths []string) {
+	t.Helper()
+	orig := configPaths
+	t.Cleanup(func() { configPaths = orig })
+	configPaths = paths
+}
+
+// TestLoadFromPathUnreadablePathReturnsError confirms loadFromPath surfaces
+// an error for a nonexistent/unreadable path, which is what drives Load()'s
+// defaultConfig() fallback exercised by TestLoadAbsentFileFallsBackToDefaultConfig.
+func TestLoadFromPathUnreadablePathReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.yml")
+	if _, err := loadFromPath(path); err == nil {
+		t.Fatalf("loadFromPath(%q): expected error for nonexistent file, got nil", path)
+	}
+}
+
+// TestLoadAbsentFileFallsBackToDefaultConfig asserts that when no config
+// file can be found, Load() (the real production entry point) returns a
+// *Config equal to defaultConfig() field-for-field, across every page and
+// every group defaultConfig() defines.
+func TestLoadAbsentFileFallsBackToDefaultConfig(t *testing.T) {
+	withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
+
+	got := pagesOf(Load())
+	want := pagesOf(defaultConfig())
+
+	for _, page := range pageNames {
+		gotGroups := got[page]
+		wantGroups := want[page]
+		if len(gotGroups) != len(wantGroups) {
+			t.Errorf("page %q: got %d groups, want %d", page, len(gotGroups), len(wantGroups))
+		}
+		for name, wantGroup := range wantGroups {
+			gotGroup, ok := gotGroups[name]
+			if !ok {
+				t.Errorf("page %q group %q: missing from fallback config", page, name)
+				continue
+			}
+			groupsEqual(t, page, name, gotGroup, wantGroup)
+		}
+	}
+}
+
+// TestMaintenanceCleanupGroupDefaultConsistentAcrossAbsentAndOmitted pins
+// down that maintenance_cleanup_group resolves to the identical
+// GroupConfig{Enabled:false, Actions:[bls-gc entry]} whether the config file
+// is entirely absent or present but silent about maintenance_cleanup_group
+// specifically (while still mentioning maintenance_page and another of its
+// groups).
+func TestMaintenanceCleanupGroupDefaultConsistentAcrossAbsentAndOmitted(t *testing.T) {
+	wantGroup := GroupConfig{
+		Enabled: false,
+		Actions: []ActionConfig{
+			{
+				Title:  "Clean Up Boot Old Entries",
+				Script: "/usr/libexec/bls-gc",
+				Sudo:   true,
+			},
+		},
+	}
+
+	// Sanity: wantGroup must match defaultConfig()'s actual value, not a
+	// hand-duplicated guess that could drift from the real default.
+	if actual := defaultConfig().MaintenancePage["maintenance_cleanup_group"]; !reflect.DeepEqual(actual, wantGroup) {
+		t.Fatalf("test setup assumption violated: defaultConfig() maintenance_cleanup_group is %+v, want %+v", actual, wantGroup)
+	}
+
+	// Absent-file case.
+	withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
+	absentCfg := Load()
+	groupsEqual(t, "maintenance_page", "maintenance_cleanup_group",
+		absentCfg.MaintenancePage["maintenance_cleanup_group"], wantGroup)
+
+	// Partial-file case: mentions maintenance_page and a sibling group, but
+	// omits maintenance_cleanup_group entirely.
+	path := writeConfigFile(t, "maintenance_page:\n  maintenance_brew_group:\n    enabled: false\n")
+	partialCfg, err := loadFromPath(path)
+	if err != nil {
+		t.Fatalf("loadFromPath(%q): %v", path, err)
+	}
+	groupsEqual(t, "maintenance_page", "maintenance_cleanup_group",
+		partialCfg.MaintenancePage["maintenance_cleanup_group"], wantGroup)
+}
+
+// defaultBearingGroups lists every group in defaultConfig() that defines a
+// non-Enabled default field (AppID, Website/Issues/Chat, Actions, or
+// BundlesPaths). Enabled-only-overlay coverage loops over all of them, not
+// just one, per the repo's regression-tests-must-cover-every-collection-entry
+// skill.
+var defaultBearingGroups = []struct {
+	page  string
+	group string
+}{
+	{"system_page", "health_group"},
+	{"applications_page", "applications_installed_group"},
+	{"help_page", "help_resources_group"},
+	{"maintenance_page", "maintenance_cleanup_group"},
+	{"applications_page", "brew_bundles_group"},
+}
+
+// TestEnabledOnlyOverlayPreservesOtherDefaultFields feeds a partial file
+// that sets only `enabled` (true, then separately false) on a group, and
+// asserts every other default-bearing field on that group is unchanged from
+// defaultConfig(). Exercised for every group above, not a single sample.
+func TestEnabledOnlyOverlayPreservesOtherDefaultFields(t *testing.T) {
+	defPages := pagesOf(defaultConfig())
+
+	for _, gc := range defaultBearingGroups {
+		for _, enabledVal := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/%s/enabled=%v", gc.page, gc.group, enabledVal), func(t *testing.T) {
+				content := fmt.Sprintf("%s:\n  %s:\n    enabled: %v\n", gc.page, gc.group, enabledVal)
+				path := writeConfigFile(t, content)
+
+				cfg, err := loadFromPath(path)
+				if err != nil {
+					t.Fatalf("loadFromPath(%q): %v", path, err)
+				}
+
+				got := pagesOf(cfg)[gc.page][gc.group]
+				want := defPages[gc.page][gc.group]
+				want.Enabled = enabledVal
+
+				groupsEqual(t, gc.page, gc.group, got, want)
+			})
+		}
+	}
+}
+
+// TestOmittedEnabledInheritsDocumentedDefault asserts that a group present
+// in the file (with some other field set) but silent about `enabled`
+// inherits the documented default Enabled value from defaultConfig() -- true
+// for an ordinary group, false for maintenance_cleanup_group specifically --
+// rather than the Go zero value false.
+func TestOmittedEnabledInheritsDocumentedDefault(t *testing.T) {
+	def := defaultConfig()
+
+	t.Run("ordinary group inherits default enabled=true", func(t *testing.T) {
+		if !def.SystemPage["health_group"].Enabled {
+			t.Fatal("test setup assumption violated: health_group default is not enabled")
+		}
+
+		path := writeConfigFile(t, "system_page:\n  health_group:\n    app_id: com.example.Other\n")
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+
+		got := cfg.SystemPage["health_group"]
+		if !got.Enabled {
+			t.Errorf("health_group: omitted `enabled` got %v, want true (default)", got.Enabled)
+		}
+		if got.AppID != "com.example.Other" {
+			t.Errorf("health_group: AppID override not applied, got %q", got.AppID)
+		}
+	})
+
+	t.Run("maintenance_cleanup_group inherits default enabled=false", func(t *testing.T) {
+		if def.MaintenancePage["maintenance_cleanup_group"].Enabled {
+			t.Fatal("test setup assumption violated: maintenance_cleanup_group default is enabled")
+		}
+
+		content := "maintenance_page:\n" +
+			"  maintenance_cleanup_group:\n" +
+			"    actions:\n" +
+			"      - title: Custom\n" +
+			"        script: /usr/libexec/custom\n" +
+			"        sudo: true\n"
+		path := writeConfigFile(t, content)
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+
+		got := cfg.MaintenancePage["maintenance_cleanup_group"]
+		if got.Enabled {
+			t.Errorf("maintenance_cleanup_group: omitted `enabled` got %v, want false (default, not the Go zero-value coincidence)", got.Enabled)
+		}
+		wantActions := []ActionConfig{{Title: "Custom", Script: "/usr/libexec/custom", Sudo: true}}
+		if !reflect.DeepEqual(got.Actions, wantActions) {
+			t.Errorf("maintenance_cleanup_group: Actions override not applied, got %+v, want %+v", got.Actions, wantActions)
+		}
+	})
+}
+
+// TestExplicitEmptySliceOverlayClearsDefault asserts that an explicit empty
+// slice (`actions: []`, `bundles_paths: []`) overlays to an empty (len==0)
+// slice rather than restoring the default slice.
+func TestExplicitEmptySliceOverlayClearsDefault(t *testing.T) {
+	t.Run("actions: []", func(t *testing.T) {
+		path := writeConfigFile(t, "maintenance_page:\n  maintenance_cleanup_group:\n    actions: []\n")
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+		got := cfg.MaintenancePage["maintenance_cleanup_group"].Actions
+		if len(got) != 0 {
+			t.Errorf("maintenance_cleanup_group.Actions = %+v, want empty slice", got)
+		}
+	})
+
+	t.Run("bundles_paths: []", func(t *testing.T) {
+		path := writeConfigFile(t, "applications_page:\n  brew_bundles_group:\n    bundles_paths: []\n")
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+		got := cfg.ApplicationsPage["brew_bundles_group"].BundlesPaths
+		if len(got) != 0 {
+			t.Errorf("brew_bundles_group.BundlesPaths = %+v, want empty slice", got)
+		}
+	})
+}
+
+// TestNonEmptySliceOverlayReplacesDefaultContents asserts that a non-empty
+// actions/bundles_paths list in the file fully replaces the default list
+// contents (exact-equal), not a superset/append of the default.
+func TestNonEmptySliceOverlayReplacesDefaultContents(t *testing.T) {
+	t.Run("actions replaces default list", func(t *testing.T) {
+		content := "maintenance_page:\n" +
+			"  maintenance_cleanup_group:\n" +
+			"    actions:\n" +
+			"      - title: Only Action\n" +
+			"        script: /usr/libexec/only\n" +
+			"        sudo: false\n"
+		path := writeConfigFile(t, content)
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+
+		got := cfg.MaintenancePage["maintenance_cleanup_group"].Actions
+		want := []ActionConfig{{Title: "Only Action", Script: "/usr/libexec/only", Sudo: false}}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("maintenance_cleanup_group.Actions = %+v, want %+v (exact replacement, not appended to default)", got, want)
+		}
+	})
+
+	t.Run("bundles_paths replaces default list", func(t *testing.T) {
+		content := "applications_page:\n" +
+			"  brew_bundles_group:\n" +
+			"    bundles_paths:\n" +
+			"      - /custom/path/one\n" +
+			"      - /custom/path/two\n"
+		path := writeConfigFile(t, content)
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+
+		got := cfg.ApplicationsPage["brew_bundles_group"].BundlesPaths
+		want := []string{"/custom/path/one", "/custom/path/two"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("brew_bundles_group.BundlesPaths = %+v, want %+v (exact replacement, not appended to default)", got, want)
+		}
+	})
+}
+
+// TestIsGroupEnabledMatchesExpectedForEveryGroup calls IsGroupEnabled for
+// every (page, group) pair defaultConfig() defines, both for the
+// absent-file fallback config and for a partial-file config that overrides
+// several groups across different pages, asserting each result matches the
+// expected default/override. Looped, not sampled.
+func TestIsGroupEnabledMatchesExpectedForEveryGroup(t *testing.T) {
+	defPages := pagesOf(defaultConfig())
+
+	t.Run("absent file", func(t *testing.T) {
+		withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
+		cfg := Load()
+
+		for _, page := range pageNames {
+			for name, group := range defPages[page] {
+				if got := cfg.IsGroupEnabled(page, name); got != group.Enabled {
+					t.Errorf("IsGroupEnabled(%q, %q) = %v, want %v (default)", page, name, got, group.Enabled)
+				}
+			}
+		}
+	})
+
+	t.Run("partial file overrides several groups", func(t *testing.T) {
+		content := "system_page:\n" +
+			"  health_group:\n" +
+			"    enabled: false\n" +
+			"updates_page:\n" +
+			"  brew_trust_group:\n" +
+			"    enabled: false\n" +
+			"maintenance_page:\n" +
+			"  maintenance_cleanup_group:\n" +
+			"    enabled: true\n" +
+			"help_page:\n" +
+			"  help_resources_group:\n" +
+			"    enabled: false\n"
+		path := writeConfigFile(t, content)
+		cfg, err := loadFromPath(path)
+		if err != nil {
+			t.Fatalf("loadFromPath(%q): %v", path, err)
+		}
+
+		type pageGroup struct{ page, group string }
+		overrides := map[pageGroup]bool{
+			{"system_page", "health_group"}:                   false,
+			{"updates_page", "brew_trust_group"}:              false,
+			{"maintenance_page", "maintenance_cleanup_group"}: true,
+			{"help_page", "help_resources_group"}:             false,
+		}
+
+		for _, page := range pageNames {
+			for name, group := range defPages[page] {
+				want := group.Enabled
+				if override, ok := overrides[pageGroup{page, name}]; ok {
+					want = override
+				}
+				if got := cfg.IsGroupEnabled(page, name); got != want {
+					t.Errorf("IsGroupEnabled(%q, %q) = %v, want %v", page, name, got, want)
+				}
+			}
+		}
+	})
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -113,6 +113,21 @@ Per-wrapper mechanics:
 
 Each preference group on every page checks `config.IsGroupEnabled(pageName, groupName)` before building its widgets. Groups default to enabled if not specified in config. The `maintenance_cleanup_group` defaults to disabled in the default config.
 
+`internal/config/config.go` builds the effective `*Config` by overlaying a
+parsed file onto `defaultConfig()` field by field, not by replacing it
+wholesale — `mergeConfig` walks each page, `mergePage` walks each group within
+a page, and `mergeGroup` walks each field within a group. The overlay is
+driven by `rawConfig`/`rawPageConfig`/`rawGroupConfig`, a pointer-typed mirror
+of `Config`/`PageConfig`/`GroupConfig` used only for YAML decoding: a `nil`
+pointer means the file omitted (or explicitly nulled) that key, so
+`defaultConfig()`'s value survives; a non-nil pointer means the file set that
+key — including to an empty string or empty slice — so it replaces the
+default outright. This is why `maintenance_cleanup_group` stays disabled
+overall (and keeps its default `actions` entry) when a config file mentions
+the group only to flip an unrelated field, and why `Load()` falling back to
+`defaultConfig()` when no file is found or the file is unreadable/invalid
+preserves that same per-group default — it is never "all features enabled."
+
 ### Package manager wrapper pattern
 
 Each wrapper in `internal/` follows a consistent shape:


### PR DESCRIPTION
Implements issue #60 via the mill workflow.

Closes #60

# Plan: overlay-merge semantics for `internal/config`

## Problem recap

`internal/config/config.go` currently does two things wrong when a config
file is present:

1. `loadFromPath` unmarshals the YAML directly into `*Config` and returns it
   as-is (config.go:51-63, 84-89) — it never merges the parsed value against
   `defaultConfig()`. Any group the file mentions loses every default field
   it doesn't repeat (app IDs, Help URLs, `Actions`, `BundlesPaths`).
2. `GroupConfig.Enabled` is a plain `bool` (config.go:27), so YAML can't
   distinguish "the file omitted `enabled`" from "the file said
   `enabled: false`" — both unmarshal to the Go zero value `false`. A group
   the file mentions for any reason (e.g. just to set `app_id`) silently
   flips from enabled to disabled.

`IsGroupEnabled`'s "missing key → enabled" fallback (config.go:173-177) only
covers a group that's absent from the map entirely; it does nothing for a
group that's present but incomplete, which is the actual bug surface the
spec's evidence describes (an omitted cleanup group becomes an empty visible
group; an omitted Help group loses its default links).

## Automated clarification already recorded in spec.md

A prior mill round appended overlay semantics for slice fields to
`.mill/spec.md`: omitted slice → keep default; explicit empty slice (`[]`) →
clear; non-empty slice → replace. This plan applies that same three-way rule
uniformly to every optional field, not just slices (see interpretation #2
below), and treats it as binding.

## Interpretations adopted where the spec is silent

1. **Explicit YAML null is treated as omitted.** A key present with no value
   (`actions:` with nothing after it) parses to Go `nil` for a pointer field,
   identically to a fully omitted key — it inherits the default. This is the
   reading a maintainer editing YAML by hand would expect (a stray blank
   value shouldn't wipe a default), and there is no way to distinguish it
   from "omitted" without a custom YAML-node-level unmarshaler, which is more
   machinery than this bug warrants.
2. **Scalar optional fields (`app_id`, `website`, `issues`, `chat`) get the
   same presence-aware overlay as slices**, even though the spec's automated
   clarification note only names slice fields explicitly. The spec's plain
   acceptance criteria say "Default values for app IDs, actions, and Help
   URLs are preserved unless overridden," which only makes sense if presence
   tracking applies to strings too — otherwise an omitted `website` can never
   be told apart from an explicit `website: ""`. Uniform treatment across all
   optional field kinds is also simpler to implement and review than a
   slices-only special case.
3. **An explicit empty string (`website: ""`) is a real override**, clearing
   the field to empty, exactly like an explicit empty slice — "presence of
   the key" is the override signal, independent of what value follows it.
4. **Unknown/custom group names** (present in the file, not present in
   `defaultConfig()` for that page — e.g. a future or typo'd group) keep
   defaulting `Enabled` to `true` when the file omits it, generalizing
   `IsGroupEnabled`'s existing "missing key → enabled" behavior down to the
   "missing field on a present-but-unrecognized group" case. Nothing in the
   spec suggests these should behave differently from a wholly-absent group.
5. **No exported type changes.** `GroupConfig`/`PageConfig`/`Config` keep
   their current field types (`bool`, `string`, `[]ActionConfig`, ...); the
   pointer-based presence tracking lives entirely in a new private
   `rawConfig`/`rawPageConfig`/`rawGroupConfig` shadow used only during
   parsing, then merged down into the existing concrete types. This means
   `internal/views`'s existing reads of `groupCfg.Website`, `.AppID`,
   `.Actions`, etc. (help_page.go, maintenance_page.go, applications_page.go,
   system_page.go) need no changes at all — which matters because
   `internal/views` imports puregotk and per the repo's
   `gtk-headless-tests` skill can carry no tests of its own, so keeping its
   surface untouched avoids re-reviewing GTK-adjacent code for a config-only
   bug fix.

## Chunk sequencing and rationale

Three chunks, strictly sequential (each depends on the previous landing):

**c1 — the merge implementation itself**, isolated to
`internal/config/config.go`. No test file yet: the chunk is reviewable purely
as "does this merge algorithm look right," and it leaves the tree green
because there are no existing config tests to break and the new code is
exercised by nothing yet (build/vet/lint still fully cover it for
compile-correctness). Keeping this chunk implementation-only keeps the diff
near the small end of the 100-400 line budget instead of ballooning past it
with test scaffolding.

**c2 — the regression-test matrix**, entirely additive
(`internal/config/config_test.go`). This is where the spec's actual testing
acceptance criteria get satisfied with real, gated checks rather than
inspection (per the repo's `acceptance-criteria-need-automated-checks-not-inspection`
skill) — every scenario in the spec's acceptance list (absent file, partial
pages, partial groups, omitted `enabled`) gets a table-driven case, and per
the repo's `regression-tests-must-cover-every-collection-entry` skill,
assertions loop across every group `defaultConfig()` defines instead of
sampling one representative group. Splitting this from c1 keeps each diff
independently reviewable (algorithm vs. proof-of-correctness) while both
still land before any downstream consumer changes.

**c3 — documentation**, doc-only (`CONFIG.md`, `yeti/OVERVIEW.md`). Ordered
last so the prose describes behavior that's already implemented and tested,
not aspirational behavior. This chunk now also removes CONFIG.md's
contradictory "all features enabled" claims (see "Revision round 2" below) so
the doc chunk leaves no stale prose behind, not just new prose added.
`AGENTS.md` is deliberately *not* touched: its "Repository invariants" and
"Build, test, lint" sections don't state any fact about config default/overlay
behavior today, so per the repo's `agents-md-is-a-plan-acceptance-criterion`
skill (which cuts both ways — add it when a chunk changes a fact AGENTS.md
asserts, but don't pad an unrelated chunk with it otherwise) there is nothing
in AGENTS.md to correct. `README.md` only points at `CONFIG.md` for details
and states no default semantics itself, so it's likewise left alone.

## Why not fold c2/c3 into c1

The implementation (c1) is genuinely reviewable on its own — the merge
function's correctness is a matter of reading its branch structure against
the stated rule. Bundling the full test matrix into the same diff as the
algorithm would push the chunk well past the ~400-line guidance once every
default-bearing group is exercised individually (five groups × several
scenarios each, table-driven). Bundling documentation into either code chunk
would mix a prose review with a logic review; keeping it last and separate
lets a reviewer confirm the shipped behavior before signing off on how it's
described.

## Revision round 2: addressing the reviewer's objection

Round 1's reviewer objected (medium severity) that c3 added overlay prose
without fixing two pre-existing, now-contradictory claims already in
`CONFIG.md`:

- Line 13: "If no configuration file is found, all features are enabled by
  default." — unqualified, even though `defaultConfig()` ships
  `maintenance_cleanup_group` disabled.
- The Notes section (lines 153-154): "Missing entries default to
  `enabled: true`" and "Invalid or unreadable configuration files will fall
  back to all features enabled" — same unqualified claim, restated twice more.

The objection is correct and is not a matter of interpretation: `CONFIG.md`'s
own "Maintenance Page" group listing (around line 55) never states that
`maintenance_cleanup_group` defaults to disabled either, so as of round 1 a
reader of `CONFIG.md` alone (as opposed to `yeti/OVERVIEW.md`, which already
gets this right in three places — its "Config file search order" sentence,
its "Configuration-driven UI visibility" paragraph, and its group table) had
no way to learn this default exists at all, and would additionally be told
the opposite by three separate sentences. A chunk that only adds new overlay
prose near "Notes" while leaving those three sentences in place would ship
`c3` "complete" by its own acceptance criteria while leaving the single most
concrete, checkable factual error in the whole doc untouched — exactly the
failure mode the objection names.

**Fix adopted:** c3's scope is widened (still doc-only, still `CONFIG.md` +
`yeti/OVERVIEW.md`, no line-count concern for a doc chunk) to explicitly
rewrite all three CONFIG.md locations:
1. Line 13's intro sentence gains the `maintenance_cleanup_group` exception,
   matching `yeti/OVERVIEW.md`'s existing wording.
2. The Maintenance Page group listing gains a "(disabled by default)" note on
   `maintenance_cleanup_group`, closing the gap where CONFIG.md's own
   reference table never stated this.
3. The Notes section's two contradictory bullets are replaced outright (not
   supplemented) with the precise per-field overlay rule plus an explicit
   statement that an absent/unreadable file falls back to `defaultConfig()`
   in full — including `maintenance_cleanup_group` staying disabled.

c3's acceptance criteria now include concrete, checkable greps (`grep -n
'except' CONFIG.md`, `grep -n 'maintenance_cleanup_group' CONFIG.md`, `grep
-n 'all features enabled' CONFIG.md`) so "the contradictory sentences are
gone and replaced with the qualified version" is verifiable the same way the
rest of this repo's acceptance criteria are, not left to a reviewer's
re-reading of prose.

**Why no automated *test* enforces this (vs. code, which gets `go test`
coverage in c2):** the repo's
`acceptance-criteria-need-automated-checks-not-inspection` skill requires a
real gated check for acceptance criteria that ask for something to be
"tested" or for cross-source consistency (its example: nFPM package layout
vs. the source-install layout, both machine-readable configs). CONFIG.md's
overlay-semantics description is free-form prose the spec asks to be
"documented," not "tested" — there is no second machine-readable source of
truth to assert it against the way `.goreleaser.yaml` can be parsed and
compared to `internal/updex.HelperPath`. Grep-based acceptance criteria (spot
checks a human/reviewer runs once, not a CI gate) are the appropriate rigor
here; adding a `_test.go` that parses `CONFIG.md`'s Markdown prose and
pattern-matches sentences would be brittle (any future rewording breaks it
for no safety benefit) and is not what any `gates_chunk`/`gates_deep` command
in `.mill/config.json` would exercise regardless, since none of them read
Markdown files.

## Cross-cutting invariants touched

- **Config-driven visibility is real** (AGENTS.md): this whole bug is a
  special case of that invariant — a group whose config the file barely
  touches must not spuriously flip visibility. c1's merge logic is the fix;
  c2's tests are what pin it down as a regression guard.
- **GTK main-thread safety / privilege boundary**: not implicated by any
  chunk here — `internal/config` touches neither GTK widgets nor pkexec.
  Noted only to confirm no chunk needs to reason about them.
- **gtk-headless-tests / gate-test-scope-is-internal-only**: c2's test file
  lives in `internal/config` (no puregotk import, already under the gated
  `./internal/...` test scope), so it's automatically covered by
  `gates_chunk`'s test line and by `make ci` without any special handling.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "Define and document overlay semantics for partial config files.",
      "status": "met",
      "evidence": "internal/config/config.go:124-129 defines field-by-field overlay behavior; CONFIG.md:154-163 and yeti/OVERVIEW.md:116-129 document it."
    },
    {
      "requirement": "Omitted enabled means the documented default, not false.",
      "status": "met",
      "evidence": "internal/config/config.go:65-67 parses enabled as *bool and internal/config/config.go:172-174 changes Enabled only when present; defaults are defined at internal/config/config.go:200-254, including maintenance_cleanup_group false at internal/config/config.go:230-232; covered by internal/config/config_test.go:188-241."
    },
    {
      "requirement": "Default values for app IDs, actions, and Help URLs are preserved unless overridden.",
      "status": "met",
      "evidence": "internal/config/config.go:175-191 replaces AppID, Actions, Website, Issues, Chat, and BundlesPaths only when the raw field is present; defaults exist at internal/config/config.go:203-226 and internal/config/config.go:230-252; preservation coverage is in internal/config/config_test.go:144-186."
    },
    {
      "requirement": "maintenance_cleanup_group has the same default with no config and partial config.",
      "status": "met",
      "evidence": "internal/config/config.go:229-239 defines maintenance_cleanup_group as disabled with its default action; internal/config/config.go:147-159 preserves default groups omitted from a partial page; internal/config/config_test.go:103-142 compares absent-file and partial-file behavior."
    },
    {
      "requirement": "Tests cover absent files.",
      "status": "met",
      "evidence": "internal/config/config_test.go:76-101 tests Load() fallback to defaultConfig() when configPaths points at a nonexistent file."
    },
    {
      "requirement": "Tests cover partial pages.",
      "status": "met",
      "evidence": "internal/config/config_test.go:317-377 loads a config that overrides only selected pages, then loops every page/group to confirm defaults and overrides."
    },
    {
      "requirement": "Tests cover partial groups.",
      "status": "met",
      "evidence": "internal/config/config_test.go:160-186 tests groups where only enabled is specified and verifies all other default-bearing fields are preserved across every default-bearing group."
    },
    {
      "requirement": "Tests cover omitted enabled fields.",
      "status": "met",
      "evidence": "internal/config/config_test.go:188-241 tests a present ordinary group and maintenance_cleanup_group with enabled omitted."
    },
    {
      "requirement": "An omitted slice preserves the default.",
      "status": "met",
      "evidence": "internal/config/config.go:68-72 parses slice fields as pointers and internal/config/config.go:178-191 assigns slices only when present; internal/config/config_test.go:160-186 verifies omitted default-bearing fields, including actions and bundles_paths, are preserved."
    },
    {
      "requirement": "An explicit empty slice clears the field to empty.",
      "status": "met",
      "evidence": "internal/config/config.go:178-191 assigns present slice values directly, including empty slices; internal/config/config_test.go:244-271 covers actions: [] and bundles_paths: []."
    },
    {
      "requirement": "A non-empty slice replaces the default.",
      "status": "met",
      "evidence": "internal/config/config.go:178-191 assigns present slice values directly; internal/config/config_test.go:273-315 verifies non-empty actions and bundles_paths replace rather than append."
    },
    {
      "requirement": "Slice overlay semantics apply to actions, bundles_paths, and other slice-valued config fields, including maintenance_cleanup_group's default Actions.",
      "status": "met",
      "evidence": "internal/config/config.go:68-72 includes Actions and BundlesPaths in rawGroupConfig; internal/config/config.go:178-191 applies the same pointer-presence merge to both; internal/config/config_test.go:244-315 covers both fields, including maintenance_cleanup_group Actions."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)