### PR TITLE
Implement or remove the inert updates_settings_group

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -38,7 +38,6 @@ page_name:
 - `flatpak_updates_group`: Available Flatpak application updates (user and system)
 - `brew_updates_group`: Homebrew package updates and outdated packages
 - `brew_trust_group`: Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); only shown when there is something to trust
-- `updates_settings_group`: Update preferences and settings
 
 ### Applications Page (`applications_page`)
 
@@ -85,8 +84,6 @@ updates_page:
     enabled: true # Keep Flatpak updates
   brew_updates_group:
     enabled: false # Hide Homebrew updates
-  updates_settings_group:
-    enabled: true
 
 applications_page:
   applications_installed_group:

--- a/config.bootc-example.yml
+++ b/config.bootc-example.yml
@@ -23,8 +23,6 @@ updates_page:
     enabled: false  # Hide Homebrew updates (not typically used on other distros)
   brew_trust_group:
     enabled: false  # Hide Homebrew tap trust (not typically used on other distros)
-  updates_settings_group:
-    enabled: true  # Show update settings
 
 applications_page:
   applications_installed_group:

--- a/config.yml
+++ b/config.yml
@@ -20,8 +20,6 @@ updates_page:
     enabled: true
   brew_trust_group:
     enabled: true
-  updates_settings_group:
-    enabled: true
 
 applications_page:
   applications_installed_group:

--- a/docs/agents/skills/grep-removal-criteria-must-exclude-mill-and-tests.md
+++ b/docs/agents/skills/grep-removal-criteria-must-exclude-mill-and-tests.md
@@ -1,0 +1,37 @@
+# A "prove it's fully removed" grep criterion must exclude `.mill/` and must not fight a regression test that names the removed thing
+
+**When it applies:** Planning or reviewing any chunk whose acceptance
+criteria include a repo-wide `grep -rn <removed-identifier> .`-style check
+asserting some name, key, flag, or symbol is now completely gone — especially
+when the same chunk also adds a regression test meant to prevent that exact
+thing from silently coming back.
+
+**What to do:** A bare `grep -rn <name> .` (even with `--include`/`.git/`
+filters) also walks `.mill/` — and `.mill/spec.md`, `.mill/plan.md`, and
+`.mill/objections.json` necessarily keep naming the removed thing as the
+historical record of *why* it was removed. That makes the criterion
+unsatisfiable as literally written. Exclude `.mill/` (and `.git/`) from the
+start: `grep -rn <name> . --exclude-dir=.git --exclude-dir=.mill`, rather than
+enumerating an explicit allowlist of product/doc paths — an allowlist has to
+be kept in sync as new files are added, while excluding the two fixed
+tooling directories does not.
+
+Separately, check whether the chunk's own new regression test needs to spell
+the removed identifier to prove its absence (e.g. a test named after the key,
+or a string-literal assertion quoting it) — if so, that test file will also
+trip the same grep, since it lives outside `.mill/`. Resolve this by writing
+the test so it never needs the literal name at all: assert the *exact*
+remaining set (`len(x) == N` plus membership of every surviving entry) rather
+than "does not contain `<removed-name>`". An exact-set check is strictly
+stronger anyway — it also catches the same thing being re-added under a
+*different* name — and it removes the conflict without touching the grep's
+scope or the test's location.
+
+**Learned from:** issue #58's mill run — plan round 1 was rejected because
+its grep-based removal criterion walked `.mill/spec.md`/`plan.md`. Round 2's
+fix (an explicit path allowlist) was itself rejected because the allowlist
+still included `internal/` wholesale, which the same chunk's new
+`config_test.go` also lives under and was written to name the removed key.
+Round 3 converged only after fixing both at once: excluding `.mill/`
+structurally instead of allowlisting, and rewriting the test as an exact-set
+assertion that never spells the removed key's name.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -45,7 +45,6 @@ Groups with `enabled: false` are hidden from the UI. Missing entries default to 
 | Flatpak Updates | `flatpak_updates_group` | Pending Flatpak application updates |
 | Homebrew Updates | `brew_updates_group` | Outdated Homebrew packages with upgrade buttons |
 | Untrusted Taps | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); trust a tap to resume its updates. Shown only when there is something to trust |
-| Settings | `updates_settings_group` | Update preferences |
 
 ### Applications Page (`applications_page`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,11 +206,10 @@ func defaultConfig() *Config {
 			},
 		},
 		UpdatesPage: PageConfig{
-			"bootc_updates_group":    GroupConfig{Enabled: true},
-			"flatpak_updates_group":  GroupConfig{Enabled: true},
-			"brew_updates_group":     GroupConfig{Enabled: true},
-			"brew_trust_group":       GroupConfig{Enabled: true},
-			"updates_settings_group": GroupConfig{Enabled: true},
+			"bootc_updates_group":   GroupConfig{Enabled: true},
+			"flatpak_updates_group": GroupConfig{Enabled: true},
+			"brew_updates_group":    GroupConfig{Enabled: true},
+			"brew_trust_group":      GroupConfig{Enabled: true},
 		},
 		ApplicationsPage: PageConfig{
 			"applications_installed_group": GroupConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
+	"runtime"
 	"testing"
 )
 
@@ -374,4 +376,87 @@ func TestIsGroupEnabledMatchesExpectedForEveryGroup(t *testing.T) {
 			}
 		}
 	})
+}
+
+// repoRoot returns the absolute path to the repository root, computed from
+// this source file's own location rather than the test binary's working
+// directory. internal/config/config_test.go sits two directories below the
+// repo root (<root>/internal/config/config_test.go), the same depth as
+// internal/installcheck/installcheck.go, so the same runtime.Caller(0) +
+// triple filepath.Dir trick applies. This is not imported from
+// internal/installcheck to avoid adding a cross-package dependency for a
+// 3-line helper.
+func repoRoot() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+}
+
+// TestUpdatesPageDefaultGroupSetIsExact asserts that defaultConfig()'s
+// updates_page group set is exactly the four groups the Updates page view
+// still builds. This is an exact-set equality check (length plus every
+// expected key present), not a single named-key absence lookup, so it fails
+// loudly whether a formerly-shipped, now-removed group is silently
+// re-added under its old name or under any new one.
+func TestUpdatesPageDefaultGroupSetIsExact(t *testing.T) {
+	want := map[string]bool{
+		"bootc_updates_group":   true,
+		"flatpak_updates_group": true,
+		"brew_updates_group":    true,
+		"brew_trust_group":      true,
+	}
+
+	got := defaultConfig().UpdatesPage
+	if len(got) != len(want) {
+		t.Fatalf("defaultConfig().UpdatesPage has %d groups, want %d: got keys %v", len(got), len(want), groupKeys(got))
+	}
+	for name := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("defaultConfig().UpdatesPage: missing expected group %q; got keys %v", name, groupKeys(got))
+		}
+	}
+}
+
+func groupKeys(page PageConfig) []string {
+	keys := make([]string, 0, len(page))
+	for name := range page {
+		keys = append(keys, name)
+	}
+	return keys
+}
+
+// isGroupEnabledCallPattern matches config.IsGroupEnabled("updates_page",
+// "<name>") calls in Go source text, capturing the group-name argument.
+var isGroupEnabledCallPattern = regexp.MustCompile(`IsGroupEnabled\(\s*"updates_page"\s*,\s*"([^"]+)"\s*\)`)
+
+// TestUpdatesPageDefaultGroupsHaveBuilders reads internal/views/updates_page.go
+// as plain text (internal/config must never import internal/views or
+// puregotk, directly or transitively, per
+// docs/agents/skills/gtk-headless-tests.md) and asserts every group
+// defaultConfig() defines for updates_page is gated by a real
+// config.IsGroupEnabled("updates_page", ...) call in that view file. This is
+// the regression test that would have caught a group being
+// declared/defaulted/shipped/documented with no view ever checking it: a
+// group with no matching IsGroupEnabled call fails this test.
+func TestUpdatesPageDefaultGroupsHaveBuilders(t *testing.T) {
+	path := filepath.Join(repoRoot(), "internal", "views", "updates_page.go")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	matches := isGroupEnabledCallPattern.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatalf("found zero IsGroupEnabled(\"updates_page\", ...) calls in %s; regex may no longer match the source", path)
+	}
+
+	gated := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		gated[m[1]] = true
+	}
+
+	for name := range defaultConfig().UpdatesPage {
+		if !gated[name] {
+			t.Errorf("defaultConfig().UpdatesPage group %q has no matching config.IsGroupEnabled(\"updates_page\", ...) call in %s", name, path)
+		}
+	}
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -242,7 +242,6 @@ page_name:
 | `updates_page` | `flatpak_updates_group` | Flatpak pending updates |
 | `updates_page` | `brew_updates_group` | Homebrew outdated packages |
 | `updates_page` | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); hidden unless there is something to trust |
-| `updates_page` | `updates_settings_group` | Update settings |
 | `applications_page` | `flatpak_user_group` | User Flatpak applications |
 | `applications_page` | `flatpak_system_group` | System Flatpak applications |
 | `applications_page` | `brew_group` | Homebrew formulae and casks |


### PR DESCRIPTION
Implements issue #58 via the mill workflow.

Closes #58

# Plan: remove inert `updates_settings_group`

## Revision note (round 3)

Round 2 was rejected on one high-severity objection: the acceptance
criterion `grep -rn updates_settings_group internal/ config.yml
config.bootc-example.yml CONFIG.md docs/reference.md yeti/OVERVIEW.md
README.md AGENTS.md returns zero matches` cannot be satisfied at the same
time as the chunk's other acceptance criteria, because the same chunk adds
`internal/config/config_test.go` tests that were written to name
`updates_settings_group` in a test name and/or string literal (to assert the
key is absent) — and `internal/config/config_test.go` is under `internal/`,
which the grep walks. A maintainer applying both criteria together cannot
land the chunk as specified.

**Fix applied:** rather than special-case the grep around the test file (the
objection's suggested fallback — "exclude `*_test.go`, or list
`internal/config/config.go` instead of all `internal/`"), I removed the
underlying conflict instead: the new regression test is now written so it
**never spells the literal string `updates_settings_group`** anywhere in
`internal/config/config_test.go` — not in a test name, not in a string
literal, not in a comment. This is possible without any loss of assertion
strength:

- The "key is gone" check does not need to name the removed key at all. It
  only needs to assert that `defaultConfig().UpdatesPage`'s key set is
  **exactly** `{bootc_updates_group, flatpak_updates_group,
  brew_updates_group, brew_trust_group}` (length 4, each expected key
  present). That exact-set equality is a stronger check than a
  single-key-absence lookup anyway — it catches a future re-addition under
  *any* name, not just this one — and it happens to sidestep the whole
  conflict, since nothing in the assertion needs to reference the string
  `"updates_settings_group"`.
- Prose comments explaining the test's intent refer to "the removed group"
  or "the formerly-shipped updates_page group" rather than naming it, which
  costs nothing in clarity given the test sits directly below the four
  surviving keys are already spelled out.

With that constraint on the test file, the grep criterion no longer needs a
file-list allowlist or a `*_test.go` exclusion at all — it can go back to
being a single, simple, repo-wide check: `grep -rn updates_settings_group . 
--exclude-dir=.git --exclude-dir=.mill` returns zero matches. `.git/` is
excluded because it's build tooling, not product surface; `.mill/` is
excluded because `spec.md`, `plan.md` (this file), and `objections.json`
necessarily still name the key as historical record of *why* it was removed,
which is a different kind of reference than the product/config/docs surface
the issue is about. This is simpler than round 2's eight-path explicit
allowlist (which was itself round 1's fix for a different variant of the
same underlying problem — a grep walking somewhere it shouldn't) and, unlike
an allowlist, doesn't need to be kept in sync if a new product file that
could plausibly reference the key is added later — the exclude list is two
fixed, structural directories, not an enumeration of "everywhere the key
happens not to appear right now."

No other change from round 2's plan; the rest of round 2 survived review
unchallenged.

## Revision note (round 2, retained for history)

Round 1 was rejected on one high-severity objection: the acceptance
criterion's `grep -rn updates_settings_group . --include='*.go'
--include='*.yml' --include='*.md' | grep -v '\.git/'` is not concretely
satisfiable, because it walks the whole repo root and therefore also matches
`.mill/spec.md` (which quotes the key in the issue's Evidence/Decision
sections) and `.mill/plan.md` itself (which necessarily names the key
throughout this document) — both `.md` files, neither excluded by the
`.git/`-only filter.

Round 2's fix named an explicit set of committed product/config/docs paths
instead of walking `.`. That fix was itself insufficient (see the round 3
note above) because it included `internal/` wholesale, which also contains
the new test file. Round 3 supersedes this by removing the conflict at its
source (the test file's wording) rather than by further narrowing the grep's
path list.

## Interpretation of the spec

The issue's "Decision" section already resolves the only real ambiguity
(supported vs. removed): **remove the key completely**. That leaves three
smaller judgment calls I'm recording explicitly rather than guessing
silently:

1. **Scope of "schema-to-builder test".** This repo has no schema file
   (confirmed: no `*.schema.*`, no JSON-schema, no codegen — `AGENTS.md`
   states "There are no generated files and no codegen step"). The decision
   text anticipates this and prescribes the fallback explicitly: a
   puregotk-free Go test over the default config, asserting the removed key
   is gone and, "as feasible," that remaining `updates_page` default group
   keys each correspond to a real builder. I read "as feasible" as: prove
   each surviving key is at least gated by a real `config.IsGroupEnabled`
   call in the view file that owns that page, since the actual widget
   construction lives in `internal/views` (a puregotk-importing package that
   cannot host a `_test.go` at all per
   `docs/agents/skills/gtk-headless-tests.md`). A text/regex scan of
   `internal/views/updates_page.go`'s source, done from a package that never
   imports `views` or puregotk, is the strongest check available without
   violating that constraint. This mirrors how `internal/installcheck`
   already parses real repo-root config as data (`.goreleaser.yaml`) instead
   of importing the package it's checking — including reusing the same
   `runtime.Caller(0)` + triple `filepath.Dir` repo-root trick, since
   `internal/config/config_test.go` sits at the same repo depth as
   `internal/installcheck/installcheck.go`. Deriving the "does a builder gate
   this key" answer from the live source text (rather than a hand-maintained
   literal set of expected group names) means the check can't silently drift
   the way `updates_settings_group` itself did — a genuinely dropped
   `IsGroupEnabled` call fails the test immediately instead of requiring
   someone to remember to update a parallel list.

2. **The criterion is scoped to `updates_page` only**, per the decision
   text's exact wording ("remaining `updates_page` default group keys").
   `yeti/OVERVIEW.md` already documents a second, pre-existing inert-ish
   entry — `applications_page`'s `brew_bundles_group`, annotated "Config key
   exists but has no corresponding UI builder in current code" — but that is
   a different page, a different (already-tracked) situation, and outside
   what this issue's acceptance criteria ask for. Widening the new test to
   cover `applications_page` too would be scope creep on an issue that is
   specifically about `updates_settings_group`; it isn't touched here.

3. **A pre-existing, unrelated documentation typo.** `CONFIG.md`'s
   "Disabling Homebrew Features" example (around line 82) has
   `updates_status_group` where every other reference in the repo says
   `bootc_updates_group` — an evident typo (confirmed against
   `docs/superpowers/plans/2026-07-06-modernization.md`'s historical note
   about a prior `bootc_updates_group` rename that this example was never
   updated for), but for a *different* key than the one this issue is about,
   and not a claim this chunk's change makes newly wrong (it was already
   wrong, independent of `updates_settings_group`'s existence). Per
   `docs/agents/skills/doc-chunks-must-fix-existing-contradictions.md`, the
   obligation is to fix contradictions about the *subject being changed*
   that the chunk's own edit exposes or leaves unresolved — this typo names
   an unrelated group and is orthogonal to whether `updates_settings_group`
   is documented. I'm leaving it untouched and calling it out explicitly here
   (and as an acceptance criterion) so it reads as a deliberate scoping
   decision, not an oversight a reviewer has to catch. (This decision was
   part of round 1 and drew no objection in review, so it is unchanged here.)

4. **Not spelling the removed key's name inside the new test.** This is new
   to round 3 (see the revision note above). It is a plan-level choice about
   *how* the test proves the key is gone, made specifically so the grep-based
   removal-completeness criterion and the new-test criterion can both hold at
   once. It costs nothing in test strength (an exact 4-key-set equality
   check is strictly stronger than a single named-key absence check) and
   nothing in readability (the four surviving keys are enumerated right next
   to the assertion).

## Why one chunk

Every location that references `updates_settings_group` was found with a
single `grep -r` (7 hits across 6 non-`.mill` files, one of them the config
struct literal itself). None of the edits are more than a couple of lines;
the only substantial addition is the new regression test. Splitting "delete
the dead key" from "add the test that proves it's dead" would leave an
intermediate state where the acceptance criterion ("add a test preventing
inert groups") is unmet, which
`docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md`
flags as exactly the kind of gap that gets a plan rejected — so both halves
belong in the same chunk. Estimated diff size (6 files touched, ~15 lines
removed, ~60-90 lines of new test added) comfortably fits the 100-400 line
chunk-review guideline without padding.

## Chunk c1 — remove the key, add the regression test

**Production/doc edits** (all pure deletions of the same dead key, no logic
changes elsewhere):

- `internal/config/config.go`: delete the
  `"updates_settings_group": GroupConfig{Enabled: true}` entry from
  `defaultConfig()`'s `UpdatesPage` map (currently line 213).
- `config.yml`: delete the `updates_settings_group:` / `enabled: true` pair
  under `updates_page:` (lines 23-24).
- `config.bootc-example.yml`: delete the same pair (lines 26-27), including
  its inline comment.
- `CONFIG.md`: delete the bullet-list entry under "Updates Page" (line 41)
  and the `updates_settings_group: enabled: true` lines inside the
  "Disabling Homebrew Features" YAML example (~line 88). Leave the example's
  unrelated `updates_status_group` typo alone (see interpretation note 3
  above).
- `docs/reference.md`: delete the `| Settings | updates_settings_group | ... |`
  table row (line 48).
- `yeti/OVERVIEW.md`: delete the
  `| updates_page | updates_settings_group | Update settings |` table row
  (line 245).
- `AGENTS.md` and `README.md` are **not** in this chunk's file list: grep
  confirms neither ever mentions `updates_settings_group`, so there is no
  stale invariant prose to fix in either, per
  `docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md`'s "don't
  pad an unrelated chunk" guidance.

**New test** (`internal/config/config_test.go`, appended to the existing
file, following its established helper conventions — `pagesOf`, table-driven
`t.Run` subtests, loops over every entry rather than one sample, per
`docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`):

- A small unexported `repoRoot()` helper using the same
  `runtime.Caller(0)` + triple `filepath.Dir` trick as
  `internal/installcheck.RepoRoot()` (not imported from there, to avoid
  adding a cross-package dependency for a 3-line helper; `internal/config`
  sits at the same repo depth so the same relative-dir math applies).
- `TestUpdatesPageDefaultGroupSetIsExact` (or similarly named — deliberately
  *not* named after the removed key, see revision note round 3): asserts
  `len(defaultConfig().UpdatesPage) == 4` and that its key set is exactly
  `{bootc_updates_group, flatpak_updates_group, brew_updates_group,
  brew_trust_group}` — an exact-set assertion, not a single named-key
  absence check, so a future accidental re-add (under this name or any other
  new one) still fails the test. Comments in this test refer to "the removed
  group" rather than spelling `updates_settings_group`.
- `TestUpdatesPageDefaultGroupsHaveBuilders` (or similarly named): reads
  `internal/views/updates_page.go` as text from `repoRoot()`, regex-extracts
  every `config.IsGroupEnabled("updates_page", "<name>")` call's second
  argument into a set, `t.Fatal`s if that set is empty (so a regex that
  silently stops matching doesn't make the test vacuously pass), then loops
  over every key in `defaultConfig().UpdatesPage` and asserts each is present
  in the extracted set — this is the regression test that would have caught
  `updates_settings_group` being declared/defaulted/shipped/documented with
  no view ever checking it.
- Neither new test, including its comments, contains the literal substring
  `updates_settings_group` anywhere — the mechanism that keeps the
  repo-wide removal grep (see round 3 revision note) satisfiable at the same
  time as the test's existence.

## Sequencing

Single chunk, no ordering dependencies on other work. Safe to implement and
land independently of anything else in flight.

## Gate expectations

`gates_chunk` (gofmt, `go vet`, `golangci-lint`, `go build ./...`,
`go test ./internal/... -run "^Test[^I]" -skip "Integration"`) should pass
outright — the change is a subtractive config/doc edit plus a new,
puregotk-free, `internal/...`-scoped test. `make ci` (`gates_deep`) exercises
the same set with `go.mod tidy` and the race detector added; no dependency or
concurrency surface is touched, so no separate risk there.

## Backward-compatibility note (not an acceptance criterion, just a check I
ran while planning)

A live `/etc/chairlift/config.yml` that still sets
`updates_page.updates_settings_group.enabled: true` after this change ships
does not break: `mergePage` treats a raw-file group name absent from
`defaultConfig()` as an "unknown group" and merges it in as an inert map
entry (defaulting `Enabled` to `true` if omitted) that nothing ever reads —
identical to today's behavior, since nothing reads it today either. No
migration or config-file compatibility shim is needed.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "Decide whether update settings are a supported feature.",
      "status": "met",
      "evidence": ".mill/spec.md:21-26 records the decision to remove `updates_settings_group` completely because it is inert."
    },
    {
      "requirement": "If supported, implement a real config-gated group and define its settings.",
      "status": "met",
      "evidence": "The supported-feature branch is not applicable because .mill/spec.md:23-26 chooses removal instead; no implementation of an update-settings group is required under that decision."
    },
    {
      "requirement": "If unsupported, remove the key from defaults, examples, schema, and documentation.",
      "status": "met",
      "evidence": "Defaults now list only four updates groups in internal/config/config.go:208-213; shipped config has only those groups in config.yml:14-22; the bootc example has no settings group in config.bootc-example.yml:19-25; docs list only the four remaining groups in CONFIG.md:35-40, docs/reference.md:40-47, and yeti/OVERVIEW.md:236-244. `**/*schema*` and `**/*.schema.*` matched no schema files."
    },
    {
      "requirement": "Add a schema-to-builder test preventing inert groups.",
      "status": "met",
      "evidence": "internal/config/config_test.go:431-462 adds `TestUpdatesPageDefaultGroupsHaveBuilders`, which reads `internal/views/updates_page.go`, extracts `IsGroupEnabled(\"updates_page\", ...)` calls, fails if none are found, and checks every default updates_page group has a matching gate."
    },
    {
      "requirement": "Remove `updates_settings_group` completely.",
      "status": "met",
      "evidence": "The key is absent from the current product/config/docs surfaces: internal/config/config.go:208-213, config.yml:14-22, config.bootc-example.yml:19-25, CONFIG.md:35-40, docs/reference.md:40-47, and yeti/OVERVIEW.md:236-244; audit grep found no `updates_settings_group` matches outside `.mill`/`.git`."
    },
    {
      "requirement": "Remove the key from every reference: config defaults (`internal/config/config.go`), `config.yml`, `config.bootc-example.yml`, `CONFIG.md`, `docs/reference.md`, and anything else (`grep -r updates_settings_group`).",
      "status": "met",
      "evidence": "The named files no longer reference the key: internal/config/config.go:208-213, config.yml:14-22, config.bootc-example.yml:19-25, CONFIG.md:35-40 and CONFIG.md:75-87, docs/reference.md:40-47, yeti/OVERVIEW.md:236-244; audit grep found no `updates_settings_group` matches outside `.mill`/`.git`."
    },
    {
      "requirement": "Because this repo has no schema file, implement the schema-to-builder criterion as a puregotk-free Go test over the default config.",
      "status": "met",
      "evidence": ".mill/spec.md:28-33 specifies the no-schema fallback; no schema files were present, and the added test is in package `config` with imports shown in internal/config/config_test.go:1-10 and production package imports in internal/config/config.go:1-10, none of which import puregotk."
    },
    {
      "requirement": "Assert that the removed key is absent from the defaults.",
      "status": "met",
      "evidence": "internal/config/config_test.go:394-416 asserts the updates_page default group set is exactly `bootc_updates_group`, `flatpak_updates_group`, `brew_updates_group`, and `brew_trust_group`; internal/config/config.go:208-213 contains exactly those defaults."
    },
    {
      "requirement": "As feasible, assert that remaining `updates_page` default group keys each correspond to a real builder.",
      "status": "met",
      "evidence": "internal/config/config_test.go:431-462 checks every default updates_page group against real `IsGroupEnabled` calls; internal/views/updates_page.go:32, internal/views/updates_page.go:58, internal/views/updates_page.go:75, and internal/views/updates_page.go:110 provide the corresponding builders/gates."
    },
    {
      "requirement": "The test must live in a package that does not import puregotk.",
      "status": "met",
      "evidence": "The test lives in `package config` at internal/config/config_test.go:1; its imports are standard-library only in internal/config/config_test.go:3-10, and the package's production imports are `log`, `os`, `path/filepath`, and `gopkg.in/yaml.v3` in internal/config/config.go:4-10."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)