### PR TITLE
fix: rename the five reserved-prefix TestI… unit tests so CI runs them

### DIFF
--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -156,7 +156,10 @@ go tool cover -html=coverage.out -o coverage.html
 - Exclude integration tests by naming convention
 
 **Integration Tests:**
-- Naming convention: prefix with `TestIntegration` or include `Integration` in name
+- Naming convention: any name beginning `TestI` (not merely those beginning
+  `TestIntegr…`) or containing `Integration` is excluded by `-run "^Test[^I]" -skip "Integration"`;
+  those names are reserved for environment-dependent tests, so ordinary unit
+  tests must not use the `TestI` prefix
 - Skipped in CI unit test runs
 - Require external tools (nbc, flatpak, brew)
 
@@ -224,7 +227,7 @@ func TestContextCancellation(t *testing.T) {
 
 **Table-Driven Tests:**
 ```go
-func TestIsGroupEnabled(t *testing.T) {
+func TestGroupEnabledLookup(t *testing.T) {
     tests := []struct {
         name      string
         page      string

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,15 @@ The app builds pure-Go (`CGO_ENABLED=0`); the race detector needs CGO.
   boundary invariant below).
 
 CI (`.github/workflows/test.yml`) filters tests with `-run "^Test[^I]"
--skip "Integration"`. Names beginning `TestI…` or containing `Integration` are
-the escape hatch for tests that need a real environment and are **excluded from
-the standard run** — a skipped test protects nothing, so keep regression tests
-inside the standard filter (see the GTK-headless skill below).
+-skip "Integration"`. That filter excludes *any* test whose name begins `TestI`
+— not only `TestIntegration` — or contains `Integration` anywhere. Those names
+are reserved for tests that require a real environment (a live `brew`,
+`flatpak`, `bootc`, or GTK display). Ordinary unit tests must not use the
+`TestI` prefix: a test that trips the filter is never executed by `make ci` or
+by CI and therefore protects nothing. The accident is easy to make, because
+plain unit-test names such as `TestIsValid`, `TestInitConfig`, or `TestIndexOf`
+all start with `TestI` and would be silently skipped; name them so the first
+letter after `Test` is not `I` (see the GTK-headless skill below).
 
 There are no generated files and no codegen step; everything under version
 control is hand-written Go, YAML, and data assets.

--- a/docs/agents/skills/grep-acceptance-criteria-subtests-and-cross-chunk-conflicts.md
+++ b/docs/agents/skills/grep-acceptance-criteria-subtests-and-cross-chunk-conflicts.md
@@ -1,0 +1,32 @@
+# Grep-based acceptance criteria over test names must account for subtests and for other chunks' own criteria
+
+**When it applies:** Planning or reviewing any chunk whose acceptance
+criteria include (a) a grep-based count of `go test -list`/`RUN` lines
+expected to change by some exact number, or (b) a `grep -P '\bWORD\b'`-style
+"this name must not appear" check — especially in a multi-chunk plan where a
+later chunk's acceptance criteria also grep for text containing that same
+word (e.g. documenting the convention by naming the pattern in prose).
+
+**What to do:** For RUN-line/test-count deltas: `go test -list`/`-v` output
+includes one line per top-level test *and* one per subtest (`t.Run(...)`), so
+renaming or adding parent tests that already contain table-driven or
+`t.Run`-based subtests changes the count by more than the number of renamed
+identifiers. Compute the expected delta by actually listing tests before and
+after (or reasoning subtest-by-subtest), not by counting renamed function
+names. For `\b`-anchored greps: GNU grep's `\b` treats an ellipsis character
+and most punctuation as a word boundary, so a criterion like
+`grep -P '\bTestInstall\b'` returning nothing can directly conflict with a
+sibling chunk's requirement that some doc literally contain the string
+`TestInstall…` (three dots) as a worked example — both are technically true
+readings of "the old name must be gone" vs. "the doc must explain the
+mistake," but they cannot both hold over the same tree. When a plan spans
+multiple chunks, cross-check every grep-based acceptance criterion against
+every other chunk's criteria for the same identifiers before finalizing —
+don't verify each chunk's checks only in isolation.
+
+**Learned from:** issue #76's mill run, plan round 2 — round 2 was rejected
+twice: once because a RUN-line-count criterion assumed +5 lines for five
+renamed tests but two of them had two subtests each (actual delta +9), and
+once because c1's `grep -P '\bTestInstall\b'` (must return nothing) directly
+contradicted c2's requirement that `AGENTS.md` name the exact accident
+`TestInstall…`, since GNU grep's word-boundary matches at the ellipsis.

--- a/docs/agents/skills/rename-only-scope-forbids-new-non-test-files.md
+++ b/docs/agents/skills/rename-only-scope-forbids-new-non-test-files.md
@@ -1,0 +1,27 @@
+# A "rename-only" or "no production code changes" scope forbids new files too, even test-support ones
+
+**When it applies:** Planning or reviewing any chunk whose spec/acceptance
+criteria explicitly narrow the change to a rename, a doc fix, or otherwise say
+"no production code changes" / "adding new test cases is out of scope" —
+especially when the natural implementation instinct is to add a small helper
+package, fixture, or shared constant to make the rename cleaner or more
+DRY.
+
+**What to do:** Take the scope restriction literally against the whole
+working tree, not just against packages the spec mentions by name. A new file
+under `internal/` — even one framed as "test-support," a names/constants
+table, or a helper used only by `_test.go` files — is still source compiled
+by `go build ./...` and still a new production file the moment it isn't
+itself a `_test.go` file. If a rename or doc-only chunk starts to want a new
+non-test file, that is a signal the chunk has grown scope, not a loophole in
+the constraint. Either inline the needed value directly in each `_test.go`
+file that uses it (accepting some duplication) or flag the scope conflict
+back to the spec rather than planning around it.
+
+**Learned from:** issue #76's mill run, plan round 1 — a plan chunk for a
+five-test rename added `internal/testnames/testnames.go` plus two new tests
+to centralize the old/new name mapping. The reviewer rejected it (high
+severity) because the spec explicitly required a rename-only change with no
+production code under `internal/` touched and no new test cases, and framing
+the new file as "test support" didn't remove the conflict — it was still a
+non-test `.go` file compiled by `go build ./...`.

--- a/docs/superpowers/plans/2026-07-06-modernization.md
+++ b/docs/superpowers/plans/2026-07-06-modernization.md
@@ -1222,7 +1222,7 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func TestInstalledFormulaeByTap(t *testing.T) {
+func TestFormulaeGroupedByTap(t *testing.T) {
 	cellar := t.TempDir()
 	writeFile(t, filepath.Join(cellar, "multica", "0.3.19", "INSTALL_RECEIPT.json"),
 		`{"source": {"tap": "multica-ai/tap"}}`)
@@ -1242,7 +1242,7 @@ func TestInstalledFormulaeByTap(t *testing.T) {
 	}
 }
 
-func TestInstalledCasksByTap(t *testing.T) {
+func TestCasksGroupedByTap(t *testing.T) {
 	caskroom := t.TempDir()
 	writeFile(t, filepath.Join(caskroom, "somecask", ".metadata", "1.0", "20260101", "Casks", "somecask.json"),
 		`{"token": "somecask", "tap": "ublue-os/tap"}`)
@@ -1469,7 +1469,7 @@ Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 - [ ] **Step 1: Write the failing tests (append to trust_test.go)**
 
 ```go
-func TestIsUntrustedTapMessage(t *testing.T) {
+func TestUntrustedTapMessageDetection(t *testing.T) {
 	cases := []struct {
 		in   string
 		want bool

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -316,12 +316,12 @@ func TestNonEmptySliceOverlayReplacesDefaultContents(t *testing.T) {
 	})
 }
 
-// TestIsGroupEnabledMatchesExpectedForEveryGroup calls IsGroupEnabled for
+// TestGroupEnabledMatchesExpectedForEveryGroup calls IsGroupEnabled for
 // every (page, group) pair defaultConfig() defines, both for the
 // absent-file fallback config and for a partial-file config that overrides
 // several groups across different pages, asserting each result matches the
 // expected default/override. Looped, not sampled.
-func TestIsGroupEnabledMatchesExpectedForEveryGroup(t *testing.T) {
+func TestGroupEnabledMatchesExpectedForEveryGroup(t *testing.T) {
 	defPages := pagesOf(defaultConfig())
 
 	t.Run("absent file", func(t *testing.T) {

--- a/internal/homebrew/trust_test.go
+++ b/internal/homebrew/trust_test.go
@@ -61,7 +61,7 @@ func writeFile(t *testing.T, path, content string) {
 	}
 }
 
-func TestInstalledFormulaeByTap(t *testing.T) {
+func TestFormulaeGroupedByTap(t *testing.T) {
 	cellar := t.TempDir()
 	writeFile(t, filepath.Join(cellar, "multica", "0.3.19", "INSTALL_RECEIPT.json"),
 		`{"source": {"tap": "multica-ai/tap"}}`)
@@ -81,7 +81,7 @@ func TestInstalledFormulaeByTap(t *testing.T) {
 	}
 }
 
-func TestInstalledCasksByTap(t *testing.T) {
+func TestCasksGroupedByTap(t *testing.T) {
 	caskroom := t.TempDir()
 	writeFile(t, filepath.Join(caskroom, "somecask", ".metadata", "1.0", "20260101", "Casks", "somecask.json"),
 		`{"token": "somecask", "tap": "ublue-os/tap"}`)
@@ -122,7 +122,7 @@ func TestInstalledCasksByTap(t *testing.T) {
 	}
 }
 
-func TestIsUntrustedTapMessage(t *testing.T) {
+func TestUntrustedTapMessageDetection(t *testing.T) {
 	cases := []struct {
 		in   string
 		want bool

--- a/internal/views/actionmsg/actionmsg_test.go
+++ b/internal/views/actionmsg/actionmsg_test.go
@@ -96,9 +96,9 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
-// TestInstall covers both dry-run states for the Homebrew package-install
-// toast text.
-func TestInstall(t *testing.T) {
+// TestPackageInstallMessage covers both dry-run states for the Homebrew
+// package-install toast text.
+func TestPackageInstallMessage(t *testing.T) {
 	tests := []struct {
 		name         string
 		dryRun       bool


### PR DESCRIPTION
CI filters tests with `-run "^Test[^I]" -skip "Integration"`, reserving those
names for tests that need a real environment. Five ordinary unit tests
accidentally used the reserved `TestI` prefix, so neither the unit job, the
race job, nor `make ci` ever executed them.

Two of the five were regression tests, so the regressions they were written to
guard were unprotected:

- `TestIsGroupEnabledMatchesExpectedForEveryGroup` — the looped per-group
  regression test added with the partial-config merge work (#81)
- `TestInstall` — the dry-run toast-text regression test

## Renames

| before | after |
|---|---|
| `TestInstalledFormulaeByTap` | `TestFormulaeGroupedByTap` |
| `TestInstalledCasksByTap` | `TestCasksGroupedByTap` |
| `TestIsUntrustedTapMessage` | `TestUntrustedTapMessageDetection` |
| `TestInstall` | `TestPackageInstallMessage` |
| `TestIsGroupEnabledMatchesExpectedForEveryGroup` | `TestGroupEnabledMatchesExpectedForEveryGroup` |

Rename only — behavior, table cases, and assertions are unchanged, and no
production code under `cmd/` or `internal/` is touched. The CI filters
themselves are untouched.

## Documentation

`AGENTS.md` now states that the filter excludes *any* `TestI…` name, not only
`TestIntegration…`, and gives concrete examples of innocent-looking names that
trip it. `.planning/codebase/TESTING.md` claimed the convention was
`TestIntegration`-prefixed only, and its table-driven example was itself named
`TestIsGroupEnabled` — an instance of the very bug; both are reconciled.

## Verification

- `grep -rn "^func TestI" --include='*_test.go' .` returns no matches.
- `go test ./internal/... -v -run "^Test[^I]" -skip "Integration"` prints
  `--- PASS` for all five new names (5 of 5).
- `make ci` passes, which runs the same filter under both the unit and race
  steps.

Closes #76