### PR TITLE
Fix GoReleaser Full Changelog URL owner

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -156,7 +156,7 @@ nfpms:
 
 release:
   footer: |
-    **Full Changelog**: https://github.com/bketelsen/{{ .ProjectName }}/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: {{ .Metadata.Homepage }}/compare/{{ .PreviousTag }}...{{ .Tag }}
 
     ---
 

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -12,13 +12,20 @@ import (
 )
 
 // wantSPDXLicense is the SPDX identifier the project's actual license (GPLv3
-// text in LICENSE, gtk.LicenseGpl30Value — puregotk's "GPL 3.0 or later"
+// text in LICENSE, gtk.LicenseGpl30Value — the GTK bindings' "GPL 3.0 or later"
 // enum value — in internal/window/window.go's about dialog) resolves to.
 // .goreleaser.yaml's top-level metadata.license and every nfpms[] entry's
 // license must agree with this constant; see
 // yeti/package-managers.md's "Install-path consistency" section for the
 // MIT/GPL drift bug this guards against.
 const wantSPDXLicense = "GPL-3.0-or-later"
+
+// wantHomepage is the repository URL .goreleaser.yaml's metadata.homepage must
+// declare. It is the single source of truth for the repository URL in that
+// file: release.footer's "Full Changelog" link derives from
+// {{ .Metadata.Homepage }} rather than repeating an owner literal, so a silent
+// edit here would silently redirect every generated release note.
+const wantHomepage = "https://github.com/frostyard/chairlift"
 
 // loadGoreleaserConfig parses the real, repo-root .goreleaser.yaml — not a
 // fixture or copy that could drift from the file goreleaser actually reads
@@ -136,5 +143,72 @@ func TestGoreleaserLicenseIsGPL(t *testing.T) {
 				t.Errorf("nfpms[%d].license = %q, want %q", i, nfpm.License, wantSPDXLicense)
 			}
 		})
+	}
+}
+
+// TestGoreleaserMetadataHomepageIsFrostyardRepo parses the real
+// .goreleaser.yaml and asserts metadata.homepage still names this
+// repository. The value became load-bearing when release.footer started
+// deriving its Full Changelog URL from {{ .Metadata.Homepage }}: a drifting
+// homepage now silently points every release note's changelog link at the
+// wrong repository, which this test catches instead.
+func TestGoreleaserMetadataHomepageIsFrostyardRepo(t *testing.T) {
+	cfg := loadGoreleaserConfig(t)
+
+	if cfg.Metadata.Homepage != wantHomepage {
+		t.Errorf("metadata.homepage = %q, want %q (single source of truth for the repository URL, consumed by release.footer)", cfg.Metadata.Homepage, wantHomepage)
+	}
+}
+
+// TestGoreleaserReleaseFooterUsesMetadataHomepage parses the real
+// .goreleaser.yaml and asserts release.footer's "Full Changelog" line builds
+// its URL from the {{ .Metadata.Homepage }} template variable rather than
+// from a hardcoded repository owner literal.
+//
+// The assertions are on the raw *template text* read from the YAML: the
+// footer is expanded by goreleaser at release time, and goreleaser (Pro) is
+// not installed on the gate host or in make ci, so nothing here renders the
+// template or shells out.
+//
+// It is deliberately non-vacuous: an absent or empty footer, or zero or more
+// than one "Full Changelog" line, is a t.Fatal rather than a silent pass.
+func TestGoreleaserReleaseFooterUsesMetadataHomepage(t *testing.T) {
+	cfg := loadGoreleaserConfig(t)
+
+	footer := cfg.Release.Footer
+	if strings.TrimSpace(footer) == "" {
+		t.Fatal("release.footer is absent or empty in .goreleaser.yaml")
+	}
+
+	var matches []string
+	for _, line := range strings.Split(footer, "\n") {
+		if strings.Contains(line, "Full Changelog") {
+			matches = append(matches, line)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("release.footer has %d lines containing %q, want exactly 1; footer:\n%s", len(matches), "Full Changelog", footer)
+	}
+	line := matches[0]
+
+	if !strings.Contains(line, "{{ .Metadata.Homepage }}") {
+		t.Errorf("Full Changelog line = %q, want it to derive its repository URL from the %q template variable", line, "{{ .Metadata.Homepage }}")
+	}
+	if !strings.Contains(line, "/compare/{{ .PreviousTag }}...{{ .Tag }}") {
+		t.Errorf("Full Changelog line = %q, want it to keep the %q suffix", line, "/compare/{{ .PreviousTag }}...{{ .Tag }}")
+	}
+	if strings.Contains(line, ".ProjectName") {
+		t.Errorf("Full Changelog line = %q, want no .ProjectName: metadata.homepage already ends in the repository name, so the two must not be concatenated", line)
+	}
+
+	// The footer must contain no repository URL literal at all. Asserting the
+	// absence of "github.com/" (rather than of the previous owner's name)
+	// also catches the URL being rewritten to a hardcoded current-owner
+	// literal, which would reintroduce the duplication this guards against —
+	// and it keeps the removed literal out of the tree, per
+	// docs/agents/skills/grep-removal-criteria-must-exclude-mill-and-tests.md.
+	// The surviving https://goreleaser.com/pro link is unaffected.
+	if strings.Contains(footer, "github.com/") {
+		t.Errorf("release.footer contains a hardcoded repository URL literal; it must reference {{ .Metadata.Homepage }} instead. footer:\n%s", footer)
 	}
 }

--- a/internal/installcheck/installcheck.go
+++ b/internal/installcheck/installcheck.go
@@ -8,8 +8,8 @@
 //
 // This package holds no logic reachable from cmd/ or any other internal/
 // package — only shared test-time helpers used by makefile_test.go and
-// goreleaser_test.go. It imports no puregotk, directly or transitively, so a
-// _test.go living here never trips the gtk-headless-tests.md constraint
+// goreleaser_test.go. It imports no GTK bindings, directly or transitively,
+// so a _test.go living here never trips the gtk-headless-tests.md constraint
 // (docs/agents/skills/gtk-headless-tests.md), and it lives under
 // internal/... so it is actually exercised by gates_chunk, make ci, and CI's
 // `go test ./internal/...` filter, per
@@ -38,13 +38,30 @@ func RepoRoot() string {
 // does not need to (and deliberately does not) mirror the whole schema.
 type GoreleaserConfig struct {
 	Metadata MetadataConfig `yaml:"metadata"`
+	Release  ReleaseConfig  `yaml:"release"`
 	Nfpms    []NfpmConfig   `yaml:"nfpms"`
 }
 
 // MetadataConfig is the subset of the top-level metadata: block relevant to
-// license consistency.
+// license consistency (License) and to the repository URL (Homepage).
+//
+// Homepage is load-bearing, not decorative: release.footer's "Full Changelog"
+// link derives its repository URL from the {{ .Metadata.Homepage }} template
+// variable, so this is the single source of truth for the repository URL in
+// .goreleaser.yaml. Like License, it must be named here or yaml.v3 silently
+// drops the value and any test asserting on it passes vacuously.
 type MetadataConfig struct {
-	License string `yaml:"license"`
+	Homepage string `yaml:"homepage"`
+	License  string `yaml:"license"`
+}
+
+// ReleaseConfig is the subset of the top-level release: block relevant to the
+// generated release notes. Footer holds the raw, unrendered Go template text
+// goreleaser expands at release time; the tests assert on that template text
+// (they never render it, and never invoke goreleaser, which is not installed
+// on the gate host or in make ci).
+type ReleaseConfig struct {
+	Footer string `yaml:"footer"`
 }
 
 // NfpmConfig is the subset of an nfpms[] entry relevant to install-location

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -263,7 +263,7 @@ page_name:
 - **Version**: Set via ldflags by goreleaser (`buildVersion`, `buildCommit`, `buildDate`, `buildBy`)
 - **Semantic versioning**: Uses [svu](https://github.com/caarlos0/svu) via `make bump`
 - **CI**: GitHub Actions workflows for test, snapshot, and release (`.github/workflows/`); snapshot publishers use the `chairlift-dev-release` concurrency group without in-progress cancellation so uploads to the rolling `dev` release cannot overlap. GitHub retains only the newest pending run in a concurrency group, so rapid pushes can skip intermediate snapshots while preserving the active upload and latest queued snapshot.
-- **Release**: GoReleaser config at `.goreleaser.yaml`
+- **Release**: GoReleaser config at `.goreleaser.yaml`. Its `metadata.homepage` is the single source of truth for the repository URL and is consumed by `release.footer`, whose "Full Changelog" link is templated from `{{ .Metadata.Homepage }}` rather than a hardcoded owner; two static tests guard that pairing — see the "Install-path consistency (`internal/installcheck`)" section of [package-managers.md](./package-managers.md#install-path-consistency-internalinstallcheck)
 - **Other targets**: `make fmt` (gofmt), `make lint` (golangci-lint), `make install`/`make uninstall` (system install including polkit policies, icons, and wrapper script; default `PREFIX=/usr`, the only prefix that matches where polkit reads policy/rules files and the updex helper's fixed pkexec exec-path annotation — see "Privileged operations" above), `make build-linux-amd64`/`make build-linux-arm64` (cross-compilation)
 
 ### Runtime dependencies

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -297,3 +297,49 @@ pass vacuously regardless of what the YAML says. This test exists so a
 future edit reintroducing MIT (or any other license) in either location —
 the exact regression that motivated it — fails the gate instead of shipping
 mislabeled deb/rpm/apk package metadata again.
+
+A fourth and fifth regression test guard the same class of drift for the
+**repository URL**. `.goreleaser.yaml`'s `metadata.homepage`
+(`https://github.com/frostyard/chairlift`) is the **single source of truth**
+for that URL: GoReleaser Pro v2.13+ exposes the global `metadata:` block as
+template context to every templated field, so `release.footer`'s "Full
+Changelog" line derives its URL from `{{ .Metadata.Homepage }}` plus the
+`/compare/{{ .PreviousTag }}...{{ .Tag }}` suffix. The footer therefore
+contains no repository-owner literal at all, and `{{ .ProjectName }}` is
+deliberately **not** concatenated onto it — the homepage already ends in the
+repository name, so appending the project name would produce a doubled path.
+The regression this guards: the footer used to hardcode the repository's
+previous owner in that URL while `metadata.homepage` already named the
+current one, so a single file identified one repository two disagreeing ways
+and every generated release note's Full Changelog link pointed at the wrong
+owner. Deriving the footer from the homepage removes the duplicate rather
+than policing it, and the two tests keep the now-load-bearing source of truth
+honest:
+
+- **`TestGoreleaserMetadataHomepageIsFrostyardRepo`** asserts
+  `cfg.Metadata.Homepage` still equals `https://github.com/frostyard/chairlift`,
+  so the value the footer depends on cannot silently drift.
+- **`TestGoreleaserReleaseFooterUsesMetadataHomepage`** asserts the parsed
+  `release.footer` has exactly one "Full Changelog" line, that it references
+  `{{ .Metadata.Homepage }}`, that it keeps the
+  `/compare/{{ .PreviousTag }}...{{ .Tag }}` suffix, and that it contains no
+  `.ProjectName`; a separate check rejects any `github.com/` literal anywhere
+  in the footer, which catches a rewrite to a hardcoded *current*-owner URL
+  just as surely as a stale one. An absent or empty footer, or any line count
+  other than exactly one "Full Changelog" line, is a `t.Fatal`, not a silent
+  pass, so the test cannot succeed vacuously against a config whose footer
+  was deleted.
+
+Both assert on the **template text** parsed out of the YAML — never a
+rendered value. The footer is a Go template expanded by GoReleaser only at
+release time, and GoReleaser Pro (this config sets `pro: true` and a
+`nightly:` block) is not installed on the gate host or in `make ci`; it runs
+only in `.github/workflows/{release,snapshot}.yml` via `goreleaser-action`
+with a `GORELEASER_KEY` secret. `goreleaser check` is therefore deliberately
+not run anywhere — locally, in `gates_chunk`, or in `make ci` — and neither
+test shells out or renders anything. As with the license guard,
+`MetadataConfig.Homepage` and `ReleaseConfig.Footer` in
+`internal/installcheck/installcheck.go` exist solely so `yaml.Unmarshal` has
+somewhere to put those values, exactly as `MetadataConfig.License` does;
+without the struct fields yaml.v3 drops them and both tests would pass
+vacuously regardless of what the YAML says.

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -237,8 +237,9 @@ nothing stops them (or `internal/updex.HelperPath`, the fixed absolute path
 drifting apart again the way the Makefile's old `/usr/local` default drifted
 from the policy's `/usr/bin` in the bug this package now guards against.
 
-`internal/installcheck` holds two regression tests, not production code, that
-turn "verified by inspection" into a real, gated check:
+`internal/installcheck` holds five regression tests, not production code, that
+turn "verified by inspection" into a real, gated check. The first two guard the
+installed layout itself:
 
 - **`TestMakefileInstallUsesUsrPrefix`** runs `make -n install
   DESTDIR=<t.TempDir()>` — a dry run, so no compilation, no writes outside


### PR DESCRIPTION
Implements issue #72 via the mill workflow.

Closes #72

# Implementation plan — release footer must not hardcode the repository owner

## Problem

`.goreleaser.yaml`'s `release.footer` builds the "Full Changelog" link from a
hardcoded `https://github.com/<previous-owner>/{{ .ProjectName }}` literal, so
every generated release note links at the wrong repository owner, while
`metadata.homepage` in the same file already points at
`https://github.com/frostyard/chairlift`. One repository, identified two ways,
disagreeing.

## Approach

GoReleaser Pro v2.13+ exposes the global `metadata:` block to every templated
field, so `release.footer` can reference `{{ .Metadata.Homepage }}` directly.
Rather than replacing one owner literal with another and policing the duplicate
with a test, we delete the duplication: `metadata.homepage` becomes the actual
single source of truth, and the footer derives its URL from it. Static tests in
`internal/installcheck` then pin *both* halves — the homepage value itself
(now load-bearing) and the footer's reference to it.

## Hard environment constraint

GoReleaser is **not** installed on the gate host and is not part of `make ci`;
this config requires the Pro distribution (`pro: true`, `nightly:` block) and a
`GORELEASER_KEY`, and only `.github/workflows/{release,snapshot}.yml` run it.
Therefore **no acceptance criterion may require executing `goreleaser`,
including `goreleaser check`.** All verification is static: parse the YAML with
`gopkg.in/yaml.v3` (already vendored) and assert on the **template text**. The
footer is a Go template expanded only at release time — rendering it is not
attempted anywhere.

## Interpretations recorded (where the spec left room)

1. **"Contains no hardcoded repository owner" is checked as "the `release:`
   block contains no `github.com/` substring at all."** The spec's own grep
   criterion (`bketelsen/` must be gone) is necessary but not sufficient — it
   would pass if the footer were rewritten to `github.com/frostyard/...`, which
   reintroduces exactly the duplication this change removes. An
   experienced maintainer reading acceptance criterion 4 ("must fail if …
   rewritten back to a literal owner") wants the stronger check, and it has the
   side benefit that the test never has to spell the old owner's name (see
   interpretation 4).
2. **`{{ .ProjectName }}` is dropped entirely from the changelog URL**, not
   kept alongside the homepage. The spec is explicit ("do not concatenate
   both"), and `metadata.homepage` already ends in `/chairlift`. A test
   asserts `.ProjectName` does not appear on the Full Changelog line.
3. **The footer test locates the Full Changelog line specifically**, requiring
   exactly one such line, rather than asserting over the whole multi-line block
   scalar. This keeps the surviving
   `_Released with [GoReleaser Pro](https://goreleaser.com/pro)!_` line and the
   `---` rule out of the assertions, and makes the "must not pass vacuously"
   requirement concrete: zero matching lines (or an empty/absent `footer` key)
   is a `t.Fatal`, not a silent pass.
4. **Neither the tests nor the documentation may spell the literal
   `bketelsen/`.** The spec requires that string to be gone from
   `.goreleaser.yaml`; the natural repo-wide generalization
   (`grep -rn 'bketelsen/' . --exclude-dir=.git --exclude-dir=.mill`) would be
   defeated by a test that asserts `!strings.Contains(footer, "bketelsen/")` or
   by doc prose quoting the old URL — both live outside `.mill/`. Per
   `docs/agents/skills/grep-removal-criteria-must-exclude-mill-and-tests.md`
   and `…/grep-acceptance-criteria-subtests-and-cross-chunk-conflicts.md`, the
   guards are written positively (assert what the footer *must* contain, and
   assert the absence of `github.com/`) and the docs say "the repository's
   previous owner" in prose. `.mill/` and `.git/` are excluded structurally
   from every removal grep, since `.mill/spec.md` and this file necessarily
   discuss the removed literal.
   Note the maintainer entry `Brian Ketelsen <bketelsen@gmail.com>` is correct
   and stays: every grep matches `bketelsen/` **with the trailing slash**,
   never the bare name.
5. **`AGENTS.md` and `README.md` are deliberately not edited.** Per
   `docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md`, AGENTS.md
   must be in a chunk's `files` when the chunk makes one of its stated facts
   stale — but AGENTS.md states nothing about `.goreleaser.yaml`, release
   notes, or the repository URL (`grep -n 'goreleaser\|homepage\|Changelog'
   AGENTS.md` is empty), and the same skill warns against padding chunks with
   doc edits they don't need. README.md's only `.goreleaser.yaml` references
   concern the nFPM install prefix, untouched here. The spec's documentation
   criterion names "documentation describing release/packaging metadata
   invariants … consistent with how `yeti/package-managers.md` documents the
   existing license and install-path drift guards" — that is `yeti/`, and that
   is where the prose goes.
6. **The already-correct half still gets a real test.** `metadata.homepage` is
   correct today, but per
   `docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md`
   "already correct, verified by inspection" does not satisfy a testing
   criterion — and here the value is newly load-bearing, so
   `TestGoreleaserMetadataHomepageIsFrostyardRepo` is written even though it
   passes without any config fix.
7. **No collection iteration is needed.** `release.footer` and
   `metadata.homepage` are scalars, not slices, so
   `docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`
   does not apply to the new tests. The existing `nfpms[]` loops are untouched.

## Chunks

### c1 — Footer derives from `{{ .Metadata.Homepage }}`, with static guards

Touches `.goreleaser.yaml` (one line), `internal/installcheck/installcheck.go`
(three struct additions), and `internal/installcheck/goreleaser_test.go` (two
new tests). Roughly 90–120 changed lines including doc comments in the style of
the existing tests.

The footer line becomes:

```
    **Full Changelog**: {{ .Metadata.Homepage }}/compare/{{ .PreviousTag }}...{{ .Tag }}
```

The YAML subset in `installcheck.go` gains `MetadataConfig.Homepage`,
`ReleaseConfig{Footer}`, and `GoreleaserConfig.Release`. These fields exist for
the same reason `MetadataConfig.License` does: yaml.v3 silently drops anything
not named in the struct, so without them a test would pass vacuously no matter
what the YAML says.

New tests, both using the existing `loadGoreleaserConfig(t)` helper (which
reads the **real** repo-root file via `RepoRoot()`, never a fixture):

- `TestGoreleaserMetadataHomepageIsFrostyardRepo`
- `TestGoreleaserReleaseFooterUsesMetadataHomepage`

Neither name begins with `TestI` nor contains `Integration`, so CI's
`-run "^Test[^I]" -skip "Integration"` filter actually executes them
(`AGENTS.md`); both live under `internal/...`, the only scope any gate runs
(`docs/agents/skills/gate-test-scope-is-internal-only.md`); and
`internal/installcheck` imports no puregotk directly or transitively, which the
chunk must preserve (`docs/agents/skills/gtk-headless-tests.md`).

**Invariants constraining this chunk.** The *privilege boundary* is untouched:
no new command execution, no pkexec surface, and the `nfpms[]` `bindir` and
polkit `contents[].dst` entries that `TestGoreleaserNfpmLayoutMatchesUsrPrefix`
pins to `internal/updex.HelperPath` and `/usr/share/polkit-1/{actions,rules.d}`
are byte-identical afterwards — that test and `TestGoreleaserLicenseIsGPL` must
still pass unchanged. *GTK main-thread safety* and *config-driven visibility*
are not implicated (no widget or config code is touched), but the
puregotk-free property of `internal/installcheck` is the mechanism by which
those constraints stay satisfied for its tests.

Non-vacuity is demonstrated by hand during implementation (delete the footer →
test fails; restore a literal-owner footer → test fails; change the homepage →
the homepage test fails), then reverted.

### c2 — Document the invariant in `yeti/`

Touches `yeti/package-managers.md` (extend the "Install-path consistency
(`internal/installcheck`)" section with a paragraph after the existing
`TestGoreleaserLicenseIsGPL` discussion) and `yeti/OVERVIEW.md` (the
`- **Release**: GoReleaser config at .goreleaser.yaml` bullet). Roughly 30–50
changed lines, documentation only, so the gates are trivially green.

The prose records: `metadata.homepage` is the single source of truth for the
repository URL and is consumed by `release.footer`; `{{ .ProjectName }}` is
deliberately not concatenated onto it; the guards assert parsed **template
text** and never render or invoke GoReleaser, because GoReleaser Pro is absent
from the gate host and `make ci`; and `MetadataConfig.Homepage` /
`ReleaseConfig.Footer` exist purely to give yaml.v3 somewhere to put those
values.

Per `docs/agents/skills/doc-chunks-must-fix-existing-contradictions.md` the
chunk greps both `yeti/` files for existing sentences about the release footer
or repository URL and rewrites rather than appends if any are found, so no
stale claim sits beside the new prose. Per interpretation 4, the prose must not
spell `bketelsen/`, so c1's repo-wide removal grep still holds over the tree c2
leaves behind — this cross-chunk check was performed explicitly.

## Sequencing

c1 → c2. c1 is self-contained and leaves the tree green on its own (the config
change and its guards land together, so the guards never describe a state that
does not yet exist). c2 documents what c1 established and depends on c1's test
names and struct field names being final; it changes no code and cannot
regress any gate. c1's repo-wide `bketelsen/` grep criterion is stated so that
it also holds after c2, which is why c2 carries a restated version of the same
criterion.

## Out of scope (per spec)

Running or adding `goreleaser check` anywhere; changing `metadata.maintainers`,
the release workflows, or any other `.goreleaser.yaml` block; renaming the
repository or changing `project_name`.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "Do not require executing GoReleaser; verification must statically parse YAML.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:30-46 parses the real YAML with yaml.v3; Makefile:141-159 runs no GoReleaser command."
    },
    {
      "requirement": "Only release and snapshot workflows invoke GoReleaser Pro with GORELEASER_KEY.",
      "status": "met",
      "evidence": ".github/workflows/release.yml:31-41 and .github/workflows/snapshot.yml:36-43 contain the GoReleaser Pro invocations."
    },
    {
      "requirement": "The Full Changelog URL must derive from {{ .Metadata.Homepage }}.",
      "status": "met",
      "evidence": ".goreleaser.yaml:157-159 uses {{ .Metadata.Homepage }}."
    },
    {
      "requirement": "The changelog URL must preserve /compare/{{ .PreviousTag }}...{{ .Tag }}.",
      "status": "met",
      "evidence": ".goreleaser.yaml:159; guarded by internal/installcheck/goreleaser_test.go:197-199."
    },
    {
      "requirement": "No hardcoded repository owner may remain in release.footer.",
      "status": "met",
      "evidence": ".goreleaser.yaml:157-163 contains no repository URL literal; internal/installcheck/goreleaser_test.go:204-213 rejects any github.com/ literal in the footer."
    },
    {
      "requirement": "The footer URL must not concatenate {{ .ProjectName }} with the homepage.",
      "status": "met",
      "evidence": ".goreleaser.yaml:159 omits .ProjectName; internal/installcheck/goreleaser_test.go:200-202 guards this."
    },
    {
      "requirement": "Add a static guard using the real repo-root .goreleaser.yaml, RepoRoot(), yaml.v3, and an extended GoreleaserConfig.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:30-46 uses RepoRoot and yaml.Unmarshal; internal/installcheck/installcheck.go:35-65 defines Metadata.Homepage and Release.Footer."
    },
    {
      "requirement": "The string bketelsen/ must not appear in .goreleaser.yaml.",
      "status": "met",
      "evidence": ".goreleaser.yaml:1-180 contains no bketelsen/ occurrence; direct grep returned absent."
    },
    {
      "requirement": "The Brian Ketelsen maintainer entry must remain unchanged, and removal checks must target bketelsen/ rather than the bare name.",
      "status": "met",
      "evidence": ".goreleaser.yaml:18-19 retains Brian Ketelsen <bketelsen@gmail.com>; the audit grep targeted bketelsen/."
    },
    {
      "requirement": "metadata.homepage must equal https://github.com/frostyard/chairlift and be test-guarded.",
      "status": "met",
      "evidence": ".goreleaser.yaml:14-17 has the required value; internal/installcheck/goreleaser_test.go:23-28 and 149-161 assert it."
    },
    {
      "requirement": "A test must assert that parsed release.footer references .Metadata.Homepage.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:163-196 checks the parsed Full Changelog line for {{ .Metadata.Homepage }}."
    },
    {
      "requirement": "The footer test must fail for an absent, empty, or literal-owner footer and must not pass vacuously.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:178-191 fails on absent/empty or missing/duplicate Full Changelog lines; lines 204-213 reject literal repository URLs."
    },
    {
      "requirement": "Tests must inspect raw template text and must never render the template or invoke GoReleaser.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:168-171 reads and checks strings only; no exec or template rendering is present."
    },
    {
      "requirement": "No new test name may begin with TestI or contain Integration.",
      "status": "met",
      "evidence": "internal/installcheck/goreleaser_test.go:155 and 175 define TestGoreleaserMetadataHomepageIsFrostyardRepo and TestGoreleaserReleaseFooterUsesMetadataHomepage; both are discovered by the CI filter."
    },
    {
      "requirement": "make ci must pass.",
      "status": "met",
      "evidence": "Makefile:141-159 defines the deep gate; the audited HEAD completed make ci successfully."
    },
    {
      "requirement": "Documentation must describe metadata.homepage as the repository URL source of truth consumed by release.footer.",
      "status": "met",
      "evidence": "yeti/OVERVIEW.md:266 and yeti/package-managers.md:302-346 document the invariant, tests, template-text checks, and absence of GoReleaser from gates."
    },
    {
      "requirement": "Do not add or run goreleaser check.",
      "status": "met",
      "evidence": "Makefile:141-159 and internal/installcheck/goreleaser_test.go:30-46 use only existing Go tooling and static YAML parsing; repository command search found no goreleaser check invocation."
    },
    {
      "requirement": "Do not change metadata.maintainers, release workflows, or any unrelated .goreleaser.yaml block.",
      "status": "met",
      "evidence": ".goreleaser.yaml:18-19 is unchanged; the base-to-HEAD diff changes only the Full Changelog line at .goreleaser.yaml:159 and does not modify workflows."
    },
    {
      "requirement": "Do not rename the repository or change project_name.",
      "status": "met",
      "evidence": ".goreleaser.yaml:12 remains project_name: chairlift and line 16 remains the frostyard/chairlift repository URL."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)