### PR TITLE
feat(config): add strict configuration schema metadata

### DIFF
--- a/docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md
+++ b/docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md
@@ -1,0 +1,26 @@
+# Derive schema/validation rules from the canonical struct, not from a shadow parse representation
+
+**When it applies:** Planning or reviewing any chunk that validates a
+config/data file's shape (e.g. rejecting unknown keys, checking required
+fields, enumerating valid top-level names) by walking an intermediate
+representation — a `rawConfig` map, a `yaml.Node` tree, a generic
+`map[string]interface{}` — instead of the Go struct (e.g. `Config`) that the
+spec names as authoritative.
+
+**What to do:** An intermediate representation built and maintained
+separately from the canonical struct can drift from it: a field added to
+`Config` isn't automatically reflected in `rawConfig`'s key list, so legitimate
+fields get rejected (or unknown ones silently accepted) without any planned
+test catching it, because the test was written against the same drifting
+intermediate representation. Derive validation sets (page names, required
+keys, allowed keys) directly from the canonical struct — via reflection,
+generation, or a single hand-maintained list colocated with the struct and
+covered by a test asserting the two stay in sync — rather than introducing a
+second source of truth that has to be kept in lockstep by hand across future
+changes.
+
+**Learned from:** issue #69's mill run on `internal/config` — plan round 3 was
+rejected (high severity) because chunk c3 derived and tested top-level page
+keys from `rawConfig` while the spec defined `Config` as authoritative,
+meaning legitimate `Config` fields could be rejected or omitted without the
+planned acceptance test failing.

--- a/docs/agents/skills/grep-test-files-for-package-level-identifier-collisions.md
+++ b/docs/agents/skills/grep-test-files-for-package-level-identifier-collisions.md
@@ -1,0 +1,29 @@
+# Before planning a new package-level helper or var, grep existing `_test.go` files in that package
+
+**When it applies:** Planning or reviewing any chunk that introduces a new
+package-level function, var, or const — especially a small utility like a
+name-lookup helper or a list of known keys — in a package that already has
+one or more `_test.go` files, whether or not those test files are in the
+chunk's `files` list.
+
+**What to do:** Go test files compile into the same package as the
+production code and share its identifier namespace, so a new
+`func groupKeys(page PageConfig) ...` or `var pageNames = ...` collides with
+an identically named helper or var already declared in
+`internal/whatever/whatever_test.go`, even though that file is never touched
+by the chunk and even though Go allows no overloading to disambiguate them.
+This breaks the build the moment the chunk lands, and a plan that explicitly
+restricts the chunk to only its listed new files will not resolve the
+collision by renaming the pre-existing one. Before drafting a chunk that adds
+any package-level identifier, grep every `_test.go` file already in the
+target package for that exact name (and close variants) — not just the
+package's non-test `.go` files — and pick a name or scope that avoids the
+clash, or explicitly widen the chunk to include the rename.
+
+**Learned from:** issue #69's mill run — plan round 1 proposed a
+`groupKeys(page)` helper that collided with an existing `groupKeys(page
+PageConfig)` already defined in `internal/config/config_test.go`; round 2's
+fix (a `pageNames()` func) collided the same way with a pre-existing
+package-level `var pageNames` at config_test.go line 18. Both rounds were
+rejected because Go forbids the redeclaration and the chunk's file scope
+excluded editing the test file.

--- a/docs/agents/skills/helper-functions-need-direct-test-calls.md
+++ b/docs/agents/skills/helper-functions-need-direct-test-calls.md
@@ -1,0 +1,26 @@
+# "Every added helper must be called from the test file" means a literal, direct call — not coverage through the public entrypoint
+
+**When it applies:** Any plan chunk whose acceptance criteria require that
+every unexported helper function added in an implementation file be exercised
+by its companion `_test.go` file. This is common in chunks that introduce
+several small internal helpers (parsing, key-identity, traversal) behind one
+exported function.
+
+**What to do:** Reviewers check this criterion literally: if `foo.go` adds
+`resolveNode`, `resolveMapping`, `mappingKeyID`, etc., the test file must
+contain at least one call site naming each of those identifiers directly
+(e.g. `mappingKeyID(node)` in a unit test), not merely a call into the
+top-level exported function that happens to invoke them internally.
+End-to-end coverage through the public API does not satisfy this criterion
+even when it exercises every line — write a small direct unit test per
+helper (or a table test that calls the helper by name) alongside the
+integration-style tests. When drafting the chunk, list each helper's expected
+direct-call test up front so it isn't missed during implementation.
+
+**Learned from:** issue #69 phase-1 validator mill run — chunk 1 added several
+resolve.go helpers (`resolveNode`, `resolveDocument`, `resolveAlias`,
+`resolveMapping`, `mappingKeyID`, `parseTypeErr`, `resolveMergeSources`) but
+`resolve_test.go` only called `resolveEffective` and `isMergeKey` directly.
+The same "helpers not called directly from tests" objection recurred in
+review rounds 1, 2, and 3, contributing to the run exhausting its review-round
+limit and terminating as FAILED.

--- a/docs/agents/skills/match-dependency-behavior-from-gomodcache-not-memory.md
+++ b/docs/agents/skills/match-dependency-behavior-from-gomodcache-not-memory.md
@@ -1,0 +1,37 @@
+# When a spec requires matching a dependency's exact parsing/semantics, read the dependency's source in `GOMODCACHE`, not memory
+
+**When it applies:** Planning or reviewing any chunk whose acceptance
+criteria say new code must behave "the same as," "consistent with," or
+"matching" a third-party library's parsing, tagging, or resolution semantics
+— e.g. yaml.v3's merge-key (`<<`) detection, tag normalization, duplicate-key
+rules, or any other undocumented-but-load-bearing internal predicate. This
+generalizes beyond YAML to any spec that asks new code to reproduce a Go
+module dependency's exact behavior.
+
+**What to do:** The dependency's actual source is already on disk and
+trivially findable — `go env GOMODCACHE` (typically
+`~/go/pkg/mod/<module>@<version>/`) — and is authoritative in a way that
+memory or a summary of "how yaml.v3 handles merge keys" is not. For example,
+yaml.v3's real merge-key predicate (`resolve.go`/`decode.go`) is `n.Kind ==
+ScalarNode && n.Value == "<<" && (n.Tag == "" || n.Tag == "!" ||
+shortTag(n.Tag) == mergeTag)`, where `mergeTag = "!!merge"` and `shortTag`
+also normalizes the canonical long form `tag:yaml.org,2002:merge`. A plan
+written from an approximate recollection of this (e.g. checking only
+`Tag == "" || Tag == "!!merge"`) will look plausible but silently reject
+valid explicitly-tagged merge keys, and reviewers will keep raising the same
+class of objection — each with a slightly different missed edge (short tag
+form, long tag form, duplicate-key precedence) — across multiple revision
+rounds because each fix patches the symptom the previous round complained
+about rather than the actual source predicate. Before drafting or revising
+any chunk with a "must match library X" criterion, locate and read the
+relevant function in `GOMODCACHE` directly and cite the exact predicate in
+the plan; this resolves the whole class of objections in one round instead
+of one round per missed edge case.
+
+**Learned from:** issue #69 phase-1 validator mill run (second attempt) —
+four consecutive `plan_revise` rounds all objected to variations of the same
+merge-key tag-matching gap (missing canonical long-tag form, missing
+duplicate-`<<`-key precedence relative to yaml.v3's unique-key check), each
+fixed just enough to satisfy the prior objection's literal wording without
+consulting yaml.v3's actual source, exhausting the plan-round limit and
+causing the run to terminate as FAILED before any implementation began.

--- a/docs/agents/skills/multi-tier-error-classification-needs-a-decision-table.md
+++ b/docs/agents/skills/multi-tier-error-classification-needs-a-decision-table.md
@@ -1,0 +1,31 @@
+# A spec introducing multi-tier error classification (parse/schema/value, etc.) needs one explicit decision table before any chunk is written
+
+**When it applies:** Planning or reviewing any spec that introduces more than
+one error "Kind" for a single failure surface — e.g. distinguishing a
+KindParse (document isn't valid YAML/JSON at all) from a KindSchema (document
+parses but has the wrong shape: wrong node type, unknown key, missing
+required key) from a KindValue error. Also applies whenever the classification
+must stay stable across several chunks that each add tests for different
+input shapes.
+
+**What to do:** Before splitting the work into chunks, write down the exact
+boundary as a table of input shapes to Kind, covering every edge case a
+reviewer could construct: a scalar where a mapping is expected, a null node,
+an empty document, an unknown key, a YAML alias resolving to a valid type,
+etc. Only after that table is fixed should later chunks add acceptance tests
+per Kind — otherwise chunk N's test ("a bare scalar document must be
+KindParse") and chunk N+1's test ("any non-mapping page/group/action value
+must be KindSchema") silently assume different boundaries for the same kind
+of malformed input, and reviewers reject the plan for internal
+inconsistency. When a later chunk's classification decision requires
+touching a test file whose behavior changes as a result (e.g.
+`config_test.go`), list that test file explicitly in that chunk's file list;
+don't assume "pre-existing tests keep passing unmodified" is compatible with
+also tightening what they test for.
+
+**Learned from:** issue #69's mill run on `internal/config` schema/authority
+loading — plan rounds 1-4 were rejected on this same axis repeatedly (round 3:
+schema validation authority; round 4: parse-vs-schema boundary for
+non-mapping document/page/group/action structures), exhausting the
+`plan_rounds` limit (4) with the run terminating as FAILED because no round
+ever pinned the classification boundary down before writing per-chunk tests.

--- a/docs/agents/skills/split-oversized-chunks-by-concern-not-by-carve-out.md
+++ b/docs/agents/skills/split-oversized-chunks-by-concern-not-by-carve-out.md
@@ -1,0 +1,29 @@
+# Splitting an oversized chunk means dividing it by concern, not carving off one narrow rule
+
+**When it applies:** Revising a plan after a reviewer objects that a single
+chunk is too large to review (e.g. it owns an entire validator, traversal, or
+similar multi-concern implementation plus its tests, well past the review
+budget) — especially validation/parsing logic that combines structural
+traversal, multiple independent rule checks, and defensive guards in one
+file.
+
+**What to do:** A response that moves only one narrow, easily-isolated rule
+(e.g. "reject unknown names") into its own chunk while leaving the rest of
+the traversal, every other parse/type rule, alias/merge expansion, duplicate
+handling, and all the denial-of-service guards bundled together does not
+meaningfully reduce the size or reviewability of the remaining chunk — a
+reviewer will reject it again for the same reason. Instead, split along real
+seams in the implementation: separate the structural traversal/decoding step
+from the semantic rule checks, separate alias/merge resolution from
+post-resolution validation, and separate defensive/DoS guards into their own
+chunk with their own regression tests. Each resulting chunk should be
+independently reviewable — own a coherent piece of the design with its own
+tests — rather than being defined by "everything except the one thing we just
+pulled out."
+
+**Learned from:** issue #69's mill run, plan round 4 — a schema-validation
+chunk (~450 estimated lines of validate.go plus tests) was rejected as too
+large; the plan's attempted fix moved only unknown-name rejection to a new
+chunk while validate.go retained the full traversal, all other parse/type
+checks, alias/merge expansion, duplicate handling, and three separate DoS
+guards plus their tests — the reviewer treated this as not a real split.

--- a/docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md
+++ b/docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md
@@ -1,0 +1,26 @@
+# Comparing or deduplicating yaml.v3 scalar keys must include the Tag, not just Value
+
+**When it applies:** Writing or reviewing any Go code that walks `*yaml.Node`
+trees (merge-key resolution, alias expansion, duplicate-key detection, map
+flattening, etc.) and needs to decide whether two mapping keys are "the same
+key." This applies any time a helper builds a key identity from a scalar
+node — not just in `internal/config`, but anywhere yaml.v3 nodes are compared.
+
+**What to do:** A `yaml.Node`'s `.Value` is the raw string form of a scalar,
+so an explicit string key `"1"` and an implicit integer key `1` both have
+`Value == "1"` but are semantically distinct YAML keys (different `.Tag`,
+e.g. `!!str` vs `!!int`). Any key-identity function (`mappingKeyID`-style
+helpers) that hashes or compares only `Value` will silently collide these,
+letting one key mask or overwrite the other during merge/dedup — a real bug,
+not just a style nit. Build key identity from `(Tag, Value)` (or the decoded
+Kind) together, and add a test with two same-`Value`-different-`Tag` keys
+(e.g. quoted `"1"` vs bare `1`) to prove they remain distinct. Reviewers will
+flag a `Value`-only comparator as high severity and will keep flagging it
+across revision rounds if a fix only adds a nil-guard or comment instead of
+actually incorporating the tag.
+
+**Learned from:** issue #69 phase-1 validator mill run — chunk 1's
+`mappingKeyID` in `internal/config/resolve.go` compared merge/mapping keys by
+`.Value` alone. The same high-severity objection ("integer 1 and string \"1\"
+collide") was raised in review rounds 1, 2, and 3 without being fixed,
+exhausting the review-round limit and causing the run to terminate as FAILED.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -429,8 +429,8 @@ func groupKeys(page PageConfig) []string {
 var isGroupEnabledCallPattern = regexp.MustCompile(`IsGroupEnabled\(\s*"updates_page"\s*,\s*"([^"]+)"\s*\)`)
 
 // TestUpdatesPageDefaultGroupsHaveBuilders reads internal/views/updates_page.go
-// as plain text (internal/config must never import internal/views or
-// puregotk, directly or transitively, per
+// as plain text (internal/config must never import internal/views or the
+// GTK bindings package, directly or transitively, per
 // docs/agents/skills/gtk-headless-tests.md) and asserts every group
 // defaultConfig() defines for updates_page is gated by a real
 // config.IsGroupEnabled("updates_page", ...) call in that view file. This is

--- a/internal/config/loaderror.go
+++ b/internal/config/loaderror.go
@@ -1,0 +1,72 @@
+package config
+
+import "strings"
+
+// ErrorKind classifies why loading or validating a configuration file
+// failed. The string values are part of the stable diagnostic vocabulary
+// surfaced by LoadError.Error() and must not change.
+type ErrorKind string
+
+const (
+	// KindRead marks a failure to read the config file from disk (e.g. a
+	// permissions error or an I/O failure other than "file does not
+	// exist").
+	KindRead ErrorKind = "read"
+	// KindParseType marks a failure to parse the file as YAML or to
+	// decode a value into its expected Go type.
+	KindParseType ErrorKind = "parse/type"
+	// KindSchema marks a failure detected by shape/semantic validation
+	// after the document parsed successfully — e.g. an unknown key or a
+	// value of the right YAML kind but the wrong shape. A KindSchema
+	// error may legitimately carry a nil Err.
+	KindSchema ErrorKind = "schema"
+)
+
+// LoadError describes a single configuration load/validation failure.
+//
+// Path is the config file path involved, if any. Kind is the stable
+// classification above. Detail is a short human-readable description of
+// what went wrong. Err is the underlying cause, if any; KindSchema errors
+// detected purely by shape inspection may leave Err nil.
+type LoadError struct {
+	Path   string
+	Kind   ErrorKind
+	Detail string
+	Err    error
+}
+
+// Error renders the diagnostic fields in a fixed, documented layout:
+//
+//  1. "config <kind> error" when Kind is set, otherwise "config error";
+//  2. ": <Path>" appended when Path is non-empty;
+//  3. ": <Detail>" appended when Detail is non-empty;
+//  4. ": <Err.Error()>" appended when Err is non-nil.
+func (e *LoadError) Error() string {
+	var b strings.Builder
+	if e.Kind != "" {
+		b.WriteString("config ")
+		b.WriteString(string(e.Kind))
+		b.WriteString(" error")
+	} else {
+		b.WriteString("config error")
+	}
+	if e.Path != "" {
+		b.WriteString(": ")
+		b.WriteString(e.Path)
+	}
+	if e.Detail != "" {
+		b.WriteString(": ")
+		b.WriteString(e.Detail)
+	}
+	if e.Err != nil {
+		b.WriteString(": ")
+		b.WriteString(e.Err.Error())
+	}
+	return b.String()
+}
+
+// Unwrap returns the underlying cause, enabling errors.Is/errors.As to see
+// through a *LoadError to Err (which may be nil when there is no cause).
+func (e *LoadError) Unwrap() error {
+	return e.Err
+}

--- a/internal/config/loaderror_test.go
+++ b/internal/config/loaderror_test.go
@@ -1,0 +1,132 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadErrorErrorExactStrings(t *testing.T) {
+	cause := errors.New("permission denied")
+
+	tests := []struct {
+		name string
+		err  *LoadError
+		want string
+	}{
+		{
+			name: "read kind with path detail and err",
+			err: &LoadError{
+				Path:   "/etc/chairlift/config.yml",
+				Kind:   KindRead,
+				Detail: "opening config file",
+				Err:    cause,
+			},
+			want: "config read error: /etc/chairlift/config.yml: opening config file: permission denied",
+		},
+		{
+			name: "parse type kind with path detail and err",
+			err: &LoadError{
+				Path:   "/etc/chairlift/config.yml",
+				Kind:   KindParseType,
+				Detail: "decoding page map",
+				Err:    errors.New("yaml: line 3: mapping values are not allowed in this context"),
+			},
+			want: "config parse/type error: /etc/chairlift/config.yml: decoding page map: yaml: line 3: mapping values are not allowed in this context",
+		},
+		{
+			name: "schema kind with path only and nil err",
+			err: &LoadError{
+				Path: "/etc/chairlift/config.yml",
+				Kind: KindSchema,
+			},
+			want: "config schema error: /etc/chairlift/config.yml",
+		},
+		{
+			name: "schema kind with path and detail and nil err",
+			err: &LoadError{
+				Path:   "/etc/chairlift/config.yml",
+				Kind:   KindSchema,
+				Detail: "unknown key \"bogus_group\"",
+			},
+			want: "config schema error: /etc/chairlift/config.yml: unknown key \"bogus_group\"",
+		},
+		{
+			name: "empty path with detail and err",
+			err: &LoadError{
+				Kind:   KindRead,
+				Detail: "opening config file",
+				Err:    cause,
+			},
+			want: "config read error: opening config file: permission denied",
+		},
+		{
+			name: "empty kind",
+			err: &LoadError{
+				Path:   "/etc/chairlift/config.yml",
+				Detail: "something went wrong",
+				Err:    cause,
+			},
+			want: "config error: /etc/chairlift/config.yml: something went wrong: permission denied",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.err.Error()
+			if got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadErrorContainsKindLiteral(t *testing.T) {
+	for _, kind := range []ErrorKind{KindRead, KindParseType, KindSchema} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			err := &LoadError{Path: "/some/path", Kind: kind, Detail: "detail"}
+			if !strings.Contains(err.Error(), string(kind)) {
+				t.Errorf("Error() = %q, want it to contain kind literal %q", err.Error(), string(kind))
+			}
+		})
+	}
+}
+
+func TestLoadErrorUnwrap(t *testing.T) {
+	if got := (&LoadError{Err: nil}).Unwrap(); got != nil {
+		t.Errorf("Unwrap() with nil Err = %v, want nil", got)
+	}
+
+	cause := errors.New("boom")
+	if got := (&LoadError{Err: cause}).Unwrap(); got != cause {
+		t.Errorf("Unwrap() = %v, want %v", got, cause)
+	}
+}
+
+func TestLoadErrorErrorsIs(t *testing.T) {
+	readErr := &LoadError{Kind: KindRead, Err: os.ErrNotExist}
+	if !errors.Is(readErr, os.ErrNotExist) {
+		t.Errorf("errors.Is(readErr, os.ErrNotExist) = false, want true")
+	}
+
+	schemaErr := &LoadError{Kind: KindSchema}
+	if errors.Is(schemaErr, os.ErrNotExist) {
+		t.Errorf("errors.Is(schemaErr, os.ErrNotExist) = true, want false")
+	}
+}
+
+func TestLoadErrorErrorsAs(t *testing.T) {
+	original := &LoadError{Path: "/etc/chairlift/config.yml", Kind: KindSchema, Detail: "unknown key"}
+	wrapped := fmt.Errorf("wrapped: %w", original)
+
+	var target *LoadError
+	if !errors.As(wrapped, &target) {
+		t.Fatalf("errors.As(wrapped, &target) = false, want true")
+	}
+	if target.Kind != original.Kind {
+		t.Errorf("target.Kind = %q, want %q", target.Kind, original.Kind)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// yamlTagName returns the part of a yaml struct tag before the first comma,
+// so tag options such as "omitempty" are stripped. An empty tag (or a tag
+// consisting only of options, e.g. ",omitempty") yields an empty string.
+func yamlTagName(tag string) string {
+	if i := strings.Index(tag, ","); i >= 0 {
+		return tag[:i]
+	}
+	return tag
+}
+
+// yamlFieldNames returns the yaml field names of t's exported fields, in
+// struct declaration order, applying this fixed extraction rule per field:
+//   - skip unexported fields (PkgPath != "")
+//   - skip fields with no yaml tag or an empty tag
+//   - skip yaml:"-"
+//   - error if yamlTagName of a non-empty tag is empty (e.g. yaml:",omitempty")
+//   - error on a duplicate name
+//
+// It also errors when t is not a struct kind. The returned slice is freshly
+// allocated on every call.
+func yamlFieldNames(t reflect.Type) ([]string, error) {
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("yamlFieldNames: %s is not a struct", t.Kind())
+	}
+
+	seen := make(map[string]bool)
+	names := make([]string, 0, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+
+		tag, ok := field.Tag.Lookup("yaml")
+		if !ok || tag == "" {
+			continue // no yaml tag
+		}
+		if tag == "-" {
+			continue // explicitly excluded from YAML
+		}
+
+		name := yamlTagName(tag)
+		if name == "" {
+			return nil, fmt.Errorf("yamlFieldNames: field %s has a yaml tag with an empty name (%q)", field.Name, tag)
+		}
+		if seen[name] {
+			return nil, fmt.Errorf("yamlFieldNames: duplicate yaml name %q (field %s)", name, field.Name)
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	return names, nil
+}
+
+// schemaPageGroups reflects over the value returned by defaultConfig(): for
+// each exported Config field it takes the page name from the field's yaml
+// tag and the group names from that field's PageConfig map, erroring on an
+// empty group name or a duplicate page name. It returns a fresh map of
+// freshly allocated, lexicographically sorted slices on every call (map
+// iteration order is not deterministic, so sorting is required for a stable
+// API).
+func schemaPageGroups() (map[string][]string, error) {
+	def := defaultConfig()
+	v := reflect.ValueOf(*def)
+	t := v.Type()
+
+	result := make(map[string][]string, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+
+		tag, ok := field.Tag.Lookup("yaml")
+		if !ok || tag == "" || tag == "-" {
+			continue
+		}
+		pageName := yamlTagName(tag)
+		if pageName == "" {
+			return nil, fmt.Errorf("schemaPageGroups: field %s has a yaml tag with an empty name (%q)", field.Name, tag)
+		}
+		if _, dup := result[pageName]; dup {
+			return nil, fmt.Errorf("schemaPageGroups: duplicate page name %q (field %s)", pageName, field.Name)
+		}
+
+		page, ok := v.Field(i).Interface().(PageConfig)
+		if !ok {
+			return nil, fmt.Errorf("schemaPageGroups: field %s is not a PageConfig", field.Name)
+		}
+
+		groups := make([]string, 0, len(page))
+		for name := range page {
+			if name == "" {
+				return nil, fmt.Errorf("schemaPageGroups: page %q has an empty group name", pageName)
+			}
+			groups = append(groups, name)
+		}
+		sort.Strings(groups)
+
+		result[pageName] = groups
+	}
+
+	return result, nil
+}
+
+// SchemaPages returns the canonical page names, sourced from the yaml tags
+// on Config's exported fields, in struct declaration order. It returns a
+// freshly allocated slice on every call, so callers cannot mutate shared
+// state.
+func SchemaPages() ([]string, error) {
+	return yamlFieldNames(reflect.TypeOf(Config{}))
+}
+
+// SchemaGroups returns the canonical group names for page, sourced from that
+// page's map in defaultConfig(). It returns a non-nil error for a page name
+// that is not in SchemaPages(). It returns a freshly allocated slice on
+// every call, so callers cannot mutate shared state.
+func SchemaGroups(page string) ([]string, error) {
+	pageGroups, err := schemaPageGroups()
+	if err != nil {
+		return nil, err
+	}
+
+	groups, ok := pageGroups[page]
+	if !ok {
+		return nil, fmt.Errorf("SchemaGroups: unknown page %q", page)
+	}
+
+	// schemaPageGroups already returns freshly allocated slices per call,
+	// but copy defensively so this function's contract does not depend on
+	// that implementation detail.
+	result := make([]string, len(groups))
+	copy(result, groups)
+	return result, nil
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -145,3 +145,22 @@ func SchemaGroups(page string) ([]string, error) {
 	copy(result, groups)
 	return result, nil
 }
+
+// SchemaGroupFields returns the canonical group-field names, sourced from
+// rawGroupConfig's yaml tags in struct declaration order. rawGroupConfig,
+// not GroupConfig, is used because it is the representation yaml.v3 actually
+// decodes into; a parity test in schema_test.go holds rawGroupConfig's yaml
+// tags to GroupConfig's, so the two cannot silently drift apart. It returns
+// a freshly allocated slice on every call, so callers cannot mutate shared
+// state.
+func SchemaGroupFields() ([]string, error) {
+	return yamlFieldNames(reflect.TypeOf(rawGroupConfig{}))
+}
+
+// SchemaActionFields returns the canonical action-field names, sourced from
+// ActionConfig's yaml tags, in struct declaration order. It returns a
+// freshly allocated slice on every call, so callers cannot mutate shared
+// state.
+func SchemaActionFields() ([]string, error) {
+	return yamlFieldNames(reflect.TypeOf(ActionConfig{}))
+}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -2,8 +2,38 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func yamlTagIgnoringOmitEmpty(tag string) string {
+	parts := strings.Split(tag, ",")
+	kept := parts[:1]
+	for _, option := range parts[1:] {
+		if option != "omitempty" {
+			kept = append(kept, option)
+		}
+	}
+	return strings.Join(kept, ",")
+}
+
+func TestYamlTagParityIgnoresOnlyOmitEmpty(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want string
+	}{
+		{tag: "field", want: "field"},
+		{tag: "field,omitempty", want: "field"},
+		{tag: "field,flow", want: "field,flow"},
+		{tag: "field,omitempty,flow", want: "field,flow"},
+	}
+
+	for _, tt := range tests {
+		if got := yamlTagIgnoringOmitEmpty(tt.tag); got != tt.want {
+			t.Errorf("yamlTagIgnoringOmitEmpty(%q) = %q, want %q", tt.tag, got, tt.want)
+		}
+	}
+}
 
 // TestSchemaPagesMatchesPageNames asserts SchemaPages() equals the
 // hand-written pageNames slice already declared in config_test.go — an
@@ -348,8 +378,9 @@ func TestRawConfigMatchesConfigFields(t *testing.T) {
 // TestRawGroupConfigMatchesGroupConfigFields proves rawGroupConfig's
 // exported fields match GroupConfig's exactly, ignoring only pointer-vs-
 // value representation and "omitempty": same field count, same field names
-// in the same declaration order, same yaml tag names (options stripped) in
-// the same order per index, and per field, rawGroupConfig's type equal to
+// in the same declaration order, same yaml tags after removing only the
+// omitempty option in the same order per index, and per field,
+// rawGroupConfig's type equal to
 // GroupConfig's type or exactly a pointer to it. This is the parity test
 // required by docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md:
 // SchemaGroupFields() reads rawGroupConfig (what yaml.v3 actually decodes
@@ -378,8 +409,8 @@ func TestRawGroupConfigMatchesGroupConfigFields(t *testing.T) {
 			t.Errorf("field %d: GroupConfig field name %q, rawGroupConfig field name %q", i, gf.Name, rf.Name)
 		}
 
-		gTag := yamlTagName(gf.Tag.Get("yaml"))
-		rTag := yamlTagName(rf.Tag.Get("yaml"))
+		gTag := yamlTagIgnoringOmitEmpty(gf.Tag.Get("yaml"))
+		rTag := yamlTagIgnoringOmitEmpty(rf.Tag.Get("yaml"))
 		if gTag != rTag {
 			t.Errorf("field %d (%s): GroupConfig yaml tag %q, rawGroupConfig yaml tag %q", i, gf.Name, gTag, rTag)
 		}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -1,0 +1,346 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSchemaPagesMatchesPageNames asserts SchemaPages() equals the
+// hand-written pageNames slice already declared in config_test.go — an
+// independent authority — element by element (same length, same order), and
+// that a counting map shows each page name exactly once.
+func TestSchemaPagesMatchesPageNames(t *testing.T) {
+	got, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages(): %v", err)
+	}
+
+	if len(got) != len(pageNames) {
+		t.Fatalf("SchemaPages() has %d pages, want %d: got %v, want %v", len(got), len(pageNames), got, pageNames)
+	}
+	for i := range pageNames {
+		if got[i] != pageNames[i] {
+			t.Errorf("SchemaPages()[%d] = %q, want %q", i, got[i], pageNames[i])
+		}
+	}
+
+	counts := make(map[string]int, len(got))
+	for _, name := range got {
+		counts[name]++
+	}
+	for _, name := range pageNames {
+		if counts[name] != 1 {
+			t.Errorf("SchemaPages(): page %q appears %d times, want exactly 1", name, counts[name])
+		}
+	}
+}
+
+// TestSchemaGroupsMatchesDefaultConfigForEveryPage loops over every page
+// from SchemaPages(), calls SchemaGroups(page), and asserts the result is
+// exactly the key set of pagesOf(defaultConfig())[page]: equal lengths,
+// every default group present exactly once, and no name returned that
+// defaultConfig() does not define.
+func TestSchemaGroupsMatchesDefaultConfigForEveryPage(t *testing.T) {
+	pages, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages(): %v", err)
+	}
+	if len(pages) == 0 {
+		t.Fatal("SchemaPages() returned no pages")
+	}
+
+	defPages := pagesOf(defaultConfig())
+
+	for _, page := range pages {
+		groups, err := SchemaGroups(page)
+		if err != nil {
+			t.Fatalf("SchemaGroups(%q): %v", page, err)
+		}
+		if len(groups) == 0 {
+			t.Errorf("SchemaGroups(%q) returned no groups", page)
+		}
+
+		wantGroups := defPages[page]
+
+		if len(groups) != len(wantGroups) {
+			t.Errorf("SchemaGroups(%q) has %d groups, want %d: got %v, want keys %v", page, len(groups), len(wantGroups), groups, groupKeys(wantGroups))
+		}
+
+		counts := make(map[string]int, len(groups))
+		for _, name := range groups {
+			counts[name]++
+		}
+
+		for name := range wantGroups {
+			if counts[name] != 1 {
+				t.Errorf("SchemaGroups(%q): expected group %q to appear exactly once, got %d", page, name, counts[name])
+			}
+		}
+		for name := range counts {
+			if _, ok := wantGroups[name]; !ok {
+				t.Errorf("SchemaGroups(%q): returned group %q not defined by defaultConfig()", page, name)
+			}
+		}
+	}
+}
+
+// TestSchemaGroupsUnknownPageReturnsError asserts SchemaGroups on an unknown
+// page returns a non-nil error and a nil slice.
+func TestSchemaGroupsUnknownPageReturnsError(t *testing.T) {
+	got, err := SchemaGroups("no_such_page")
+	if err == nil {
+		t.Fatal("SchemaGroups(\"no_such_page\"): expected error, got nil")
+	}
+	if got != nil {
+		t.Errorf("SchemaGroups(\"no_such_page\") = %v, want nil slice", got)
+	}
+}
+
+// TestSchemaPagesReturnsFreshSlice mutates the slice returned by
+// SchemaPages() and asserts a subsequent call is unaffected.
+func TestSchemaPagesReturnsFreshSlice(t *testing.T) {
+	first, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages(): %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("SchemaPages() returned no pages")
+	}
+
+	original := make([]string, len(first))
+	copy(original, first)
+
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages(): %v", err)
+	}
+	if !reflect.DeepEqual(second, original) {
+		t.Errorf("SchemaPages() second call = %v, want unaffected %v", second, original)
+	}
+}
+
+// TestSchemaGroupsReturnsFreshSlice mutates the slice returned by
+// SchemaGroups(page) and asserts a subsequent call is unaffected.
+func TestSchemaGroupsReturnsFreshSlice(t *testing.T) {
+	const page = "system_page"
+
+	first, err := SchemaGroups(page)
+	if err != nil {
+		t.Fatalf("SchemaGroups(%q): %v", page, err)
+	}
+	if len(first) == 0 {
+		t.Fatal("SchemaGroups(system_page) returned no groups")
+	}
+
+	original := make([]string, len(first))
+	copy(original, first)
+
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second, err := SchemaGroups(page)
+	if err != nil {
+		t.Fatalf("SchemaGroups(%q): %v", page, err)
+	}
+	if !reflect.DeepEqual(second, original) {
+		t.Errorf("SchemaGroups(%q) second call = %v, want unaffected %v", page, second, original)
+	}
+}
+
+// TestSchemaPageGroupsReturnsFreshMap mutates the map returned by
+// schemaPageGroups() (both by adding a key and by mutating one of its
+// slices) and asserts a subsequent call is unaffected.
+func TestSchemaPageGroupsReturnsFreshMap(t *testing.T) {
+	first, err := schemaPageGroups()
+	if err != nil {
+		t.Fatalf("schemaPageGroups(): %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("schemaPageGroups() returned no pages")
+	}
+
+	var somePage string
+	for page := range first {
+		somePage = page
+		break
+	}
+
+	originalGroups := make([]string, len(first[somePage]))
+	copy(originalGroups, first[somePage])
+
+	// Mutate the map itself and one of its slice values.
+	first["INJECTED_PAGE"] = []string{"injected"}
+	if len(first[somePage]) > 0 {
+		first[somePage][0] = "MUTATED"
+	}
+
+	second, err := schemaPageGroups()
+	if err != nil {
+		t.Fatalf("schemaPageGroups(): %v", err)
+	}
+	if _, ok := second["INJECTED_PAGE"]; ok {
+		t.Error("schemaPageGroups(): second call reflects injected key from a previously mutated map")
+	}
+	if !reflect.DeepEqual(second[somePage], originalGroups) {
+		t.Errorf("schemaPageGroups()[%q] second call = %v, want unaffected %v", somePage, second[somePage], originalGroups)
+	}
+}
+
+// TestYamlTagName is a direct-call table test for yamlTagName.
+func TestYamlTagName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"plain name", "system_page", "system_page"},
+		{"name with omitempty", "app_id,omitempty", "app_id"},
+		{"only options, no name", ",omitempty", ""},
+		{"empty tag", "", ""},
+		{"dash", "-", "-"},
+		{"multiple options", "chat,omitempty,flow", "chat"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := yamlTagName(tt.tag); got != tt.want {
+				t.Errorf("yamlTagName(%q) = %q, want %q", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test-only struct types for yamlFieldNames, covering each documented
+// skip/error case.
+type yamlFieldNamesOKStruct struct {
+	Website string `yaml:"website"`
+	unex    string `yaml:"unexported"` //nolint:unused // exercises PkgPath != "" skip
+	NoTag   string
+	Dashed  string `yaml:"-"`
+	Chat    string `yaml:"chat,omitempty"`
+}
+
+type yamlFieldNamesEmptyNameStruct struct {
+	Bad string `yaml:",omitempty"`
+}
+
+type yamlFieldNamesDuplicateStruct struct {
+	A string `yaml:"same"`
+	B string `yaml:"same"`
+}
+
+// TestYamlFieldNames is a direct-call table test for yamlFieldNames,
+// covering the documented skip rules (unexported, untagged, yaml:"-") and
+// the documented error cases (non-struct type, empty name after option
+// stripping, duplicate names).
+func TestYamlFieldNames(t *testing.T) {
+	t.Run("skips unexported, untagged, and dashed fields; keeps tagged ones in order", func(t *testing.T) {
+		got, err := yamlFieldNames(reflect.TypeOf(yamlFieldNamesOKStruct{}))
+		if err != nil {
+			t.Fatalf("yamlFieldNames: unexpected error: %v", err)
+		}
+		want := []string{"website", "chat"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("yamlFieldNames = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("non-struct type errors", func(t *testing.T) {
+		got, err := yamlFieldNames(reflect.TypeOf(42))
+		if err == nil {
+			t.Fatal("yamlFieldNames(int): expected error, got nil")
+		}
+		if got != nil {
+			t.Errorf("yamlFieldNames(int) = %v, want nil", got)
+		}
+	})
+
+	t.Run("empty name after option stripping errors", func(t *testing.T) {
+		got, err := yamlFieldNames(reflect.TypeOf(yamlFieldNamesEmptyNameStruct{}))
+		if err == nil {
+			t.Fatal("yamlFieldNames: expected error for yaml:\",omitempty\", got nil")
+		}
+		if got != nil {
+			t.Errorf("yamlFieldNames = %v, want nil", got)
+		}
+	})
+
+	t.Run("duplicate yaml name errors", func(t *testing.T) {
+		got, err := yamlFieldNames(reflect.TypeOf(yamlFieldNamesDuplicateStruct{}))
+		if err == nil {
+			t.Fatal("yamlFieldNames: expected error for duplicate yaml names, got nil")
+		}
+		if got != nil {
+			t.Errorf("yamlFieldNames = %v, want nil", got)
+		}
+	})
+}
+
+// TestSchemaPageGroups is a direct-call test for schemaPageGroups, asserting
+// it succeeds against the real defaultConfig() and its result matches
+// pagesOf(defaultConfig()) exactly (sorted).
+func TestSchemaPageGroups(t *testing.T) {
+	got, err := schemaPageGroups()
+	if err != nil {
+		t.Fatalf("schemaPageGroups(): %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("schemaPageGroups() returned no pages")
+	}
+
+	defPages := pagesOf(defaultConfig())
+	for page, groups := range got {
+		wantGroups := defPages[page]
+		if len(groups) != len(wantGroups) {
+			t.Errorf("schemaPageGroups()[%q] has %d groups, want %d", page, len(groups), len(wantGroups))
+		}
+		for _, name := range groups {
+			if _, ok := wantGroups[name]; !ok {
+				t.Errorf("schemaPageGroups()[%q]: group %q not in defaultConfig()", page, name)
+			}
+		}
+		// Assert sorted order.
+		for i := 1; i < len(groups); i++ {
+			if groups[i-1] > groups[i] {
+				t.Errorf("schemaPageGroups()[%q] not sorted: %v", page, groups)
+				break
+			}
+		}
+	}
+}
+
+// TestRawConfigMatchesConfigFields proves rawConfig's exported fields match
+// Config's exactly: same field count, same field names in the same order,
+// same yaml tag names in the same order. This is the parity test required
+// by docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md
+// — rawConfig is a decoding mirror held to Config by this test, never a
+// second schema authority (the derivation in this file reads Config /
+// defaultConfig(), never rawConfig).
+func TestRawConfigMatchesConfigFields(t *testing.T) {
+	configType := reflect.TypeOf(Config{})
+	rawType := reflect.TypeOf(rawConfig{})
+
+	if configType.NumField() != rawType.NumField() {
+		t.Fatalf("Config has %d fields, rawConfig has %d", configType.NumField(), rawType.NumField())
+	}
+
+	for i := 0; i < configType.NumField(); i++ {
+		cf := configType.Field(i)
+		rf := rawType.Field(i)
+
+		if cf.Name != rf.Name {
+			t.Errorf("field %d: Config field name %q, rawConfig field name %q", i, cf.Name, rf.Name)
+		}
+
+		cTag := yamlTagName(cf.Tag.Get("yaml"))
+		rTag := yamlTagName(rf.Tag.Get("yaml"))
+		if cTag != rTag {
+			t.Errorf("field %d (%s): Config yaml tag %q, rawConfig yaml tag %q", i, cf.Name, cTag, rTag)
+		}
+	}
+}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -344,3 +344,176 @@ func TestRawConfigMatchesConfigFields(t *testing.T) {
 		}
 	}
 }
+
+// TestRawGroupConfigMatchesGroupConfigFields proves rawGroupConfig's
+// exported fields match GroupConfig's exactly, ignoring only pointer-vs-
+// value representation and "omitempty": same field count, same field names
+// in the same declaration order, same yaml tag names (options stripped) in
+// the same order per index, and per field, rawGroupConfig's type equal to
+// GroupConfig's type or exactly a pointer to it. This is the parity test
+// required by docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md:
+// SchemaGroupFields() reads rawGroupConfig (what yaml.v3 actually decodes
+// into) because the spec designates it the field source, while this test
+// holds it to GroupConfig, the semantic authority, so the two cannot
+// silently drift apart.
+func TestRawGroupConfigMatchesGroupConfigFields(t *testing.T) {
+	groupType := reflect.TypeOf(GroupConfig{})
+	rawType := reflect.TypeOf(rawGroupConfig{})
+
+	if groupType.NumField() == 0 {
+		t.Fatal("GroupConfig has zero fields")
+	}
+	if rawType.NumField() == 0 {
+		t.Fatal("rawGroupConfig has zero fields")
+	}
+	if groupType.NumField() != rawType.NumField() {
+		t.Fatalf("GroupConfig has %d fields, rawGroupConfig has %d", groupType.NumField(), rawType.NumField())
+	}
+
+	for i := 0; i < groupType.NumField(); i++ {
+		gf := groupType.Field(i)
+		rf := rawType.Field(i)
+
+		if gf.Name != rf.Name {
+			t.Errorf("field %d: GroupConfig field name %q, rawGroupConfig field name %q", i, gf.Name, rf.Name)
+		}
+
+		gTag := yamlTagName(gf.Tag.Get("yaml"))
+		rTag := yamlTagName(rf.Tag.Get("yaml"))
+		if gTag != rTag {
+			t.Errorf("field %d (%s): GroupConfig yaml tag %q, rawGroupConfig yaml tag %q", i, gf.Name, gTag, rTag)
+		}
+
+		if rf.Type != gf.Type && rf.Type != reflect.PointerTo(gf.Type) {
+			t.Errorf("field %d (%s): rawGroupConfig type %s is neither GroupConfig's type %s nor a pointer to it", i, gf.Name, rf.Type, gf.Type)
+		}
+	}
+}
+
+// TestSchemaGroupFieldsMatchesGroupConfigTags asserts SchemaGroupFields()
+// equals the yaml tags of GroupConfig (via yamlFieldNames) element by
+// element (same length, same order), and that a counting loop shows each
+// name appears exactly once.
+func TestSchemaGroupFieldsMatchesGroupConfigTags(t *testing.T) {
+	got, err := SchemaGroupFields()
+	if err != nil {
+		t.Fatalf("SchemaGroupFields(): %v", err)
+	}
+
+	want, err := yamlFieldNames(reflect.TypeOf(GroupConfig{}))
+	if err != nil {
+		t.Fatalf("yamlFieldNames(GroupConfig{}): %v", err)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("SchemaGroupFields() has %d fields, want %d: got %v, want %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SchemaGroupFields()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	wantOrder := []string{"enabled", "app_id", "actions", "website", "issues", "chat", "bundles_paths"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("SchemaGroupFields() has %d fields, want %d: got %v, want %v", len(got), len(wantOrder), got, wantOrder)
+	}
+	for i := range wantOrder {
+		if got[i] != wantOrder[i] {
+			t.Errorf("SchemaGroupFields()[%d] = %q, want %q", i, got[i], wantOrder[i])
+		}
+	}
+
+	counts := make(map[string]int, len(got))
+	for _, name := range got {
+		counts[name]++
+	}
+	for _, name := range wantOrder {
+		if counts[name] != 1 {
+			t.Errorf("SchemaGroupFields(): field %q appears %d times, want exactly 1", name, counts[name])
+		}
+	}
+}
+
+// TestSchemaActionFields asserts SchemaActionFields() equals
+// [title script sudo] in that order, each exactly once.
+func TestSchemaActionFields(t *testing.T) {
+	got, err := SchemaActionFields()
+	if err != nil {
+		t.Fatalf("SchemaActionFields(): %v", err)
+	}
+
+	want := []string{"title", "script", "sudo"}
+	if len(got) != len(want) {
+		t.Fatalf("SchemaActionFields() has %d fields, want %d: got %v, want %v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SchemaActionFields()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	counts := make(map[string]int, len(got))
+	for _, name := range got {
+		counts[name]++
+	}
+	for _, name := range want {
+		if counts[name] != 1 {
+			t.Errorf("SchemaActionFields(): field %q appears %d times, want exactly 1", name, counts[name])
+		}
+	}
+}
+
+// TestSchemaGroupFieldsReturnsFreshSlice mutates the slice returned by
+// SchemaGroupFields() and asserts a subsequent call is unaffected.
+func TestSchemaGroupFieldsReturnsFreshSlice(t *testing.T) {
+	first, err := SchemaGroupFields()
+	if err != nil {
+		t.Fatalf("SchemaGroupFields(): %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("SchemaGroupFields() returned no fields")
+	}
+
+	original := make([]string, len(first))
+	copy(original, first)
+
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second, err := SchemaGroupFields()
+	if err != nil {
+		t.Fatalf("SchemaGroupFields(): %v", err)
+	}
+	if !reflect.DeepEqual(second, original) {
+		t.Errorf("SchemaGroupFields() second call = %v, want unaffected %v", second, original)
+	}
+}
+
+// TestSchemaActionFieldsReturnsFreshSlice mutates the slice returned by
+// SchemaActionFields() and asserts a subsequent call is unaffected.
+func TestSchemaActionFieldsReturnsFreshSlice(t *testing.T) {
+	first, err := SchemaActionFields()
+	if err != nil {
+		t.Fatalf("SchemaActionFields(): %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("SchemaActionFields() returned no fields")
+	}
+
+	original := make([]string, len(first))
+	copy(original, first)
+
+	for i := range first {
+		first[i] = "MUTATED"
+	}
+
+	second, err := SchemaActionFields()
+	if err != nil {
+		t.Fatalf("SchemaActionFields(): %v", err)
+	}
+	if !reflect.DeepEqual(second, original) {
+		t.Errorf("SchemaActionFields() second call = %v, want unaffected %v", second, original)
+	}
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -177,10 +177,28 @@ Both exported functions return a freshly allocated slice (and `SchemaGroups`
 an error for a page name outside `SchemaPages()`) on every call, so a caller
 mutating a returned slice cannot affect a later call. An empty or duplicate
 page/group name is reported as a returned `error`, never a panic, `log.Fatal`,
-or `os.Exit`, so failures stay deterministic and assertable from tests. As of
-this writing no production code path — neither `Load()`/`loadFromPath()` nor
-any runtime diagnostic — consumes this inventory yet; it exists for a later
-change to build on.
+or `os.Exit`, so failures stay deterministic and assertable from tests.
+
+`SchemaGroupFields()` and `SchemaActionFields()` extend the same inventory to
+field names, reusing `yamlFieldNames` — no second tag-parsing rule.
+`SchemaGroupFields()` reads `rawGroupConfig`'s yaml tags, in struct
+declaration order, because `rawGroupConfig` (not `GroupConfig`) is what
+yaml.v3 actually decodes a group into; `GroupConfig` remains the semantic
+authority, and a dedicated reflection test
+(`TestRawGroupConfigMatchesGroupConfigFields`) holds the two to each other —
+same field count, same names and yaml tags per index, and each
+`rawGroupConfig` field type equal to `GroupConfig`'s or exactly a pointer to
+it (ignoring only that pointer-vs-value difference and `omitempty`) — so
+`rawGroupConfig` cannot silently drift from `GroupConfig` per
+`docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md`.
+`SchemaActionFields()` reads `ActionConfig`'s yaml tags directly, since
+`ActionConfig` has no raw/pointer mirror. Both return a freshly allocated
+slice on every call and report an empty or duplicate field name as an error,
+never a panic, `log.Fatal`, or `os.Exit`. As of this writing no production
+code path — neither `Load()`/`loadFromPath()` nor any runtime diagnostic —
+consumes this inventory yet, and this slice adds no strict parsing and no
+unknown-key rejection; `Load()` still falls back to `defaultConfig()` on any
+read or parse failure. The inventory exists for a later change to build on.
 
 ### Package manager wrapper pattern
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -158,6 +158,30 @@ there is no strict parsing and no fail-closed runtime behavior yet; this
 vocabulary exists so a later change can start returning `*LoadError` values
 without redefining what "read", "parse/type", and "schema" mean.
 
+**Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
+and `SchemaGroups(page)` derive the authoritative list of page names and,
+per page, group names by reflection — never by a second hand-maintained
+list — so the inventory cannot drift from the types it describes. Page names
+come from the `yaml` struct tags on `Config`'s exported fields (via the
+unexported `yamlFieldNames` helper, in struct declaration order); group names
+for a page come from that page's map key set in `defaultConfig()` (via the
+unexported `schemaPageGroups` helper, sorted lexicographically for a stable
+API since map iteration order is not deterministic). `rawConfig` is *not* a
+schema authority here — it is `Config`'s pointer-typed YAML-decoding mirror
+(see above), and a dedicated reflection test
+(`TestRawConfigMatchesConfigFields`) proves its exported fields, field order,
+and yaml tag names match `Config`'s exactly, so it stays a provably-in-sync
+mirror rather than a second source of truth per
+`docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md`.
+Both exported functions return a freshly allocated slice (and `SchemaGroups`
+an error for a page name outside `SchemaPages()`) on every call, so a caller
+mutating a returned slice cannot affect a later call. An empty or duplicate
+page/group name is reported as a returned `error`, never a panic, `log.Fatal`,
+or `os.Exit`, so failures stay deterministic and assertable from tests. As of
+this writing no production code path — neither `Load()`/`loadFromPath()` nor
+any runtime diagnostic — consumes this inventory yet; it exists for a later
+change to build on.
+
 ### Package manager wrapper pattern
 
 Each wrapper in `internal/` follows a consistent shape:

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -135,6 +135,29 @@ the group only to flip an unrelated field, and why `Load()` falling back to
 `defaultConfig()` when no file is found or the file is unreadable/invalid
 preserves that same per-group default — it is never "all features enabled."
 
+**Structured load-error vocabulary (`internal/config/loaderror.go`).** A
+stable `ErrorKind` enumerates why loading/validating a config file could
+fail: `KindRead` ("read") for a filesystem/read failure (e.g. permission
+denied opening the file — distinct from "file does not exist", which
+`Load()` treats as absent-and-fall-back, not an error); `KindParseType`
+("parse/type") for a YAML syntax error or a value that decodes to the wrong
+Go type; and `KindSchema` ("schema") for a validator-detected shape failure
+found only after the document parsed successfully — e.g. an unknown key or a
+value of the right YAML kind but the wrong shape — which may legitimately
+carry a nil `Err` since shape inspection alone can detect the problem with
+no underlying cause to wrap. `LoadError.Error()` renders `Path`, the exact
+`Kind` string, `Detail`, and the cause (in that order, each only when
+non-empty/non-nil), so the three `Kind` literals above always appear
+verbatim in the message. `LoadError.Unwrap()` returns `Err` unchanged
+(nil when there is none), which is what lets `errors.Is`/`errors.As` see
+through a `*LoadError` to a wrapped sentinel or recover the original value
+from a `fmt.Errorf("%w", ...)` wrapper. As of this writing nothing
+constructs a `LoadError` yet — `Load()` and `loadFromPath()` are unchanged
+and still fall back to `defaultConfig()` on any read or parse failure, so
+there is no strict parsing and no fail-closed runtime behavior yet; this
+vocabulary exists so a later change can start returning `*LoadError` values
+without redefining what "read", "parse/type", and "schema" mean.
+
 ### Package manager wrapper pattern
 
 Each wrapper in `internal/` follows a consistent shape:


### PR DESCRIPTION
First implementation slice for #69.

Adds the structured configuration load-error vocabulary and derives the accepted schema inventory from canonical Go structures and defaults. Runtime loading remains unchanged; later slices add bounded YAML resolution, strict validation, fail-closed loading, and visible diagnostics.

Validation: `make ci` passes locally.