### PR TITLE
feat(config): validate YAML source graphs safely

### DIFF
--- a/docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md
+++ b/docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md
@@ -1,0 +1,30 @@
+# A test asserting an interim chunk's contract must be listed for update in the later chunk that changes that contract
+
+**When it applies:** Planning or revising a multi-chunk plan where an early
+chunk (e.g. c4) adds a test asserting some intermediate behavior — a value
+"survives as an ordinary key," a field defaults to some placeholder, a
+partial implementation returns a simplified result — and a later chunk (e.g.
+c5) is explicitly designed to change that behavior into its final form.
+
+**What to do:** When a later chunk supersedes behavior a test in an earlier
+chunk asserts, that later chunk's `files` list must include the test file
+that made the now-false assertion, and its acceptance criteria must say
+whether the assertion is replaced or removed. Don't assume "the later chunk
+implements the real behavior, so of course the old test gets fixed along the
+way" — the chunk was reviewed and approved without naming the file, so
+nothing forces it to happen, and the chunk fails its own test gate when the
+now-stale assertion still runs. Before finalizing any chunk that changes
+prior behavior, grep the test files touched by earlier chunks for assertions
+about the specific case being changed, and add those files to the new
+chunk explicitly.
+
+**Learned from:** issue #69 phase-1b mill run, plan review round 4 — c4 added
+a `resolve_test.go` assertion that a `<<` key survives as an ordinary key
+when merge is only partially resolved; c5 makes the final result merge-free
+(the `<<` key is fully consumed), which makes that exact assertion false, but
+c5's plan neither listed `resolve_test.go` in `files` nor described replacing
+the assertion. The reviewer caught it before implementation, but the same
+gap recurred across earlier rounds too (rounds 1-3 each found a similar
+"later chunk invalidates something the plan didn't track" issue), and the
+plan exhausted its 4-round revision limit and the run terminated as FAILED
+without ever reaching implementation.

--- a/docs/agents/skills/discarded-merge-branches-still-need-validation.md
+++ b/docs/agents/skills/discarded-merge-branches-still-need-validation.md
@@ -1,0 +1,29 @@
+# A spec requiring errors "anywhere reachable" to be rejected is not satisfied by resolving precedence before validating
+
+**When it applies:** Planning or reviewing a chunk that implements
+precedence/override resolution (merge keys, config overlays, priority-based
+selection) where the spec separately requires malformed data or
+resource-limit violations to be rejected wherever they are reachable in the
+input — including values a later, higher-priority source will end up
+discarding.
+
+**What to do:** Don't plan traversal as "pick the winning value per key,
+then validate/emit just the winners" — that order skips validation of
+losing branches entirely, silently accepting malformed or over-limit data
+that never surfaces in the result. When the spec says errors must be caught
+"anywhere reachable" or similar, the plan must describe (and a test must
+cover) walking every branch that participates in precedence resolution —
+including ones a later source overrides — for error/limit checks, even
+though only the winning branch's value is ever emitted. Where the spec is
+ambiguous about which specific resource limits apply to discarded branches
+(e.g. a limit defined in terms of the emitted result vs. one defined in
+terms of anything parsed), call that out explicitly as an interpretation
+rather than picking silently, since reviewers will flag the ambiguity as a
+"note"-severity objection if it isn't addressed.
+
+**Learned from:** issue #69 phase-1b mill run, plan review round 2 — the
+plan's c5/c6 chunks tested duplicate/cycle/limit errors only for winning
+values, but the spec required merge-losing values (participants in `<<`
+precedence that a later key or document overrides) to be rejected too when
+malformed or over resource limits, even though their content never appears
+in the effective result.

--- a/internal/config/loaderror.go
+++ b/internal/config/loaderror.go
@@ -12,8 +12,13 @@ const (
 	// permissions error or an I/O failure other than "file does not
 	// exist").
 	KindRead ErrorKind = "read"
-	// KindParseType marks a failure to parse the file as YAML or to
-	// decode a value into its expected Go type.
+	// KindParseType marks a failure to parse the file as YAML, to decode
+	// a value into its expected Go type, or a malformed source graph
+	// (an unsupported node shape, an alias with no target, an alias
+	// cycle, etc.) found by pure shape inspection after the YAML parsed
+	// successfully. Like KindSchema, a KindParseType error detected
+	// purely by shape/graph inspection rather than surfaced from an
+	// underlying parser error may legitimately carry a nil Err.
 	KindParseType ErrorKind = "parse/type"
 	// KindSchema marks a failure detected by shape/semantic validation
 	// after the document parsed successfully — e.g. an unknown key or a

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseYAMLDocument decodes data as YAML and returns its single document
+// tree. It is a pure parsing step: it never opens, reads, or otherwise
+// touches the filesystem itself — path is only ever copied into a returned
+// *LoadError for caller-side context.
+//
+// Empty or whitespace-only input is not an error: it returns (nil, nil),
+// matching the "absent config" semantics the rest of this package already
+// uses for a missing file. A document that fails to parse returns a
+// KindParseType *LoadError wrapping the real yaml parser error, with Detail
+// set to that error's own message (which yaml.v3 always renders as
+// "yaml: line N: ...", so the reported line is visible in Detail without a
+// second look at Err).
+//
+// Exactly one YAML document is accepted. After the first document decodes
+// successfully, only io.EOF from a second Decode proves there is no more
+// input; anything else means a second document is present — including a
+// second document that itself decodes without error, such as the null
+// document yaml.v3 synthesises for a trailing bare "---". That case, and a
+// malformed second document, both return KindParseType too: the former
+// names the second document's own starting line since there is no parser
+// error to wrap, and the latter preserves that document's parser error and
+// line exactly like a malformed first document would.
+func parseYAMLDocument(path string, data []byte) (*yaml.Node, *LoadError) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+
+	var doc yaml.Node
+	if err := dec.Decode(&doc); err != nil {
+		if err == io.EOF {
+			// No documents at all: empty or whitespace-only input.
+			return nil, nil
+		}
+		return nil, parseFailure(path, err)
+	}
+
+	var extra yaml.Node
+	switch err := dec.Decode(&extra); err {
+	case io.EOF:
+		// No second document: exactly one document, as required.
+		return &doc, nil
+	case nil:
+		// A second document decoded successfully - still one too many.
+		return nil, extraDocumentFailure(path, &extra)
+	default:
+		// A second document that is itself malformed YAML.
+		return nil, parseFailure(path, err)
+	}
+}
+
+// parseFailure wraps a yaml parser error into a KindParseType *LoadError,
+// copying path verbatim and rendering the parser error's own message (which
+// always contains "line N") into Detail.
+func parseFailure(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindParseType,
+		Detail: err.Error(),
+		Err:    err,
+	}
+}
+
+// extraDocumentFailure reports that a second, well-formed YAML document
+// follows a first one that already decoded successfully. There is no
+// parser error to wrap here - extra is valid YAML - so Err is left nil and
+// Detail instead names the line the second document starts at.
+func extraDocumentFailure(path string, extra *yaml.Node) *LoadError {
+	return &LoadError{
+		Path: path,
+		Kind: KindParseType,
+		Detail: fmt.Sprintf(
+			"only a single YAML document is supported, but a second document starts at line %d",
+			extra.Line,
+		),
+	}
+}

--- a/internal/config/source.go
+++ b/internal/config/source.go
@@ -17,9 +17,10 @@ import (
 // matching the "absent config" semantics the rest of this package already
 // uses for a missing file. A document that fails to parse returns a
 // KindParseType *LoadError wrapping the real yaml parser error, with Detail
-// set to that error's own message (which yaml.v3 always renders as
-// "yaml: line N: ...", so the reported line is visible in Detail without a
-// second look at Err).
+// set to that error's own message. When yaml.v3 includes a "line N"
+// fragment, the same fragment is therefore visible in Detail without a
+// second look at Err; when it does not report a line, this helper does not
+// invent one.
 //
 // Exactly one YAML document is accepted. After the first document decodes
 // successfully, only io.EOF from a second Decode proves there is no more
@@ -57,8 +58,8 @@ func parseYAMLDocument(path string, data []byte) (*yaml.Node, *LoadError) {
 }
 
 // parseFailure wraps a yaml parser error into a KindParseType *LoadError,
-// copying path verbatim and rendering the parser error's own message (which
-// always contains "line N") into Detail.
+// copying path verbatim and rendering the parser error's own message into
+// Detail. This preserves any "line N" fragment yaml.v3 provides.
 func parseFailure(path string, err error) *LoadError {
 	return &LoadError{
 		Path:   path,

--- a/internal/config/source_test.go
+++ b/internal/config/source_test.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// lineNumberPattern extracts the N in a yaml.v3-style "line N" fragment, as
+// rendered both by the library's own parser errors and by this package's
+// extraDocumentFailure Detail text.
+var lineNumberPattern = regexp.MustCompile(`line (\d+)`)
+
+// lineNumber returns the first "line N" number found in s, failing the test
+// if none is present.
+func lineNumber(t *testing.T, s string) int {
+	t.Helper()
+	m := lineNumberPattern.FindStringSubmatch(s)
+	if m == nil {
+		t.Fatalf("no \"line N\" found in %q", s)
+	}
+	n := 0
+	for _, r := range m[1] {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+func TestParseYAMLDocumentNilDataReturnsNil(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", nil)
+	if node != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil)", node, err)
+	}
+}
+
+func TestParseYAMLDocumentEmptyDataReturnsNil(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", []byte(""))
+	if node != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil)", node, err)
+	}
+}
+
+func TestParseYAMLDocumentWhitespaceOnlyReturnsNil(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", []byte("   \n\n"))
+	if node != nil || err != nil {
+		t.Fatalf("got (%v, %v), want (nil, nil)", node, err)
+	}
+}
+
+func TestParseYAMLDocumentValidSingleDocument(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", []byte("a: 1\nb: 2\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if node == nil {
+		t.Fatal("got nil node for a valid document")
+	}
+	if node.Kind != yaml.DocumentNode {
+		t.Fatalf("node.Kind = %v, want yaml.DocumentNode", node.Kind)
+	}
+	if len(node.Content) != 1 {
+		t.Fatalf("len(node.Content) = %d, want 1", len(node.Content))
+	}
+}
+
+func TestParseYAMLDocumentMalformedFirstDocument(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"badIndentAfterSequenceItem", "a:\n- b\n  c: d\n"},
+		{"unterminatedFlowSequence", "foo: [1, 2\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			node, err := parseYAMLDocument("cfg.yml", []byte(tc.data))
+			if node != nil {
+				t.Fatalf("got non-nil node %v for malformed input", node)
+			}
+			if err == nil {
+				t.Fatal("got nil error for malformed input")
+			}
+			if err.Kind != KindParseType {
+				t.Fatalf("err.Kind = %v, want KindParseType", err.Kind)
+			}
+			if err.Path != "cfg.yml" {
+				t.Fatalf("err.Path = %q, want %q", err.Path, "cfg.yml")
+			}
+			if err.Err == nil {
+				t.Fatal("err.Err is nil, want the yaml parser error")
+			}
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain \"line \"", err.Detail)
+			}
+			wantLine := lineNumber(t, err.Err.Error())
+			gotLine := lineNumber(t, err.Detail)
+			if gotLine != wantLine {
+				t.Fatalf("err.Detail line = %d, err.Err line = %d, want equal", gotLine, wantLine)
+			}
+		})
+	}
+}
+
+func TestParseYAMLDocumentTwoValidDocumentsRejected(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", []byte("a: 1\n---\nb: 2\n"))
+	if node != nil {
+		t.Fatalf("got non-nil node %v for a second document", node)
+	}
+	if err == nil {
+		t.Fatal("got nil error for a second document")
+	}
+	if err.Kind != KindParseType {
+		t.Fatalf("err.Kind = %v, want KindParseType", err.Kind)
+	}
+	if err.Path != "cfg.yml" {
+		t.Fatalf("err.Path = %q, want %q", err.Path, "cfg.yml")
+	}
+
+	// The second document ("b: 2") starts at the "---" separator, line 2.
+	const wantLine = 2
+	gotLine := lineNumber(t, err.Detail)
+	if gotLine != wantLine {
+		t.Fatalf("err.Detail line = %d, want %d", gotLine, wantLine)
+	}
+}
+
+func TestParseYAMLDocumentTrailingBareDashesRejected(t *testing.T) {
+	// yaml.v3 decodes a trailing bare "---" as a second, null document -
+	// not as a harmless end-of-stream marker for the first document.
+	node, err := parseYAMLDocument("cfg.yml", []byte("a: 1\n---\n"))
+	if node != nil {
+		t.Fatalf("got non-nil node %v for a trailing bare ---", node)
+	}
+	if err == nil {
+		t.Fatal("got nil error for a trailing bare ---")
+	}
+	if err.Kind != KindParseType {
+		t.Fatalf("err.Kind = %v, want KindParseType", err.Kind)
+	}
+	gotLine := lineNumber(t, err.Detail)
+	if gotLine <= 0 {
+		t.Fatalf("err.Detail line = %d, want a positive line number", gotLine)
+	}
+}
+
+func TestParseYAMLDocumentMalformedSecondDocument(t *testing.T) {
+	node, err := parseYAMLDocument("cfg.yml", []byte("a: 1\n---\nb: [1,\n"))
+	if node != nil {
+		t.Fatalf("got non-nil node %v for a malformed second document", node)
+	}
+	if err == nil {
+		t.Fatal("got nil error for a malformed second document")
+	}
+	if err.Kind != KindParseType {
+		t.Fatalf("err.Kind = %v, want KindParseType", err.Kind)
+	}
+	if err.Path != "cfg.yml" {
+		t.Fatalf("err.Path = %q, want %q", err.Path, "cfg.yml")
+	}
+	if err.Err == nil {
+		t.Fatal("err.Err is nil, want the second document's yaml parser error")
+	}
+	if !strings.Contains(err.Err.Error(), "line ") {
+		t.Fatalf("err.Err.Error() = %q, want it to contain \"line \"", err.Err.Error())
+	}
+	wantLine := lineNumber(t, err.Err.Error())
+	gotLine := lineNumber(t, err.Detail)
+	if gotLine != wantLine {
+		t.Fatalf("err.Detail line = %d, err.Err line = %d, want equal", gotLine, wantLine)
+	}
+}
+
+func TestParseYAMLDocumentReturnedErrorUnwraps(t *testing.T) {
+	_, err := parseYAMLDocument("cfg.yml", []byte("foo: [1, 2\n"))
+	if err == nil {
+		t.Fatal("got nil error for malformed input")
+	}
+	if !errors.Is(error(err), err.Err) {
+		t.Fatalf("errors.Is(err, err.Err) = false, want true")
+	}
+}

--- a/internal/config/sourcebounds.go
+++ b/internal/config/sourcebounds.go
@@ -1,0 +1,245 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// maxAliasHops is the maximum number of consecutive alias hops
+// checkAliasHopLimit accepts. Following an alias to its target adds one
+// hop; descending from any non-alias node into ordinary content resets
+// the count for that child path. Exactly maxAliasHops succeeds;
+// maxAliasHops+1 fails.
+const maxAliasHops = 64
+
+// sourceEdge is one directed parent->child content edge recorded by
+// collectSourceInventory: a mapping key or value, a sequence entry, or an
+// alias node's target. A node reached through several parents contributes
+// one sourceEdge per parent, even though collectSourceInventory's walk
+// visits the node's own content only once.
+type sourceEdge struct {
+	parent *yaml.Node
+	child  *yaml.Node
+}
+
+// sourceInventory is the result of one deterministic depth-first walk of a
+// source graph already proven acyclic and well-formed by walkSourceNode:
+// every reachable node in discovery order, every parent->child content
+// edge reachable in the graph (including edges into a node reached more
+// than once, which is what lets attributeSourceLines consider every
+// root-reachable path rather than only the first one discovered), each
+// node's discovery index (for deterministic tie-breaking), and each node's
+// first-encounter active nearest positive-line ancestor (the ancestor
+// interpretation 11's tie-break falls back to when two candidates are
+// otherwise equally near).
+type sourceInventory struct {
+	nodes          []*yaml.Node
+	discoveryIndex map[*yaml.Node]int
+	edges          []sourceEdge
+	firstAncestor  map[*yaml.Node]*yaml.Node
+}
+
+// collectSourceInventory walks root exactly once per unique node, in
+// Content slice order, recording every node and every parent->child
+// content edge reachable from it. root must already be proven acyclic
+// (walkSourceNode's job): collectSourceInventory tracks only a simple
+// visited set, not the visiting/done cycle guard, and would recurse
+// forever on a graph containing a cycle. A node's discovery index and
+// first-encounter active ancestor are fixed the first time the walk
+// reaches it; every edge into it — including from parents reached after
+// that first visit — is still appended to inv.edges, so attributeSourceLines
+// can later consider every path into a shared node, not just the one the
+// walk happened to take first.
+func collectSourceInventory(root *yaml.Node) *sourceInventory {
+	inv := &sourceInventory{
+		discoveryIndex: make(map[*yaml.Node]int),
+		firstAncestor:  make(map[*yaml.Node]*yaml.Node),
+	}
+	visited := make(map[*yaml.Node]bool)
+
+	var walk func(n *yaml.Node, activeAncestor *yaml.Node)
+	walk = func(n *yaml.Node, activeAncestor *yaml.Node) {
+		if visited[n] {
+			return
+		}
+		visited[n] = true
+		inv.discoveryIndex[n] = len(inv.nodes)
+		inv.nodes = append(inv.nodes, n)
+		inv.firstAncestor[n] = activeAncestor
+
+		nextAncestor := activeAncestor
+		if n.Line > 0 {
+			nextAncestor = n
+		}
+
+		switch n.Kind {
+		case yaml.MappingNode, yaml.SequenceNode:
+			for _, child := range n.Content {
+				inv.edges = append(inv.edges, sourceEdge{parent: n, child: child})
+				walk(child, nextAncestor)
+			}
+		case yaml.AliasNode:
+			if n.Alias != nil {
+				inv.edges = append(inv.edges, sourceEdge{parent: n, child: n.Alias})
+				walk(n.Alias, nextAncestor)
+			}
+		}
+	}
+	walk(root, nil)
+	return inv
+}
+
+// attributeSourceLines computes, for every node in inv.nodes, the source
+// line a bounds-limit error should report for it (interpretation 11): a
+// node's own Line when positive; otherwise the line of a positive-line
+// ancestor at minimum content-edge distance over all root-reachable paths,
+// not merely over the path of the node's first DFS encounter; otherwise 1,
+// for a node with no positive-line ancestor reachable on any path (a
+// wholly synthetic graph).
+//
+// This is a multi-source BFS in the parent->child direction, seeded with
+// every reachable positive-line node at distance 0 attributing its own
+// line, relaxing each edge parent->child with (dist(parent)+1,
+// line(parent)). Because inv already lists every reachable node and edge
+// exactly once, this pass touches each at most once and is O(V+E) — it
+// never re-expands a shared subgraph once per path, which is what keeps a
+// compact alias-sharing DAG linear instead of exponential.
+//
+// When two positive-line ancestors tie at the same minimum distance to a
+// node, the one that was that node's first-encounter active ancestor
+// (inv.firstAncestor) wins if it is among the tied candidates; otherwise
+// the candidate reached through the parent with the lowest discovery
+// index wins, with each parent's own children considered in Content slice
+// order (both already implied by inv.edges' construction order).
+func attributeSourceLines(inv *sourceInventory) map[*yaml.Node]int {
+	children := make(map[*yaml.Node][]*yaml.Node, len(inv.nodes))
+	for _, e := range inv.edges {
+		children[e.parent] = append(children[e.parent], e.child)
+	}
+
+	dist := make(map[*yaml.Node]int, len(inv.nodes))
+	ancestor := make(map[*yaml.Node]*yaml.Node, len(inv.nodes))
+	viaParent := make(map[*yaml.Node]*yaml.Node, len(inv.nodes))
+
+	queue := make([]*yaml.Node, 0, len(inv.nodes))
+	for _, n := range inv.nodes {
+		if n.Line > 0 {
+			dist[n] = 0
+			ancestor[n] = n
+			queue = append(queue, n)
+		}
+	}
+
+	for i := 0; i < len(queue); i++ {
+		p := queue[i]
+		nd := dist[p] + 1
+		for _, c := range children[p] {
+			if c.Line > 0 {
+				// c is itself a positive-line seed; it is never
+				// attributed from an ancestor.
+				continue
+			}
+			existing, seen := dist[c]
+			switch {
+			case !seen:
+				dist[c] = nd
+				ancestor[c] = ancestor[p]
+				viaParent[c] = p
+				queue = append(queue, c)
+			case nd == existing:
+				if preferSourceLineAncestor(inv, c, ancestor[c], viaParent[c], ancestor[p], p) {
+					ancestor[c] = ancestor[p]
+					viaParent[c] = p
+				}
+			}
+		}
+	}
+
+	lines := make(map[*yaml.Node]int, len(inv.nodes))
+	for _, n := range inv.nodes {
+		switch {
+		case n.Line > 0:
+			lines[n] = n.Line
+		case ancestor[n] != nil:
+			lines[n] = ancestor[n].Line
+		default:
+			lines[n] = 1
+		}
+	}
+	return lines
+}
+
+// preferSourceLineAncestor decides, for child c already tentatively
+// attributed to curAncestor (reached via curParent) at the minimum known
+// distance, whether a newly discovered equally-near candidate
+// (newAncestor, reached via newParent) should replace it. It implements
+// interpretation 11's tie-break: the child's first-encounter active
+// ancestor wins if it is one of the tied candidates; otherwise the
+// candidate reached through the lower-discovery-index parent wins.
+func preferSourceLineAncestor(inv *sourceInventory, c, curAncestor, curParent, newAncestor, newParent *yaml.Node) bool {
+	firstEncountered := inv.firstAncestor[c]
+	if newAncestor == firstEncountered {
+		return true
+	}
+	if curAncestor == firstEncountered {
+		return false
+	}
+	return inv.discoveryIndex[newParent] < inv.discoveryIndex[curParent]
+}
+
+// aliasHopCount is the memoized consecutive-alias-hop DP: hops(n) = 1 +
+// hops(n.Alias) when n is a yaml.AliasNode, and 0 for every other kind, so
+// descending into ordinary (non-alias) content always resets the count for
+// that child path. memo is keyed by node identity and shared across calls
+// for the same graph, so a node reachable through many parents (the
+// compact alias-sharing DAG the timeout test exercises) is computed once
+// rather than once per path.
+func aliasHopCount(n *yaml.Node, memo map[*yaml.Node]int) int {
+	if n == nil || n.Kind != yaml.AliasNode {
+		return 0
+	}
+	if v, ok := memo[n]; ok {
+		return v
+	}
+	v := 1 + aliasHopCount(n.Alias, memo)
+	memo[n] = v
+	return v
+}
+
+// checkAliasHopLimit rejects a source graph containing a node whose
+// aliasHopCount exceeds maxAliasHops, naming the limit and reporting
+// lines[n] (the offending node's own positive line, its nearest
+// positive-line ancestor over all paths, or 1 for a wholly synthetic
+// graph — see attributeSourceLines) as the error's source line. inv.nodes
+// is visited in discovery order, so the result is deterministic even when
+// more than one node exceeds the limit.
+func checkAliasHopLimit(path string, inv *sourceInventory, lines map[*yaml.Node]int) *LoadError {
+	memo := make(map[*yaml.Node]int, len(inv.nodes))
+	for _, n := range inv.nodes {
+		if aliasHopCount(n, memo) > maxAliasHops {
+			line := lines[n]
+			if line <= 0 {
+				line = 1
+			}
+			detail := fmt.Sprintf(
+				"source graph exceeds the maximum of %d consecutive alias hops (line %d)",
+				maxAliasHops, line,
+			)
+			return sourceGraphError(path, detail)
+		}
+	}
+	return nil
+}
+
+// checkSourceGraphBounds is this package's single post-acyclicity source-graph
+// bounds pass: it collects the reachable inventory, attributes a source line to
+// every reachable node, and rejects a graph exceeding maxAliasHops
+// consecutive alias hops. It must only ever be called on a root already
+// proven acyclic by walkSourceNode — collectSourceInventory and
+// aliasHopCount both assume that and would not terminate otherwise.
+func checkSourceGraphBounds(path string, root *yaml.Node) *LoadError {
+	inv := collectSourceInventory(root)
+	lines := attributeSourceLines(inv)
+	return checkAliasHopLimit(path, inv, lines)
+}

--- a/internal/config/sourcebounds.go
+++ b/internal/config/sourcebounds.go
@@ -232,14 +232,125 @@ func checkAliasHopLimit(path string, inv *sourceInventory, lines map[*yaml.Node]
 	return nil
 }
 
+// maxSourcePathVisits is the maximum number of source-node visits
+// pathVisitCount accepts on any single root-to-leaf path. Every encountered
+// node — the root, a mapping, a sequence, a scalar, an alias node, or an
+// alias target — contributes exactly one visit; "key", "value", and "alias
+// target" only identify which child node is traversed next and add no
+// separate charge, so a scalar used as a mapping key counts once, not once
+// for being a scalar plus once for being a key. Exactly maxSourcePathVisits
+// succeeds; maxSourcePathVisits+1 fails.
+const maxSourcePathVisits = 128
+
+// pathVisitCount is the memoized path-visit DP: visits(n) = 1 +
+// max(visits(child)) over every content edge reachable directly from n (a
+// document's or mapping's or sequence's Content entries, or an alias node's
+// single Alias target), and visits(n) = 1 for a node with no such edges (a
+// scalar, or an alias whose target is nil — already rejected earlier by
+// walkSourceNode on any graph reaching this pass, but handled defensively
+// here too). A mapping's key and value entries are both ordinary Content
+// children and so are both considered — proving keys count toward the
+// bound exactly like values do, and exactly once each. memo is keyed by
+// node identity and shared across calls for the same graph, so a node
+// reachable through many parents (the compact alias-sharing DAG the
+// timeout test exercises) is computed once rather than once per path,
+// keeping this DP linear in the graph's node and edge count.
+func pathVisitCount(n *yaml.Node, memo map[*yaml.Node]int) int {
+	if n == nil {
+		return 0
+	}
+	if v, ok := memo[n]; ok {
+		return v
+	}
+	deepest := 0
+	switch n.Kind {
+	case yaml.MappingNode, yaml.SequenceNode:
+		for _, child := range n.Content {
+			if v := pathVisitCount(child, memo); v > deepest {
+				deepest = v
+			}
+		}
+	case yaml.AliasNode:
+		deepest = pathVisitCount(n.Alias, memo)
+	}
+	v := 1 + deepest
+	memo[n] = v
+	return v
+}
+
+// checkSourcePathVisitLimit rejects a source graph containing a
+// root-to-leaf path exceeding maxSourcePathVisits, naming the limit and
+// reporting lines[n] (see attributeSourceLines) as the error's source
+// line for the offending node n it identifies.
+//
+// pathVisitCount is monotonically non-decreasing from any node toward the
+// root — a parent's count is always at least one more than its deepest
+// child's — so once one node's path-visit count exceeds the limit, every
+// one of its ancestors up to the graph's root does too; reporting the
+// first over-limit node found in mere discovery order would therefore
+// almost always report the root itself (discovered before any
+// descendant), which carries no useful attribution. Instead this walks
+// inv.nodes in discovery order looking for the *boundary*: a node whose
+// own count exceeds maxSourcePathVisits but whose every direct child (if
+// any) does not — the exact point along an offending path where the count
+// first crosses the limit. That boundary node is what a bounds-limit
+// error should name, and it is deterministic even when more than one
+// branch independently crosses the boundary, since discovery order breaks
+// the tie. Because the DP is memoized, wide siblings sharing one deep
+// target are each checked once and do not accumulate a global count.
+func checkSourcePathVisitLimit(path string, inv *sourceInventory, lines map[*yaml.Node]int) *LoadError {
+	memo := make(map[*yaml.Node]int, len(inv.nodes))
+	for _, n := range inv.nodes {
+		pathVisitCount(n, memo)
+	}
+
+	children := make(map[*yaml.Node][]*yaml.Node, len(inv.nodes))
+	for _, e := range inv.edges {
+		children[e.parent] = append(children[e.parent], e.child)
+	}
+
+	for _, n := range inv.nodes {
+		if memo[n] <= maxSourcePathVisits {
+			continue
+		}
+		boundary := true
+		for _, c := range children[n] {
+			if memo[c] > maxSourcePathVisits {
+				boundary = false
+				break
+			}
+		}
+		if !boundary {
+			continue
+		}
+		line := lines[n]
+		if line <= 0 {
+			line = 1
+		}
+		detail := fmt.Sprintf(
+			"source graph exceeds the maximum of %d source-node path visits (line %d)",
+			maxSourcePathVisits, line,
+		)
+		return sourceGraphError(path, detail)
+	}
+	return nil
+}
+
 // checkSourceGraphBounds is this package's single post-acyclicity source-graph
 // bounds pass: it collects the reachable inventory, attributes a source line to
 // every reachable node, and rejects a graph exceeding maxAliasHops
-// consecutive alias hops. It must only ever be called on a root already
-// proven acyclic by walkSourceNode — collectSourceInventory and
-// aliasHopCount both assume that and would not terminate otherwise.
+// consecutive alias hops or maxSourcePathVisits source-node visits on any
+// root-to-leaf path — checking the alias-hop bound first, so a graph
+// violating both limits deterministically reports the alias-hop error and
+// never evaluates the path-visit pass. It must only ever be called on a
+// root already proven acyclic by walkSourceNode — collectSourceInventory,
+// aliasHopCount, and pathVisitCount all assume that and would not
+// terminate otherwise.
 func checkSourceGraphBounds(path string, root *yaml.Node) *LoadError {
 	inv := collectSourceInventory(root)
 	lines := attributeSourceLines(inv)
-	return checkAliasHopLimit(path, inv, lines)
+	if err := checkAliasHopLimit(path, inv, lines); err != nil {
+		return err
+	}
+	return checkSourcePathVisitLimit(path, inv, lines)
 }

--- a/internal/config/sourcebounds.go
+++ b/internal/config/sourcebounds.go
@@ -74,7 +74,7 @@ func collectSourceInventory(root *yaml.Node) *sourceInventory {
 		}
 
 		switch n.Kind {
-		case yaml.MappingNode, yaml.SequenceNode:
+		case yaml.DocumentNode, yaml.MappingNode, yaml.SequenceNode:
 			for _, child := range n.Content {
 				inv.edges = append(inv.edges, sourceEdge{parent: n, child: child})
 				walk(child, nextAncestor)
@@ -264,7 +264,7 @@ func pathVisitCount(n *yaml.Node, memo map[*yaml.Node]int) int {
 	}
 	deepest := 0
 	switch n.Kind {
-	case yaml.MappingNode, yaml.SequenceNode:
+	case yaml.DocumentNode, yaml.MappingNode, yaml.SequenceNode:
 		for _, child := range n.Content {
 			if v := pathVisitCount(child, memo); v > deepest {
 				deepest = v

--- a/internal/config/sourcebounds_test.go
+++ b/internal/config/sourcebounds_test.go
@@ -339,14 +339,14 @@ func TestValidateSourceGraphPathVisitBoundary(t *testing.T) {
 	const path = "/etc/chairlift/path-visit-boundary.yml"
 
 	t.Run("exactly 128 visits succeeds", func(t *testing.T) {
-		doc := newSourceDocNode(buildSourceVisitChain(128))
+		doc := newSourceDocNode(buildSourceVisitChain(127))
 		if err := validateSourceGraph(path, doc); err != nil {
 			t.Fatalf("validateSourceGraph(128-visit chain) = %v, want nil", err)
 		}
 	})
 
 	t.Run("129 visits fails", func(t *testing.T) {
-		doc := newSourceDocNode(buildSourceVisitChain(129))
+		doc := newSourceDocNode(buildSourceVisitChain(128))
 		err := validateSourceGraph(path, doc)
 		wantParseType(t, err, path)
 
@@ -365,6 +365,24 @@ func TestValidateSourceGraphPathVisitBoundary(t *testing.T) {
 	})
 }
 
+// TestValidateSourceGraphPathVisitIncludesDocument proves the document node
+// is both charged as the first path visit and retained as an attribution
+// ancestor. The child graph has exactly 128 visits on its own, so wrapping it
+// in the required document makes the source path 129 visits; because all
+// child nodes have Line == 0, the limit error must inherit the document's
+// positive line rather than falling back to line 1.
+func TestValidateSourceGraphPathVisitIncludesDocument(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-document.yml"
+
+	doc := newSourceDocNode(buildSourceVisitChain(128))
+	doc.Line = 77
+	err := validateSourceGraph(path, doc)
+	wantParseType(t, err, path)
+	if got := sourceDetailLine(t, err); got != 77 {
+		t.Fatalf("attributed line = %d, want document line 77", got)
+	}
+}
+
 // TestValidateSourceGraphPathVisitAliasCounts confirms an alias node plus
 // its target contributes two path visits, not one: two graphs identical
 // in wrap-depth differ only in whether the deepest leaf is a direct scalar
@@ -372,7 +390,7 @@ func TestValidateSourceGraphPathVisitBoundary(t *testing.T) {
 // alone flips the result across the 128 boundary.
 func TestValidateSourceGraphPathVisitAliasCounts(t *testing.T) {
 	const path = "/etc/chairlift/path-visit-alias-counts.yml"
-	const wraps = 127
+	const wraps = 126
 
 	direct := buildSourceVisitChainWithLeaf(wraps, newSourceScalarNode("leaf"))
 	if err := validateSourceGraph(path, newSourceDocNode(direct)); err != nil {
@@ -386,6 +404,9 @@ func TestValidateSourceGraphPathVisitAliasCounts(t *testing.T) {
 	if !strings.Contains(err.Detail, "128") {
 		t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "128")
 	}
+	if got := sourceDetailLine(t, err); got != 1 {
+		t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
+	}
 }
 
 // TestValidateSourceGraphPathVisitKeyAccounting confirms mapping keys
@@ -398,19 +419,22 @@ func TestValidateSourceGraphPathVisitAliasCounts(t *testing.T) {
 func TestValidateSourceGraphPathVisitKeyAccounting(t *testing.T) {
 	const path = "/etc/chairlift/path-visit-key-accounting.yml"
 
-	t.Run("127 key-position wraps (128 visits) succeeds", func(t *testing.T) {
-		doc := newSourceDocNode(buildSourceVisitKeyChain(127, newSourceScalarNode("leaf")))
+	t.Run("126 key-position wraps (128 visits) succeeds", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitKeyChain(126, newSourceScalarNode("leaf")))
 		if err := validateSourceGraph(path, doc); err != nil {
-			t.Fatalf("validateSourceGraph(127-deep key chain) = %v, want nil", err)
+			t.Fatalf("validateSourceGraph(126-wrap key chain plus document) = %v, want nil", err)
 		}
 	})
 
-	t.Run("128 key-position wraps (129 visits) fails", func(t *testing.T) {
-		doc := newSourceDocNode(buildSourceVisitKeyChain(128, newSourceScalarNode("leaf")))
+	t.Run("127 key-position wraps (129 visits) fails", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitKeyChain(127, newSourceScalarNode("leaf")))
 		err := validateSourceGraph(path, doc)
 		wantParseType(t, err, path)
 		if !strings.Contains(err.Detail, "128") {
 			t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "128")
+		}
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
 		}
 	})
 }
@@ -562,5 +586,8 @@ func TestValidateSourceGraphBothBoundsViolatedReportsAliasHopDeterministically(t
 	}
 	if strings.Contains(err.Detail, "path visit") {
 		t.Fatalf("err.Detail = %q, want only the alias-hop limit named, not the path-visit limit too", err.Detail)
+	}
+	if got := sourceDetailLine(t, err); got != 1 {
+		t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
 	}
 }

--- a/internal/config/sourcebounds_test.go
+++ b/internal/config/sourcebounds_test.go
@@ -289,3 +289,278 @@ func TestValidateSourceGraphAliasSharingDAGTerminatesLinearly(t *testing.T) {
 		t.Fatalf("validateSourceGraph(compact alias-sharing DAG) = %v, want nil", err)
 	}
 }
+
+// buildSourceVisitChainWithLeaf wraps leaf in wraps nested one-entry
+// mapping levels, each contributing exactly one path visit (the mapping
+// node itself; its scalar key is a shallower sibling branch that never
+// wins the DP's max). The returned head node's pathVisitCount is
+// wraps + pathVisitCount(leaf).
+func buildSourceVisitChainWithLeaf(wraps int, leaf *yaml.Node) *yaml.Node {
+	node := leaf
+	for i := 0; i < wraps; i++ {
+		node = newSourceMappingNode(newSourceScalarNode("k"), node)
+	}
+	return node
+}
+
+// buildSourceVisitChain returns a chain of nested one-entry mappings ending
+// in an ordinary scalar leaf whose total path-visit count is exactly
+// depth: depth-1 wrapping mappings, each contributing one visit, plus the
+// leaf scalar's own single visit.
+func buildSourceVisitChain(depth int) *yaml.Node {
+	return buildSourceVisitChainWithLeaf(depth-1, newSourceScalarNode("leaf"))
+}
+
+// buildSourceVisitKeyChain returns a chain of nested mappings, each
+// wrapping the previous level as its own KEY (not its value) with a
+// shallow scalar value sibling, ending in leaf. Its total path-visit count
+// is exactly wraps + pathVisitCount(leaf), proving the DP must consider
+// mapping keys (not only values) to compute the deepest path, since the
+// value branch alone never grows past 2.
+func buildSourceVisitKeyChain(wraps int, leaf *yaml.Node) *yaml.Node {
+	node := leaf
+	for i := 0; i < wraps; i++ {
+		node = newSourceMappingNode(node, newSourceScalarNode("v"))
+	}
+	return node
+}
+
+// TestValidateSourceGraphPathVisitBoundary confirms the 128/129
+// source-node path-visit boundary exactly: a chain of exactly 128 visits
+// succeeds, and a chain of 129 fails as KindParseType, naming the
+// path-visit limit, the literal "128", and a positive "line N" — even
+// though every synthesized node in the chain has Line == 0, so the
+// reported line must come from the deterministic fallback. Every level of
+// the chain is a mapping with a plain scalar key, so this also proves a
+// scalar used as a mapping key counts exactly once, not twice: a
+// double-counting implementation would report a different (larger) total
+// and reject the exactly-128 case that this test requires to succeed.
+func TestValidateSourceGraphPathVisitBoundary(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-boundary.yml"
+
+	t.Run("exactly 128 visits succeeds", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitChain(128))
+		if err := validateSourceGraph(path, doc); err != nil {
+			t.Fatalf("validateSourceGraph(128-visit chain) = %v, want nil", err)
+		}
+	})
+
+	t.Run("129 visits fails", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitChain(129))
+		err := validateSourceGraph(path, doc)
+		wantParseType(t, err, path)
+
+		if err.Err != nil {
+			t.Fatalf("err.Err = %v, want nil", err.Err)
+		}
+		if !strings.Contains(err.Detail, "path visit") && !strings.Contains(err.Detail, "path-node visit") {
+			t.Fatalf("err.Detail = %q, want wording identifying the source-node path-visit limit", err.Detail)
+		}
+		if !strings.Contains(err.Detail, "128") {
+			t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "128")
+		}
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
+		}
+	})
+}
+
+// TestValidateSourceGraphPathVisitAliasCounts confirms an alias node plus
+// its target contributes two path visits, not one: two graphs identical
+// in wrap-depth differ only in whether the deepest leaf is a direct scalar
+// child or an alias node targeting that same scalar, and the substitution
+// alone flips the result across the 128 boundary.
+func TestValidateSourceGraphPathVisitAliasCounts(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-alias-counts.yml"
+	const wraps = 127
+
+	direct := buildSourceVisitChainWithLeaf(wraps, newSourceScalarNode("leaf"))
+	if err := validateSourceGraph(path, newSourceDocNode(direct)); err != nil {
+		t.Fatalf("validateSourceGraph(direct scalar leaf, %d wraps = 128 visits) = %v, want nil", wraps, err)
+	}
+
+	aliasedLeaf := newSourceAliasNode(newSourceScalarNode("leaf"))
+	aliased := buildSourceVisitChainWithLeaf(wraps, aliasedLeaf)
+	err := validateSourceGraph(path, newSourceDocNode(aliased))
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "128") {
+		t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "128")
+	}
+}
+
+// TestValidateSourceGraphPathVisitKeyAccounting confirms mapping keys
+// count toward the path-visit bound: a chain of nested mappings whose
+// depth lives entirely in the KEY position (each level's value is a
+// shallow sibling scalar) crosses the 128 boundary exactly like the
+// value-position chain in TestValidateSourceGraphPathVisitBoundary does,
+// which is only possible if the DP considers key children, not only value
+// children.
+func TestValidateSourceGraphPathVisitKeyAccounting(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-key-accounting.yml"
+
+	t.Run("127 key-position wraps (128 visits) succeeds", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitKeyChain(127, newSourceScalarNode("leaf")))
+		if err := validateSourceGraph(path, doc); err != nil {
+			t.Fatalf("validateSourceGraph(127-deep key chain) = %v, want nil", err)
+		}
+	})
+
+	t.Run("128 key-position wraps (129 visits) fails", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceVisitKeyChain(128, newSourceScalarNode("leaf")))
+		err := validateSourceGraph(path, doc)
+		wantParseType(t, err, path)
+		if !strings.Contains(err.Detail, "128") {
+			t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "128")
+		}
+	})
+}
+
+// TestValidateSourceGraphPathVisitWideSiblingsShareDeepTarget confirms
+// path visits do not accumulate globally: 200 sibling sequence entries all
+// alias the same deep (but within-bound) shared subtree. If path-visit
+// checking wrongly summed visits across siblings instead of memoizing by
+// node identity, this would spuriously reject; instead it must succeed.
+func TestValidateSourceGraphPathVisitWideSiblingsShareDeepTarget(t *testing.T) {
+	shared := buildSourceVisitChain(100)
+	entries := make([]*yaml.Node, 0, 200)
+	for i := 0; i < 200; i++ {
+		entries = append(entries, newSourceAliasNode(shared))
+	}
+	doc := newSourceDocNode(newSourceSequenceNode(entries...))
+
+	if err := validateSourceGraph("p", doc); err != nil {
+		t.Fatalf("validateSourceGraph(200 wide siblings sharing a deep target) = %v, want nil", err)
+	}
+}
+
+// TestValidateSourceGraphPathVisitAttributionEqualDistanceTieBreak is the
+// mandatory equal-distance tie-break case, observed end-to-end through a
+// path-visit-limit error: the offending (over-limit, Line == 0) node is a
+// single shared *yaml.Node reachable via two paths of the SAME minimum
+// distance (two content edges) below two different positive-line
+// ancestors, A and B. Per interpretation 11's tie-break, the winner is the
+// ancestor active on the DFS stack at the node's first deterministic
+// depth-first encounter — which is whichever of A's or B's branch the
+// walk reaches first, i.e. whichever is ordered first in the root
+// mapping's Content. This is asserted both ways: swapping the Content
+// order flips which ancestor's line is reported.
+func TestValidateSourceGraphPathVisitAttributionEqualDistanceTieBreak(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-equal-distance-tie.yml"
+
+	build := func(aFirst bool) *yaml.Node {
+		offending := buildSourceVisitChain(129) // shared node, Line == 0, over the limit on its own
+
+		// Path through A: two content edges from ancestorA to offending.
+		midA := newSourceMappingNode(newSourceScalarNode("mid-a"), offending)
+		ancestorA := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Line:    50,
+			Content: []*yaml.Node{newSourceScalarNode("a0"), midA},
+		}
+
+		// Path through B: also two content edges, to the same shared
+		// offending node — an equal minimum distance to A's path.
+		midB := newSourceMappingNode(newSourceScalarNode("mid-b"), offending)
+		ancestorB := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Line:    60,
+			Content: []*yaml.Node{newSourceScalarNode("b0"), midB},
+		}
+
+		var root *yaml.Node
+		if aFirst {
+			root = newSourceMappingNode(
+				newSourceScalarNode("first"), ancestorA,
+				newSourceScalarNode("second"), ancestorB,
+			)
+		} else {
+			root = newSourceMappingNode(
+				newSourceScalarNode("first"), ancestorB,
+				newSourceScalarNode("second"), ancestorA,
+			)
+		}
+		return newSourceDocNode(root)
+	}
+
+	t.Run("A ordered first in Content reports A's line", func(t *testing.T) {
+		err := validateSourceGraph(path, build(true))
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 50 {
+			t.Fatalf("attributed line = %d, want 50 (A, discovered first at equal distance)", got)
+		}
+	})
+
+	t.Run("B ordered first in Content reports B's line", func(t *testing.T) {
+		err := validateSourceGraph(path, build(false))
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 60 {
+			t.Fatalf("attributed line = %d, want 60 (B, discovered first at equal distance)", got)
+		}
+	})
+}
+
+// TestValidateSourceGraphPathVisitAttributionAliasEdge confirms alias
+// edges participate in attribution distance: the offending (over-limit,
+// Line == 0) node is reachable both deep in ordinary content (distance 3
+// from a positive-line ancestor) and, via an alias edge, one content edge
+// below a different positive-line ancestor at distance 2. The nearer
+// (alias-mediated) line must be reported.
+func TestValidateSourceGraphPathVisitAttributionAliasEdge(t *testing.T) {
+	const path = "/etc/chairlift/path-visit-alias-edge.yml"
+
+	offending := buildSourceVisitChain(129) // shared node, Line == 0, over the limit on its own
+
+	// Deep, alias-free path: distance 3 from a positive-line ancestor.
+	deepMid2 := newSourceMappingNode(newSourceScalarNode("mid2-key"), offending)
+	deepMid1 := newSourceMappingNode(newSourceScalarNode("mid1-key"), deepMid2)
+	deepFar := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Line:    500,
+		Content: []*yaml.Node{newSourceScalarNode("far-key"), deepMid1},
+	}
+
+	// Near path: an alias edge puts the same offending node at distance
+	// 2 from a different, nearer positive-line ancestor.
+	aliasNear := newSourceAliasNode(offending)
+	nearAncestor := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Line:    3,
+		Content: []*yaml.Node{newSourceScalarNode("near-key"), aliasNear},
+	}
+
+	root := newSourceMappingNode(
+		newSourceScalarNode("deep"), deepFar,
+		newSourceScalarNode("near"), nearAncestor,
+	)
+	doc := newSourceDocNode(root)
+
+	err := validateSourceGraph(path, doc)
+	wantParseType(t, err, path)
+	if got := sourceDetailLine(t, err); got != 3 {
+		t.Fatalf("attributed line = %d, want 3 (the nearer ancestor reached via the alias edge)", got)
+	}
+}
+
+// TestValidateSourceGraphBothBoundsViolatedReportsAliasHopDeterministically
+// confirms a graph violating both the alias-hop bound and the path-visit
+// bound returns a single, deterministic KindParseType error naming the
+// alias-hop limit (checked first by checkSourceGraphBounds) rather than
+// panicking or somehow reporting twice: 70 consecutive alias hops (over
+// the 64 limit) wrapped in 60 further ordinary-content levels (pushing the
+// total path-visit count to 131, over the 128 limit) still yields exactly
+// one error, and it is the alias-hop one.
+func TestValidateSourceGraphBothBoundsViolatedReportsAliasHopDeterministically(t *testing.T) {
+	const path = "/etc/chairlift/both-bounds-violated.yml"
+
+	aliasChain := buildSourceAliasChain(70)                  // 70 alias hops, 71 path visits on its own
+	wrapped := buildSourceVisitChainWithLeaf(60, aliasChain) // + 60 more visits = 131
+
+	err := validateSourceGraph(path, newSourceDocNode(wrapped))
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "consecutive") || !strings.Contains(err.Detail, "alias hop") {
+		t.Fatalf("err.Detail = %q, want wording identifying the consecutive alias-hop limit (checked first)", err.Detail)
+	}
+	if strings.Contains(err.Detail, "path visit") {
+		t.Fatalf("err.Detail = %q, want only the alias-hop limit named, not the path-visit limit too", err.Detail)
+	}
+}

--- a/internal/config/sourcebounds_test.go
+++ b/internal/config/sourcebounds_test.go
@@ -1,0 +1,291 @@
+package config
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// newSourceScalarNode builds a well-formed yaml.ScalarNode with the given
+// value, for use as filler content in synthetic bounds-testing graphs.
+func newSourceScalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: value}
+}
+
+// newSourceMappingNode builds a well-formed yaml.MappingNode from an
+// already-interleaved key/value content slice.
+func newSourceMappingNode(content ...*yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Content: content}
+}
+
+// newSourceSequenceNode builds a well-formed yaml.SequenceNode from its
+// entries.
+func newSourceSequenceNode(entries ...*yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.SequenceNode, Content: entries}
+}
+
+// newSourceAliasNode builds a well-formed yaml.AliasNode targeting target.
+func newSourceAliasNode(target *yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.AliasNode, Alias: target}
+}
+
+// newSourceDocNode wraps root as a well-formed yaml.DocumentNode with
+// exactly one child, ready to pass to validateSourceGraph.
+func newSourceDocNode(root *yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+}
+
+// buildSourceAliasChain returns the head of a chain of n consecutive alias
+// hops terminating in an ordinary scalar: an AliasNode whose Alias is
+// another AliasNode, n levels deep, whose innermost Alias targets a
+// non-alias scalar (hop count 0). The returned head node has
+// aliasHopCount == n and Line == 0, since none of the synthesized nodes
+// set Line.
+func buildSourceAliasChain(n int) *yaml.Node {
+	node := newSourceScalarNode("terminal")
+	for i := 0; i < n; i++ {
+		node = newSourceAliasNode(node)
+	}
+	return node
+}
+
+// buildSourceSharingDAG returns a compact alias-sharing DAG built by a
+// doubling construction: level 0 is a single scalar leaf, and each
+// subsequent level is a two-entry sequence whose entries are both aliases
+// of the previous level's single node. Node count grows linearly with
+// levels (three new nodes per level) while the number of distinct
+// root-to-leaf paths doubles per level, so a naive per-path traversal of
+// buildSourceSharingDAG(40) would need to expand roughly 2^40 paths, while
+// a linear (node-and-edge-bounded) traversal visits it in microseconds.
+func buildSourceSharingDAG(levels int) *yaml.Node {
+	level := newSourceScalarNode("leaf")
+	for i := 0; i < levels; i++ {
+		level = newSourceSequenceNode(newSourceAliasNode(level), newSourceAliasNode(level))
+	}
+	return level
+}
+
+// sourceLineDetailPattern matches the literal "line N" substring
+// interpretation 7 requires every bounds-limit LoadError.Detail to
+// contain.
+var sourceLineDetailPattern = regexp.MustCompile(`line (\d+)`)
+
+// sourceDetailLine extracts and returns the positive integer N from an
+// err.Detail's "line N" substring, failing the test if no such substring
+// is present or the captured number is not a valid positive integer.
+func sourceDetailLine(t *testing.T, err *LoadError) int {
+	t.Helper()
+	m := sourceLineDetailPattern.FindStringSubmatch(err.Detail)
+	if m == nil {
+		t.Fatalf("err.Detail = %q, want a %q substring", err.Detail, "line N")
+	}
+	n, convErr := strconv.Atoi(m[1])
+	if convErr != nil || n <= 0 {
+		t.Fatalf("err.Detail = %q: parsed line %d (err=%v), want a positive integer", err.Detail, n, convErr)
+	}
+	return n
+}
+
+// runSourceValidateWithin runs validateSourceGraph(path, doc) on a
+// goroutine and fails the test if it has not returned within timeout,
+// using an explicit timer plus select rather than a bare t.Fatal after
+// the call — the only way to prove a non-terminating (exponential or
+// infinite) traversal fails the test instead of simply hanging the test
+// binary.
+func runSourceValidateWithin(t *testing.T, path string, doc *yaml.Node, timeout time.Duration) *LoadError {
+	t.Helper()
+	resultCh := make(chan *LoadError, 1)
+	go func() {
+		resultCh <- validateSourceGraph(path, doc)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-resultCh:
+		return err
+	case <-timer.C:
+		t.Fatalf("validateSourceGraph(%q, ...) did not return within %s", path, timeout)
+		return nil
+	}
+}
+
+// TestValidateSourceGraphAliasHopBoundary confirms the 64/65 alias-hop
+// boundary exactly: a chain of 64 consecutive alias hops succeeds, and a
+// chain of 65 fails as KindParseType, naming the consecutive-alias-hop
+// limit, the literal "64", and a positive "line N" — even though every
+// synthesized node in the chain has Line == 0, so the reported line must
+// come from the deterministic fallback rather than from any node's own
+// Line.
+func TestValidateSourceGraphAliasHopBoundary(t *testing.T) {
+	const path = "/etc/chairlift/alias-hop-boundary.yml"
+
+	t.Run("exactly 64 hops succeeds", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceAliasChain(64))
+		if err := validateSourceGraph(path, doc); err != nil {
+			t.Fatalf("validateSourceGraph(64-hop chain) = %v, want nil", err)
+		}
+	})
+
+	t.Run("65 hops fails", func(t *testing.T) {
+		doc := newSourceDocNode(buildSourceAliasChain(65))
+		err := validateSourceGraph(path, doc)
+		wantParseType(t, err, path)
+
+		if err.Err != nil {
+			t.Fatalf("err.Err = %v, want nil", err.Err)
+		}
+		wantPrefix := "config parse/type error: " + path
+		if got := err.Error(); len(got) < len(wantPrefix) || got[:len(wantPrefix)] != wantPrefix {
+			t.Fatalf("err.Error() = %q, want it to start with %q", got, wantPrefix)
+		}
+		if !strings.Contains(err.Detail, "consecutive") || !strings.Contains(err.Detail, "alias hop") {
+			t.Fatalf("err.Detail = %q, want wording identifying the consecutive alias-hop limit", err.Detail)
+		}
+		if !strings.Contains(err.Detail, "64") {
+			t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "64")
+		}
+		// Every node in the chain has Line == 0: no ancestor and no
+		// own line exists anywhere in this graph, so the fallback
+		// line 1 must be reported.
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
+		}
+	})
+}
+
+// TestValidateSourceGraphAliasHopIndependentSiblingsReset confirms more
+// than 64 independent, shallow sibling aliases succeed: each alias hops
+// only once to the same shared anchored scalar, so the consecutive-hop
+// count resets on descending from the (non-alias) sequence node into each
+// alias, and none of them individually exceeds the limit even though there
+// are far more than 64 of them in the graph.
+func TestValidateSourceGraphAliasHopIndependentSiblingsReset(t *testing.T) {
+	shared := newSourceScalarNode("shared")
+	entries := make([]*yaml.Node, 0, 100)
+	for i := 0; i < 100; i++ {
+		entries = append(entries, newSourceAliasNode(shared))
+	}
+	doc := newSourceDocNode(newSourceSequenceNode(entries...))
+
+	if err := validateSourceGraph("p", doc); err != nil {
+		t.Fatalf("validateSourceGraph(100 independent sibling aliases) = %v, want nil", err)
+	}
+}
+
+// TestValidateSourceGraphAliasHopAttributionSinglePath confirms the
+// single-path attribution case: the offending (over-limit) node has
+// Line == 0, and its only root-reachable path passes through two
+// positive-line ancestors, one directly above it (distance 1) and one
+// three edges further up (distance 3). The nearer ancestor's line must be
+// reported.
+func TestValidateSourceGraphAliasHopAttributionSinglePath(t *testing.T) {
+	const path = "/etc/chairlift/alias-hop-single-path.yml"
+
+	offending := buildSourceAliasChain(65) // Line == 0, hop count 65
+
+	near := &yaml.Node{ // distance 1 from offending
+		Kind:    yaml.MappingNode,
+		Line:    20,
+		Content: []*yaml.Node{newSourceScalarNode("near-key"), offending},
+	}
+	mid := &yaml.Node{ // distance 2, no line of its own
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{newSourceScalarNode("mid-key"), near},
+	}
+	far := &yaml.Node{ // distance 3 from offending
+		Kind:    yaml.MappingNode,
+		Line:    10,
+		Content: []*yaml.Node{newSourceScalarNode("far-key"), mid},
+	}
+	doc := newSourceDocNode(far)
+
+	err := validateSourceGraph(path, doc)
+	wantParseType(t, err, path)
+	if got := sourceDetailLine(t, err); got != 20 {
+		t.Fatalf("attributed line = %d, want 20 (the distance-1 ancestor)", got)
+	}
+}
+
+// TestValidateSourceGraphAliasHopAttributionUnequalDistanceSharedNode is
+// the mandatory review-round-1 case: the offending (over-limit, Line == 0)
+// node is a single shared *yaml.Node reachable via two different paths —
+// one where it sits three content edges below positive-line ancestor A,
+// and a shorter one where it sits one content edge below a different
+// positive-line ancestor B. The nearer ancestor B's line must win
+// regardless of which path the deterministic depth-first walk happens to
+// discover first, so this is asserted with B's edge ordered both after and
+// before A's in the root mapping's Content — proving the result cannot
+// depend on encounter order.
+func TestValidateSourceGraphAliasHopAttributionUnequalDistanceSharedNode(t *testing.T) {
+	const path = "/etc/chairlift/alias-hop-unequal-distance.yml"
+
+	build := func(nearFirst bool) *yaml.Node {
+		offending := buildSourceAliasChain(65) // shared node, Line == 0
+
+		// Path through A: three edges from ancestorA down to offending.
+		nearA2 := newSourceMappingNode(newSourceScalarNode("a2"), offending)
+		nearA1 := newSourceMappingNode(newSourceScalarNode("a1"), nearA2)
+		ancestorA := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Line:    99,
+			Content: []*yaml.Node{newSourceScalarNode("a0"), nearA1},
+		}
+
+		// Path through B: one edge from ancestorB down to the same
+		// shared offending node.
+		ancestorB := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Line:    7,
+			Content: []*yaml.Node{newSourceScalarNode("b0"), offending},
+		}
+
+		var root *yaml.Node
+		if nearFirst {
+			root = newSourceMappingNode(
+				newSourceScalarNode("near"), ancestorB,
+				newSourceScalarNode("far"), ancestorA,
+			)
+		} else {
+			root = newSourceMappingNode(
+				newSourceScalarNode("far"), ancestorA,
+				newSourceScalarNode("near"), ancestorB,
+			)
+		}
+		return newSourceDocNode(root)
+	}
+
+	t.Run("nearer ancestor ordered after the farther one", func(t *testing.T) {
+		err := validateSourceGraph(path, build(false))
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 7 {
+			t.Fatalf("attributed line = %d, want 7 (the nearer ancestor B)", got)
+		}
+	})
+
+	t.Run("nearer ancestor ordered first", func(t *testing.T) {
+		err := validateSourceGraph(path, build(true))
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 7 {
+			t.Fatalf("attributed line = %d, want 7 (the nearer ancestor B)", got)
+		}
+	})
+}
+
+// TestValidateSourceGraphAliasSharingDAGTerminatesLinearly builds a
+// compact alias-sharing DAG of ~40 doubling levels — a naive per-path
+// traversal would need to expand on the order of 2^40 paths — and confirms
+// validateSourceGraph (which runs both the pre-existing traversal and this
+// chunk's inventory/attribution/hop-count passes) returns well within a
+// five-second test-local timeout, proving all of them are linear in the
+// graph's node and edge count rather than re-expanding shared subgraphs.
+func TestValidateSourceGraphAliasSharingDAGTerminatesLinearly(t *testing.T) {
+	doc := newSourceDocNode(buildSourceSharingDAG(40))
+	if err := runSourceValidateWithin(t, "p", doc, 5*time.Second); err != nil {
+		t.Fatalf("validateSourceGraph(compact alias-sharing DAG) = %v, want nil", err)
+	}
+}

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -86,9 +86,15 @@ func sourceGraphError(path, detail string) *LoadError {
 // yaml.v3 kinds. Node identity (not value equality) drives cycle
 // detection, so a node reachable through several parents is validated once
 // and re-encountering a node still on the active traversal path is
-// rejected as an alias cycle. This validation covers structural
-// well-formedness only: merge-operand shape, duplicate-key detection, and
-// the alias-hop/path-visit bounds are out of this function's scope.
+// rejected as an alias cycle. Every mapping entry whose key is a merge key
+// (isMergeKey) additionally has its value validated as a merge operand
+// (validateMergeOperand): a mapping, an alias whose immediate target is a
+// mapping, or a sequence of those, checked wherever such an entry is
+// reachable — including a branch a later merge-precedence pass would
+// discard, and inside a complex mapping key's own subtree. This validation
+// covers structural well-formedness and merge-operand shape; duplicate-key
+// detection and the alias-hop/path-visit bounds are out of this function's
+// scope.
 func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
 	if doc == nil {
 		return nil
@@ -144,6 +150,11 @@ func walkSourceNode(path string, n *yaml.Node, states map[*yaml.Node]nodeState) 
 			if err := walkSourceNode(path, value, states); err != nil {
 				return err
 			}
+			if isMergeKey(key) {
+				if err := validateMergeOperand(path, value); err != nil {
+					return err
+				}
+			}
 		}
 	case yaml.SequenceNode:
 		for _, entry := range n.Content {
@@ -174,4 +185,47 @@ func walkSourceNode(path string, n *yaml.Node, states map[*yaml.Node]nodeState) 
 
 	states[n] = done
 	return nil
+}
+
+// validateMergeOperand rejects a "<<" merge key's value unless it has one
+// of the shapes gopkg.in/yaml.v3 v3.0.1 decode.go's merge/failWantMap logic
+// accepts: a MappingNode; an AliasNode whose immediate Alias target is a
+// MappingNode (an alias-to-alias-to-mapping chain is well-formed ordinary
+// YAML content but is rejected here, because yaml.v3 unwraps only one alias
+// hop for a merge operand); or a SequenceNode each of whose entries is
+// itself one of the two prior shapes. Everything else — a scalar, an alias
+// to a sequence or scalar, or a sequence containing a non-mapping entry —
+// is a KindParseType error. value's own structural well-formedness (nil
+// entries, unsupported kinds, cycles) has already been proven by the
+// caller's walkSourceNode call before this runs, so only operand shape is
+// checked here.
+func validateMergeOperand(path string, value *yaml.Node) *LoadError {
+	if isMergeOperandMapping(value) {
+		return nil
+	}
+	if value != nil && value.Kind == yaml.SequenceNode {
+		for _, entry := range value.Content {
+			if !isMergeOperandMapping(entry) {
+				return sourceGraphError(path, "merge key sequence entry is not a mapping or an alias to a mapping")
+			}
+		}
+		return nil
+	}
+	return sourceGraphError(path, "merge key value must be a mapping, an alias to a mapping, or a sequence of those")
+}
+
+// isMergeOperandMapping reports whether n is directly a yaml.MappingNode or
+// a yaml.AliasNode whose immediate Alias target is a yaml.MappingNode. It
+// deliberately follows at most one alias hop: an alias-to-alias-to-mapping
+// chain returns false here even though it is a valid ordinary YAML value,
+// reproducing yaml.v3 v3.0.1's merge-operand rule exactly (interpretation:
+// merge alias operands use the immediate target only).
+func isMergeOperandMapping(n *yaml.Node) bool {
+	if n == nil {
+		return false
+	}
+	if n.Kind == yaml.MappingNode {
+		return true
+	}
+	return n.Kind == yaml.AliasNode && n.Alias != nil && n.Alias.Kind == yaml.MappingNode
 }

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -46,3 +46,132 @@ func isMergeKey(n *yaml.Node) bool {
 	return n.Kind == yaml.ScalarNode && n.Value == "<<" &&
 		(n.Tag == "" || n.Tag == "!" || shortYAMLTag(n.Tag) == "!!merge")
 }
+
+// nodeState tracks a *yaml.Node's traversal progress by node identity (map
+// key is the pointer itself, not any decoded value) so that a node reached
+// through more than one parent is walked exactly once: unseen nodes are
+// absent from the map, visiting marks a node currently on the active
+// depth-first path (re-encountering one is an alias cycle), and done marks
+// a node that was already fully validated and whose result may be reused.
+type nodeState int
+
+const (
+	visiting nodeState = iota
+	done
+)
+
+// sourceGraphError builds a KindParseType *LoadError for a structural
+// defect found while validating a source graph. These are pure shape
+// rejections with no underlying Go error to preserve, so Err is left nil;
+// LoadError.Error() still renders the "config parse/type error: <path>:
+// <detail>" wording from Path and Detail alone.
+func sourceGraphError(path, detail string) *LoadError {
+	return &LoadError{Path: path, Kind: KindParseType, Detail: detail}
+}
+
+// validateSourceGraph walks every node and content edge reachable from doc
+// — through document content, mapping keys, mapping values, sequence
+// entries, and alias targets, in each node's Content slice order — and
+// rejects malformed source graphs as a KindParseType *LoadError without
+// panicking, even when doc is a synthetic *yaml.Node tree unreachable from
+// real YAML text.
+//
+// doc == nil succeeds: it is parseYAMLDocument's valid empty-input result.
+// Otherwise doc must be a yaml.DocumentNode with exactly one non-nil child;
+// every reachable mapping must have an even number of non-nil key/value
+// content entries; every reachable sequence must have only non-nil
+// entries; every reachable scalar must have no content children; every
+// reachable alias must have no content children and a non-nil Alias
+// target; and every reachable node's Kind must be one of the supported
+// yaml.v3 kinds. Node identity (not value equality) drives cycle
+// detection, so a node reachable through several parents is validated once
+// and re-encountering a node still on the active traversal path is
+// rejected as an alias cycle. This validation covers structural
+// well-formedness only: merge-operand shape, duplicate-key detection, and
+// the alias-hop/path-visit bounds are out of this function's scope.
+func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind != yaml.DocumentNode {
+		return sourceGraphError(path, "source document root is not a YAML document node")
+	}
+	if len(doc.Content) != 1 {
+		return sourceGraphError(path, "source document must contain exactly one top-level node")
+	}
+	if doc.Content[0] == nil {
+		return sourceGraphError(path, "source document top-level node is nil")
+	}
+
+	states := make(map[*yaml.Node]nodeState)
+	return walkSourceNode(path, doc.Content[0], states)
+}
+
+// walkSourceNode validates a single reachable node and, on success,
+// recurses into its content edges in Content slice order. states records
+// each node's traversal progress by pointer identity; a node absent from
+// states is unseen, one present with visiting is on the active
+// depth-first path (so re-encountering it is a cycle), and one present
+// with done was already fully validated.
+func walkSourceNode(path string, n *yaml.Node, states map[*yaml.Node]nodeState) *LoadError {
+	if n == nil {
+		return sourceGraphError(path, "source graph has a nil node")
+	}
+	if state, seen := states[n]; seen {
+		if state == visiting {
+			return sourceGraphError(path, "source graph contains an alias cycle")
+		}
+		return nil
+	}
+	states[n] = visiting
+
+	switch n.Kind {
+	case yaml.MappingNode:
+		if len(n.Content)%2 != 0 {
+			return sourceGraphError(path, "mapping node has an odd number of content entries")
+		}
+		for i := 0; i < len(n.Content); i += 2 {
+			key, value := n.Content[i], n.Content[i+1]
+			if key == nil {
+				return sourceGraphError(path, "mapping node has a nil key")
+			}
+			if value == nil {
+				return sourceGraphError(path, "mapping node has a nil value")
+			}
+			if err := walkSourceNode(path, key, states); err != nil {
+				return err
+			}
+			if err := walkSourceNode(path, value, states); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, entry := range n.Content {
+			if entry == nil {
+				return sourceGraphError(path, "sequence node has a nil entry")
+			}
+			if err := walkSourceNode(path, entry, states); err != nil {
+				return err
+			}
+		}
+	case yaml.ScalarNode:
+		if len(n.Content) != 0 {
+			return sourceGraphError(path, "scalar node has unexpected content")
+		}
+	case yaml.AliasNode:
+		if len(n.Content) != 0 {
+			return sourceGraphError(path, "alias node has unexpected content")
+		}
+		if n.Alias == nil {
+			return sourceGraphError(path, "alias node has no target")
+		}
+		if err := walkSourceNode(path, n.Alias, states); err != nil {
+			return err
+		}
+	default:
+		return sourceGraphError(path, "source graph node has an unsupported kind")
+	}
+
+	states[n] = done
+	return nil
+}

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -119,7 +119,7 @@ func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
 	if err := walkSourceNode(path, doc.Content[0], states); err != nil {
 		return err
 	}
-	return checkSourceGraphBounds(path, doc.Content[0])
+	return checkSourceGraphBounds(path, doc)
 }
 
 // walkSourceNode validates a single reachable node and, on success,

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -96,9 +96,11 @@ func sourceGraphError(path, detail string) *LoadError {
 // mapping's explicit keys must also be pairwise unique under sourceKeyID
 // identity (checkDuplicateMappingKeys), checked per mapping rather than
 // globally, so the same key value may recur in a sibling or nested mapping
-// without conflict. This validation covers structural well-formedness,
-// merge-operand shape, and duplicate-key detection; the alias-hop/path-visit
-// bounds are out of this function's scope.
+// without conflict. Once every reachable node passes those checks and the
+// graph is thereby proven acyclic, checkSourceGraphBounds (sourcebounds.go)
+// runs as a second pass rejecting a graph exceeding the maximum of 64
+// consecutive alias hops; the maximum-128-source-node-visits bound is out
+// of this function's scope as of this writing.
 func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
 	if doc == nil {
 		return nil
@@ -114,7 +116,10 @@ func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
 	}
 
 	states := make(map[*yaml.Node]nodeState)
-	return walkSourceNode(path, doc.Content[0], states)
+	if err := walkSourceNode(path, doc.Content[0], states); err != nil {
+		return err
+	}
+	return checkSourceGraphBounds(path, doc.Content[0])
 }
 
 // walkSourceNode validates a single reachable node and, on success,

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// longYAMLTagPrefix is the "tag:yaml.org,2002:" canonical-tag prefix that
+// gopkg.in/yaml.v3 v3.0.1 resolve.go defines as longTagPrefix and that
+// shortYAMLTag strips when normalizing a tag to its short "!!" form.
+const longYAMLTagPrefix = "tag:yaml.org,2002:"
+
+// shortYAMLTag reproduces gopkg.in/yaml.v3 v3.0.1 resolve.go:shortTag's
+// rewrite of a canonical "tag:yaml.org,2002:xxx" tag to yaml.v3's short
+// "!!xxx" form. A tag that does not carry the long prefix — including the
+// empty tag, the bare "!" non-specific tag, an already-short "!!xxx" tag, a
+// custom "!xxx" tag, or a long tag under a different authority
+// (e.g. "tag:example.com,2020:merge") — is returned unchanged, exactly as
+// shortTag leaves it. yaml.v3's shortTag additionally special-cases a small
+// set of well-known tags (null, bool, str, int, float, timestamp, seq, map,
+// binary, merge) through a lookup table, but that table always yields the
+// same "!!" + suffix result the plain prefix-strip produces for those tags,
+// so this reproduction needs no such table to match its behavior exactly.
+func shortYAMLTag(tag string) string {
+	if strings.HasPrefix(tag, longYAMLTagPrefix) {
+		return "!!" + tag[len(longYAMLTagPrefix):]
+	}
+	return tag
+}
+
+// isMergeKey reproduces gopkg.in/yaml.v3 v3.0.1 decode.go:isMerge's
+// predicate for recognizing a YAML merge key ("<<"): n must be a
+// yaml.ScalarNode whose Value is exactly "<<", and whose Tag is either
+// absent ("", the implicit/unresolved tag), the bare non-specific tag
+// ("!"), or resolves via shortYAMLTag to the short merge tag ("!!merge") —
+// which accepts both that short form directly and its canonical long form
+// ("tag:yaml.org,2002:merge"). A quoted "<<" (explicitly tagged "!!str") is
+// therefore an ordinary key, not a merge key, and so is any node whose
+// Value isn't literally "<<" regardless of its tag. n may be nil; isMergeKey
+// reports false rather than panicking.
+func isMergeKey(n *yaml.Node) bool {
+	if n == nil {
+		return false
+	}
+	return n.Kind == yaml.ScalarNode && n.Value == "<<" &&
+		(n.Tag == "" || n.Tag == "!" || shortYAMLTag(n.Tag) == "!!merge")
+}

--- a/internal/config/sourcegraph.go
+++ b/internal/config/sourcegraph.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -91,10 +92,13 @@ func sourceGraphError(path, detail string) *LoadError {
 // (validateMergeOperand): a mapping, an alias whose immediate target is a
 // mapping, or a sequence of those, checked wherever such an entry is
 // reachable — including a branch a later merge-precedence pass would
-// discard, and inside a complex mapping key's own subtree. This validation
-// covers structural well-formedness and merge-operand shape; duplicate-key
-// detection and the alias-hop/path-visit bounds are out of this function's
-// scope.
+// discard, and inside a complex mapping key's own subtree. Every reachable
+// mapping's explicit keys must also be pairwise unique under sourceKeyID
+// identity (checkDuplicateMappingKeys), checked per mapping rather than
+// globally, so the same key value may recur in a sibling or nested mapping
+// without conflict. This validation covers structural well-formedness,
+// merge-operand shape, and duplicate-key detection; the alias-hop/path-visit
+// bounds are out of this function's scope.
 func validateSourceGraph(path string, doc *yaml.Node) *LoadError {
 	if doc == nil {
 		return nil
@@ -155,6 +159,9 @@ func walkSourceNode(path string, n *yaml.Node, states map[*yaml.Node]nodeState) 
 					return err
 				}
 			}
+		}
+		if err := checkDuplicateMappingKeys(path, n); err != nil {
+			return err
 		}
 	case yaml.SequenceNode:
 		for _, entry := range n.Content {
@@ -228,4 +235,57 @@ func isMergeOperandMapping(n *yaml.Node) bool {
 		return true
 	}
 	return n.Kind == yaml.AliasNode && n.Alias != nil && n.Alias.Kind == yaml.MappingNode
+}
+
+// sourceKeyID identifies a mapping key for duplicate-key detection using
+// exactly gopkg.in/yaml.v3 v3.0.1 decode.go's uniqueKeys predicate (inside
+// decoder.mapping): two keys are the same key when their Kind and Value
+// match, nothing else. Deliberately no third field is compared, even though
+// docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md
+// requires that omitted third field for *merge/dedup key identity*
+// elsewhere in this package. This is a narrow, intentional exception:
+// yaml.v3's own duplicate-key guard never looks at that field either, so a
+// faithful reproduction means a bare `1` (resolved !!int) and a quoted "1"
+// (explicit !!str) collide as the same key here, exactly as yaml.Unmarshal
+// itself would report them with its default UniqueKeys(true) behavior.
+// Later merge-precedence identity (a different, not-yet-implemented
+// concern) is expected to need that third field and will not reuse
+// sourceKeyID.
+type sourceKeyID struct {
+	Kind  yaml.Kind
+	Value string
+}
+
+// checkDuplicateMappingKeys rejects a mapping n whose reachable explicit
+// keys are not pairwise unique under sourceKeyID identity (see its doc
+// comment for exactly what "unique" means here), as a KindParseType
+// *LoadError naming the repeated key's value and, when the parser recorded
+// a positive line for it, that line. It assumes the caller (walkSourceNode)
+// has already rejected an odd content count and any nil key/value, so every
+// key at an even index is non-nil.
+//
+// Unlike gopkg.in/yaml.v3 v3.0.1 decode.go's uniqueKeys loop — which nests
+// a second index j over i+2..l inside the first, an O(k^2) pairwise
+// comparison per mapping — this builds one hash set per mapping, sized
+// from len(n.Content)/2, and makes a single linear pass over key indices:
+// O(k) per mapping and O(V+E) over the whole reachable graph. This is a
+// deliberate departure from yaml.v3's own (quadratic) implementation while
+// reproducing its comparison exactly; a mapping with tens of thousands of
+// distinct keys must not make the validator's own running time blow up the
+// way the pairwise loop would.
+func checkDuplicateMappingKeys(path string, n *yaml.Node) *LoadError {
+	seen := make(map[sourceKeyID]struct{}, len(n.Content)/2)
+	for i := 0; i < len(n.Content); i += 2 {
+		key := n.Content[i]
+		id := sourceKeyID{Kind: key.Kind, Value: key.Value}
+		if _, dup := seen[id]; dup {
+			detail := fmt.Sprintf("mapping key %q is duplicated", key.Value)
+			if key.Line > 0 {
+				detail = fmt.Sprintf("mapping key %q is duplicated (line %d)", key.Value, key.Line)
+			}
+			return sourceGraphError(path, detail)
+		}
+		seen[id] = struct{}{}
+	}
+	return nil
 }

--- a/internal/config/sourcegraph_test.go
+++ b/internal/config/sourcegraph_test.go
@@ -6,6 +6,246 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// scalarNode builds a well-formed yaml.ScalarNode with the given value, for
+// use as filler content (mapping keys/values, sequence entries) in
+// synthetic source-graph tests.
+func scalarNode(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: value}
+}
+
+// wantParseType fails the test unless err is a non-nil *LoadError with
+// Kind == KindParseType and Path == path.
+func wantParseType(t *testing.T, err *LoadError, path string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("validateSourceGraph(%q, ...) = nil, want a KindParseType error", path)
+	}
+	if err.Kind != KindParseType {
+		t.Fatalf("err.Kind = %q, want %q", err.Kind, KindParseType)
+	}
+	if err.Path != path {
+		t.Fatalf("err.Path = %q, want %q", err.Path, path)
+	}
+}
+
+// TestValidateSourceGraphNilDoc confirms nil doc succeeds: it is
+// parseYAMLDocument's valid empty-input result.
+func TestValidateSourceGraphNilDoc(t *testing.T) {
+	if err := validateSourceGraph("p", nil); err != nil {
+		t.Fatalf("validateSourceGraph(\"p\", nil) = %v, want nil", err)
+	}
+}
+
+// TestValidateSourceGraphRootShape covers the four ways a non-nil root can
+// fail the top-level document shape check, each as its own case, each
+// asserting KindParseType with Path == the path argument.
+func TestValidateSourceGraphRootShape(t *testing.T) {
+	const path = "/etc/chairlift/root-shape.yml"
+
+	tests := []struct {
+		name string
+		root *yaml.Node
+	}{
+		{
+			name: "root is not a document node",
+			root: &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("k"), scalarNode("v")}},
+		},
+		{
+			name: "document node with zero children",
+			root: &yaml.Node{Kind: yaml.DocumentNode, Content: nil},
+		},
+		{
+			name: "document node with two children",
+			root: &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{scalarNode("a"), scalarNode("b")}},
+		},
+		{
+			name: "document node with a nil child",
+			root: &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{nil}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantParseType(t, validateSourceGraph(path, tt.root), path)
+		})
+	}
+}
+
+// TestValidateSourceGraphValidNestedDocument builds a document mixing
+// mappings, sequences, scalars, and an alias to an earlier anchor, and
+// confirms it validates cleanly.
+func TestValidateSourceGraphValidNestedDocument(t *testing.T) {
+	anchored := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Anchor:  "shared",
+		Content: []*yaml.Node{scalarNode("name"), scalarNode("shared-value")},
+	}
+	alias := &yaml.Node{Kind: yaml.AliasNode, Alias: anchored}
+	seq := &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{scalarNode("item1"), alias, scalarNode("item2")},
+	}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("shared"), anchored,
+			scalarNode("list"), seq,
+			scalarNode("scalar"), scalarNode("value"),
+		},
+	}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+
+	if err := validateSourceGraph("p", doc); err != nil {
+		t.Fatalf("validateSourceGraph(valid nested document) = %v, want nil", err)
+	}
+}
+
+// TestValidateSourceGraphStructuralRejections covers every synthetic
+// malformed-shape case as its own subtest: none of these graphs are
+// reachable from real YAML text, so a panic here fails the test just as
+// surely as a wrong error would.
+func TestValidateSourceGraphStructuralRejections(t *testing.T) {
+	const path = "/etc/chairlift/structural.yml"
+
+	oddMapping := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("onlykey")},
+	}
+	nilKeyMapping := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{nil, scalarNode("v")},
+	}
+	nilValueMapping := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("k"), nil},
+	}
+	nilEntrySequence := &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{scalarNode("a"), nil},
+	}
+	scalarWithContent := &yaml.Node{
+		Kind:    yaml.ScalarNode,
+		Value:   "x",
+		Content: []*yaml.Node{scalarNode("unexpected")},
+	}
+	aliasWithContent := &yaml.Node{
+		Kind:    yaml.AliasNode,
+		Alias:   scalarNode("target"),
+		Content: []*yaml.Node{scalarNode("unexpected")},
+	}
+	aliasWithNilTarget := &yaml.Node{
+		Kind:  yaml.AliasNode,
+		Alias: nil,
+	}
+	zeroKindNode := &yaml.Node{Kind: yaml.Kind(0)}
+	unsupportedKindNode := &yaml.Node{Kind: yaml.Kind(99)}
+
+	tests := []struct {
+		name string
+		root *yaml.Node
+	}{
+		{name: "mapping with odd content length", root: oddMapping},
+		{name: "mapping with a nil key", root: nilKeyMapping},
+		{name: "mapping with a nil value", root: nilValueMapping},
+		{name: "sequence with a nil entry", root: nilEntrySequence},
+		{name: "scalar node with non-empty content", root: scalarWithContent},
+		{name: "alias node with non-empty content", root: aliasWithContent},
+		{name: "alias node with nil Alias", root: aliasWithNilTarget},
+		{name: "node with Kind 0", root: zeroKindNode},
+		{name: "node with an unsupported Kind value", root: unsupportedKindNode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{tt.root}}
+			wantParseType(t, validateSourceGraph(path, doc), path)
+		})
+	}
+}
+
+// TestValidateSourceGraphAliasCycles builds a self alias cycle (a mapping
+// value aliasing its own enclosing anchored mapping) and a mutual alias
+// cycle (two anchored mappings aliasing each other), and confirms each is
+// rejected as KindParseType, proving the traversal terminates rather than
+// hanging or overflowing the stack.
+func TestValidateSourceGraphAliasCycles(t *testing.T) {
+	const path = "/etc/chairlift/cycles.yml"
+
+	t.Run("self alias cycle", func(t *testing.T) {
+		self := &yaml.Node{Kind: yaml.MappingNode, Anchor: "self"}
+		selfAlias := &yaml.Node{Kind: yaml.AliasNode, Alias: self}
+		self.Content = []*yaml.Node{scalarNode("key"), selfAlias}
+
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{self}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+
+	t.Run("mutual alias cycle", func(t *testing.T) {
+		m1 := &yaml.Node{Kind: yaml.MappingNode, Anchor: "m1"}
+		m2 := &yaml.Node{Kind: yaml.MappingNode, Anchor: "m2"}
+		aliasToM2 := &yaml.Node{Kind: yaml.AliasNode, Alias: m2}
+		aliasToM1 := &yaml.Node{Kind: yaml.AliasNode, Alias: m1}
+		m1.Content = []*yaml.Node{scalarNode("key1"), aliasToM2}
+		m2.Content = []*yaml.Node{scalarNode("key2"), aliasToM1}
+
+		root := &yaml.Node{
+			Kind:    yaml.SequenceNode,
+			Content: []*yaml.Node{m1, m2},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+}
+
+// TestValidateSourceGraphNodeIdentityNotValueEquality proves node identity,
+// not value equality, drives the seen-state map: the same *yaml.Node
+// pointer is a child of several parents (a shared scalar reused as several
+// mapping values, and a shared mapping reused as several sequence
+// entries), which must be accepted without falsely reporting a cycle.
+func TestValidateSourceGraphNodeIdentityNotValueEquality(t *testing.T) {
+	sharedScalar := scalarNode("shared")
+	sharedMapping := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("k"), scalarNode("v")},
+	}
+
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("a"), sharedScalar,
+			scalarNode("b"), sharedScalar,
+			scalarNode("seq"), &yaml.Node{
+				Kind:    yaml.SequenceNode,
+				Content: []*yaml.Node{sharedMapping, sharedMapping, sharedMapping},
+			},
+		},
+	}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+
+	if err := validateSourceGraph("p", doc); err != nil {
+		t.Fatalf("validateSourceGraph(shared node graph) = %v, want nil", err)
+	}
+}
+
+// TestValidateSourceGraphNilErrRenders confirms a validator-detected graph
+// error may have Err == nil while Error() still renders the parse/type
+// wording, since these are pure shape rejections with no underlying Go
+// error to preserve.
+func TestValidateSourceGraphNilErrRenders(t *testing.T) {
+	const path = "/etc/chairlift/nil-err.yml"
+
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: nil}
+	err := validateSourceGraph(path, doc)
+	wantParseType(t, err, path)
+
+	if err.Err != nil {
+		t.Fatalf("err.Err = %v, want nil", err.Err)
+	}
+	if got, want := err.Error(), "config parse/type error: "+path; got == "" || got[:len(want)] != want {
+		t.Fatalf("err.Error() = %q, want it to start with %q", got, want)
+	}
+}
+
 // TestMergeKeyRecognition exercises isMergeKey directly against
 // gopkg.in/yaml.v3 v3.0.1 decode.go:isMerge's exact predicate: a
 // yaml.ScalarNode with Value "<<" and a Tag that is either absent, the bare

--- a/internal/config/sourcegraph_test.go
+++ b/internal/config/sourcegraph_test.go
@@ -246,6 +246,314 @@ func TestValidateSourceGraphNilErrRenders(t *testing.T) {
 	}
 }
 
+// mergeKeyNode builds a well-formed implicit-tag "<<" merge key scalar
+// node, for use as a mapping key in merge-operand source-graph tests.
+func mergeKeyNode() *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: "<<"}
+}
+
+// simpleMapping builds a one-entry well-formed yaml.MappingNode, used as a
+// merge operand's mapping-shaped filler content.
+func simpleMapping(key, value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode(key), scalarNode(value)}}
+}
+
+// TestValidateSourceGraphMergeOperandAccepted covers every merge-operand
+// shape yaml.v3 v3.0.1 accepts: a mapping literal; an alias to a mapping;
+// a sequence of aliases to mappings; and a sequence mixing an inline
+// mapping with an alias to a mapping.
+func TestValidateSourceGraphMergeOperandAccepted(t *testing.T) {
+	anchoredA := &yaml.Node{Kind: yaml.MappingNode, Anchor: "a", Content: []*yaml.Node{scalarNode("ka"), scalarNode("va")}}
+	anchoredB := &yaml.Node{Kind: yaml.MappingNode, Anchor: "b", Content: []*yaml.Node{scalarNode("kb"), scalarNode("vb")}}
+
+	tests := []struct {
+		name  string
+		value *yaml.Node
+	}{
+		{
+			name:  "mapping literal",
+			value: simpleMapping("k", "v"),
+		},
+		{
+			name:  "alias to a mapping",
+			value: &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredA},
+		},
+		{
+			name: "sequence of two aliases both to mappings",
+			value: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				{Kind: yaml.AliasNode, Alias: anchoredA},
+				{Kind: yaml.AliasNode, Alias: anchoredB},
+			}},
+		},
+		{
+			name: "sequence mixing an inline mapping and an alias to a mapping",
+			value: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				simpleMapping("k", "v"),
+				{Kind: yaml.AliasNode, Alias: anchoredA},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &yaml.Node{
+				Kind:    yaml.MappingNode,
+				Content: []*yaml.Node{mergeKeyNode(), tt.value, scalarNode("anchors"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{anchoredA, anchoredB}}},
+			}
+			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+			if err := validateSourceGraph("p", doc); err != nil {
+				t.Fatalf("validateSourceGraph(merge operand %s) = %v, want nil", tt.name, err)
+			}
+		})
+	}
+}
+
+// TestValidateSourceGraphMergeOperandRejected covers every merge-operand
+// shape yaml.v3 v3.0.1 rejects, each its own case returning KindParseType
+// with Path copied: a scalar operand; an alias to a sequence; an alias to
+// a scalar; an alias whose immediate target is itself an AliasNode that
+// ultimately resolves to a mapping (the immediate-target-only rule); a
+// sequence containing a scalar; a sequence containing a sequence; and a
+// sequence containing an alias to a non-mapping.
+func TestValidateSourceGraphMergeOperandRejected(t *testing.T) {
+	const path = "/etc/chairlift/merge-rejected.yml"
+
+	anchoredMapping := &yaml.Node{Kind: yaml.MappingNode, Anchor: "m", Content: []*yaml.Node{scalarNode("k"), scalarNode("v")}}
+	anchoredSeq := &yaml.Node{Kind: yaml.SequenceNode, Anchor: "s", Content: []*yaml.Node{scalarNode("item")}}
+	anchoredScalar := &yaml.Node{Kind: yaml.ScalarNode, Anchor: "sc", Value: "scalar-anchor"}
+	// aliasToMapping is itself anchored, so a second alias can target it
+	// (an alias-to-alias) rather than the mapping directly.
+	aliasToMapping := &yaml.Node{Kind: yaml.AliasNode, Anchor: "alias-to-mapping", Alias: anchoredMapping}
+
+	tests := []struct {
+		name  string
+		value *yaml.Node
+	}{
+		{
+			name:  "scalar operand",
+			value: scalarNode("5"),
+		},
+		{
+			name:  "alias to a sequence",
+			value: &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredSeq},
+		},
+		{
+			name:  "alias to a scalar",
+			value: &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredScalar},
+		},
+		{
+			name:  "alias whose immediate target is itself an alias that ultimately resolves to a mapping",
+			value: &yaml.Node{Kind: yaml.AliasNode, Alias: aliasToMapping},
+		},
+		{
+			name: "sequence containing a scalar",
+			value: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				simpleMapping("k", "v"), scalarNode("not a mapping"),
+			}},
+		},
+		{
+			name: "sequence containing a sequence",
+			value: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				simpleMapping("k", "v"),
+				{Kind: yaml.SequenceNode, Content: []*yaml.Node{scalarNode("nested")}},
+			}},
+		},
+		{
+			name: "sequence containing an alias to a non-mapping",
+			value: &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+				simpleMapping("k", "v"),
+				{Kind: yaml.AliasNode, Alias: anchoredScalar},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := &yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					mergeKeyNode(), tt.value,
+					scalarNode("anchors"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+						anchoredMapping, anchoredSeq, anchoredScalar, aliasToMapping,
+					}},
+				},
+			}
+			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+			wantParseType(t, validateSourceGraph(path, doc), path)
+		})
+	}
+}
+
+// TestValidateSourceGraphMergeAliasChainAsymmetry pins the immediate-target
+// rule's asymmetry: an alias-to-alias-to-mapping chain is well-formed
+// ordinary YAML content when it is an ordinary mapping value (returns nil),
+// but is a malformed merge operand when the same chain is used as a "<<"
+// value (returns KindParseType), because yaml.v3 v3.0.1 only unwraps one
+// alias hop for a merge operand.
+func TestValidateSourceGraphMergeAliasChainAsymmetry(t *testing.T) {
+	buildChain := func() (mapping, innerAlias, outerAlias *yaml.Node) {
+		mapping = &yaml.Node{Kind: yaml.MappingNode, Anchor: "target", Content: []*yaml.Node{scalarNode("k"), scalarNode("v")}}
+		innerAlias = &yaml.Node{Kind: yaml.AliasNode, Anchor: "inner", Alias: mapping}
+		outerAlias = &yaml.Node{Kind: yaml.AliasNode, Alias: innerAlias}
+		return
+	}
+
+	t.Run("as an ordinary mapping value", func(t *testing.T) {
+		mapping, innerAlias, outerAlias := buildChain()
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				scalarNode("target"), mapping,
+				scalarNode("inner"), innerAlias,
+				scalarNode("ordinary"), outerAlias,
+			},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("validateSourceGraph(alias chain as ordinary value) = %v, want nil", err)
+		}
+	})
+
+	t.Run("as a merge operand", func(t *testing.T) {
+		const path = "/etc/chairlift/merge-chain.yml"
+		mapping, innerAlias, outerAlias := buildChain()
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				scalarNode("target"), mapping,
+				scalarNode("inner"), innerAlias,
+				mergeKeyNode(), outerAlias,
+			},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+}
+
+// TestValidateSourceGraphMergeCycles confirms &a {<<: *a} (a self merge)
+// and a mutual merge cycle between two anchored mappings each return
+// KindParseType and the test terminates rather than hanging: c3's generic
+// visiting-state alias-cycle rule catches the merge operand's alias before
+// any merge-specific code inspects its shape.
+func TestValidateSourceGraphMergeCycles(t *testing.T) {
+	const path = "/etc/chairlift/merge-cycles.yml"
+
+	t.Run("self merge", func(t *testing.T) {
+		self := &yaml.Node{Kind: yaml.MappingNode, Anchor: "a"}
+		selfAlias := &yaml.Node{Kind: yaml.AliasNode, Alias: self}
+		self.Content = []*yaml.Node{mergeKeyNode(), selfAlias}
+
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{self}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+
+	t.Run("mutual merge cycle", func(t *testing.T) {
+		m1 := &yaml.Node{Kind: yaml.MappingNode, Anchor: "m1"}
+		m2 := &yaml.Node{Kind: yaml.MappingNode, Anchor: "m2"}
+		aliasToM2 := &yaml.Node{Kind: yaml.AliasNode, Alias: m2}
+		aliasToM1 := &yaml.Node{Kind: yaml.AliasNode, Alias: m1}
+		m1.Content = []*yaml.Node{mergeKeyNode(), aliasToM2}
+		m2.Content = []*yaml.Node{mergeKeyNode(), aliasToM1}
+
+		root := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{m1, m2}}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+}
+
+// TestValidateSourceGraphMergeKeyTagForms confirms all four merge-key tag
+// forms from c2 (implicit, "!", "!!merge", the canonical long tag) trigger
+// merge-operand validation — each rejecting an invalid scalar operand as
+// KindParseType — and that a quoted "<<" key (tagged "!!str") does not
+// trigger it, so a quoted "<<" key with a scalar value validates cleanly.
+func TestValidateSourceGraphMergeKeyTagForms(t *testing.T) {
+	const path = "/etc/chairlift/merge-tags.yml"
+
+	tagCases := []struct {
+		name string
+		tag  string
+	}{
+		{name: "implicit tag", tag: ""},
+		{name: "bare non-specific tag", tag: "!"},
+		{name: "short merge tag", tag: "!!merge"},
+		{name: "canonical long merge tag", tag: "tag:yaml.org,2002:merge"},
+	}
+
+	for _, tt := range tagCases {
+		t.Run(tt.name, func(t *testing.T) {
+			key := &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: tt.tag}
+			root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{key, scalarNode("not-a-mapping")}}
+			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+			wantParseType(t, validateSourceGraph(path, doc), path)
+		})
+	}
+
+	t.Run("quoted << key does not trigger merge validation", func(t *testing.T) {
+		key := &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: "!!str"}
+		root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{key, scalarNode("just a string value")}}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("validateSourceGraph(quoted << key with scalar value) = %v, want nil", err)
+		}
+	})
+}
+
+// TestValidateSourceGraphMergeInComplexKey confirms a malformed merge
+// operand nested inside a complex mapping key's own subtree returns
+// KindParseType, and that an otherwise well-formed complex mapping key
+// validates cleanly: complex keys are traversed but not classified in this
+// slice.
+func TestValidateSourceGraphMergeInComplexKey(t *testing.T) {
+	t.Run("malformed merge operand inside a complex key", func(t *testing.T) {
+		const path = "/etc/chairlift/complex-key-bad-merge.yml"
+		complexKey := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{mergeKeyNode(), scalarNode("not-a-mapping")},
+		}
+		root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{complexKey, scalarNode("value")}}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+
+	t.Run("well-formed complex key", func(t *testing.T) {
+		complexKey := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{scalarNode("nested"), scalarNode("key-value")},
+		}
+		root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{complexKey, scalarNode("value")}}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("validateSourceGraph(well-formed complex key) = %v, want nil", err)
+		}
+	})
+}
+
+// TestValidateSourceGraphMergeDiscardedBranchStillValidated confirms a
+// malformed merge operand in a mapping entry that a later merge-precedence
+// pass would discard (an earlier "<<" source overridden by a later one)
+// still returns KindParseType: this slice validates every reachable entry,
+// not just the one an effective-merge pass would keep
+// (docs/agents/skills/discarded-merge-branches-still-need-validation.md).
+func TestValidateSourceGraphMergeDiscardedBranchStillValidated(t *testing.T) {
+	const path = "/etc/chairlift/merge-discarded.yml"
+
+	// The first "<<" entry (which real merge precedence would discard in
+	// favor of the second, later "<<" entry) has a malformed scalar
+	// operand; the second is a well-formed mapping. Duplicate merge-key
+	// detection is not part of this slice (c5), so this graph reaches the
+	// malformed operand before any duplicate-key check could short-circuit
+	// it.
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), scalarNode("malformed-and-discarded"),
+			mergeKeyNode(), simpleMapping("winner-key", "winner-value"),
+		},
+	}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	wantParseType(t, validateSourceGraph(path, doc), path)
+}
+
 // TestMergeKeyRecognition exercises isMergeKey directly against
 // gopkg.in/yaml.v3 v3.0.1 decode.go:isMerge's exact predicate: a
 // yaml.ScalarNode with Value "<<" and a Tag that is either absent, the bare

--- a/internal/config/sourcegraph_test.go
+++ b/internal/config/sourcegraph_test.go
@@ -1,7 +1,12 @@
 package config
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -653,4 +658,284 @@ func TestShortYAMLTagNormalization(t *testing.T) {
 			}
 		})
 	}
+}
+
+// duplicateKeyLinePattern extracts the "line N" phrase checkDuplicateMappingKeys
+// embeds in a duplicate-key error's Detail when the parser recorded a
+// positive line for the repeated key.
+var duplicateKeyLinePattern = regexp.MustCompile(`line (\d+)`)
+
+// mergeKeyNodeWithTag builds a "<<" scalar merge-key node carrying an
+// explicit tag, for combining differently-tagged merge keys in
+// duplicate-key tests: sourceKeyID compares only Kind and Value, so two
+// "<<" keys collide as duplicates regardless of which of isMergeKey's four
+// accepted tag forms each one carries.
+func mergeKeyNodeWithTag(tag string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: tag}
+}
+
+// TestValidateSourceGraphDuplicateExplicitKey confirms a real, parsed
+// mapping with two "a:" keys is rejected as KindParseType, with Path
+// copied and a Detail that names the duplicated key's value and contains a
+// positive "line N" — using parseYAMLDocument (not a synthetic node) so
+// the key's Line field is the parser's own, genuinely positive line.
+func TestValidateSourceGraphDuplicateExplicitKey(t *testing.T) {
+	const path = "/etc/chairlift/dup.yml"
+	doc, perr := parseYAMLDocument(path, []byte("a: 1\nb: 2\na: 3\n"))
+	if perr != nil {
+		t.Fatalf("parseYAMLDocument(%q) = %v, want nil", path, perr)
+	}
+
+	err := validateSourceGraph(path, doc)
+	wantParseType(t, err, path)
+
+	if !strings.Contains(err.Detail, `"a"`) {
+		t.Fatalf("err.Detail = %q, want it to name the duplicated key %q", err.Detail, "a")
+	}
+	m := duplicateKeyLinePattern.FindStringSubmatch(err.Detail)
+	if m == nil {
+		t.Fatalf("err.Detail = %q, want it to contain a %q phrase", err.Detail, "line N")
+	}
+	line, convErr := strconv.Atoi(m[1])
+	if convErr != nil || line <= 0 {
+		t.Fatalf("err.Detail = %q parsed line %q, want a positive line number", err.Detail, m[1])
+	}
+}
+
+// TestValidateSourceGraphDuplicateMergeKeys confirms two "<<" mapping
+// entries are rejected as duplicates in each of the three tag combinations
+// the spec calls out: implicit + implicit, implicit + "!!merge", and
+// implicit + the canonical long merge tag. sourceKeyID identity never
+// looks at Tag, so all three combinations collide identically even though
+// isMergeKey treats all four tag forms as equally valid merge keys.
+func TestValidateSourceGraphDuplicateMergeKeys(t *testing.T) {
+	tagCombos := []struct {
+		name string
+		tagA string
+		tagB string
+	}{
+		{name: "implicit + implicit", tagA: "", tagB: ""},
+		{name: "implicit + !!merge", tagA: "", tagB: "!!merge"},
+		{name: "implicit + tag:yaml.org,2002:merge", tagA: "", tagB: "tag:yaml.org,2002:merge"},
+	}
+
+	for _, tt := range tagCombos {
+		t.Run(tt.name, func(t *testing.T) {
+			const path = "/etc/chairlift/dup-merge.yml"
+			root := &yaml.Node{
+				Kind: yaml.MappingNode,
+				Content: []*yaml.Node{
+					mergeKeyNodeWithTag(tt.tagA), simpleMapping("ka", "va"),
+					mergeKeyNodeWithTag(tt.tagB), simpleMapping("kb", "vb"),
+				},
+			}
+			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+			wantParseType(t, validateSourceGraph(path, doc), path)
+		})
+	}
+}
+
+// TestValidateSourceGraphDuplicateBareAndQuotedIntKey confirms a bare `1`
+// and a quoted "1" are rejected as duplicates even though yaml.v3 resolves
+// them to different Tags (!!int vs !!str): sourceKeyID identity compares
+// only Kind and Value, so the differing Tag doesn't save them. Real,
+// parsed YAML (not synthetic nodes) proves the Tags genuinely differ, the
+// same way the yaml.v3 decoder itself would resolve them.
+func TestValidateSourceGraphDuplicateBareAndQuotedIntKey(t *testing.T) {
+	const path = "/etc/chairlift/dup-int-str.yml"
+	doc, perr := parseYAMLDocument(path, []byte("1: a\n\"1\": b\n"))
+	if perr != nil {
+		t.Fatalf("parseYAMLDocument(%q) = %v, want nil", path, perr)
+	}
+	wantParseType(t, validateSourceGraph(path, doc), path)
+}
+
+// TestValidateSourceGraphDuplicateKeysArePerMappingNotGlobal confirms a
+// key value shared by two different mappings — a sibling and, separately,
+// a parent/nested pair — is not a duplicate: the seen-key set is scoped to
+// a single mapping's own Content, not shared across the whole graph.
+func TestValidateSourceGraphDuplicateKeysArePerMappingNotGlobal(t *testing.T) {
+	t.Run("sibling mappings sharing a key", func(t *testing.T) {
+		siblingA := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("1"), scalarNode("va")}}
+		siblingB := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("1"), scalarNode("vb")}}
+		root := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{scalarNode("s1"), siblingA, scalarNode("s2"), siblingB},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("sibling mappings sharing key %q = %v, want nil", "1", err)
+		}
+	})
+
+	t.Run("nested mapping sharing a key with its parent", func(t *testing.T) {
+		nested := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("1"), scalarNode("nested-value")}}
+		root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("1"), nested}}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("nested mapping sharing key %q with parent = %v, want nil", "1", err)
+		}
+	})
+}
+
+// TestValidateSourceGraphDuplicateKeysRequireSameKind confirms a scalar
+// key and an alias-node key whose Value happens to equal the scalar's
+// Value are not duplicates: sourceKeyID also requires equal Kind, and a
+// yaml.AliasNode's own Value is its anchor name, not its target's value.
+func TestValidateSourceGraphDuplicateKeysRequireSameKind(t *testing.T) {
+	target := scalarNode("target-value")
+	aliasKey := &yaml.Node{Kind: yaml.AliasNode, Value: "x", Alias: target}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("x"), scalarNode("v1"),
+			aliasKey, scalarNode("v2"),
+		},
+	}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	if err := validateSourceGraph("p", doc); err != nil {
+		t.Fatalf("scalar key %q and alias key with equal Value = %v, want nil", "x", err)
+	}
+}
+
+// TestValidateSourceGraphDuplicateKeysReachableViaMergeOperand confirms a
+// duplicate pair inside a mapping reachable only as a "<<" merge operand's
+// value is rejected.
+func TestValidateSourceGraphDuplicateKeysReachableViaMergeOperand(t *testing.T) {
+	const path = "/etc/chairlift/dup-via-merge-operand.yml"
+	operand := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("dup"), scalarNode("v1"), scalarNode("dup"), scalarNode("v2")},
+	}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{mergeKeyNode(), operand}}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	wantParseType(t, validateSourceGraph(path, doc), path)
+}
+
+// TestValidateSourceGraphDuplicateKeysReachableViaAliasTarget confirms a
+// duplicate pair inside a mapping reachable only by following an alias
+// node's target (not through any merge key) is rejected.
+func TestValidateSourceGraphDuplicateKeysReachableViaAliasTarget(t *testing.T) {
+	const path = "/etc/chairlift/dup-via-alias.yml"
+	dupMapping := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("dup"), scalarNode("v1"), scalarNode("dup"), scalarNode("v2")},
+	}
+	alias := &yaml.Node{Kind: yaml.AliasNode, Value: "a", Alias: dupMapping}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("k"), alias}}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	wantParseType(t, validateSourceGraph(path, doc), path)
+}
+
+// TestValidateSourceGraphDuplicateKeysReachableInComplexKeySubtree confirms
+// a duplicate pair inside a complex (mapping-shaped) key's own subtree is
+// rejected, even though the complex key itself is just an ordinary,
+// unclassified mapping-node key of its parent.
+func TestValidateSourceGraphDuplicateKeysReachableInComplexKeySubtree(t *testing.T) {
+	const path = "/etc/chairlift/dup-in-complex-key.yml"
+	complexKey := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("dup"), scalarNode("v1"), scalarNode("dup"), scalarNode("v2")},
+	}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{complexKey, scalarNode("value")}}
+	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+	wantParseType(t, validateSourceGraph(path, doc), path)
+}
+
+// TestValidateSourceGraphDuplicateKeysSharedMappingCheckedOnce confirms a
+// mapping node reachable through two different parent entries is checked
+// exactly once: a genuine duplicate inside it still yields a single error,
+// and a well-formed shared mapping referenced twice yields nil rather than
+// a false duplicate manufactured by revisiting it.
+func TestValidateSourceGraphDuplicateKeysSharedMappingCheckedOnce(t *testing.T) {
+	t.Run("genuine duplicate in a mapping shared by two parents", func(t *testing.T) {
+		const path = "/etc/chairlift/dup-shared.yml"
+		shared := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{scalarNode("dup"), scalarNode("v1"), scalarNode("dup"), scalarNode("v2")},
+		}
+		root := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{scalarNode("first"), shared, scalarNode("second"), shared},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		wantParseType(t, validateSourceGraph(path, doc), path)
+	})
+
+	t.Run("well-formed mapping shared by two parents", func(t *testing.T) {
+		shared := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("a"), scalarNode("va")}}
+		root := &yaml.Node{
+			Kind:    yaml.MappingNode,
+			Content: []*yaml.Node{scalarNode("first"), shared, scalarNode("second"), shared},
+		}
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+		if err := validateSourceGraph("p", doc); err != nil {
+			t.Fatalf("well-formed mapping shared by two parents = %v, want nil", err)
+		}
+	})
+}
+
+// buildDistinctKeyMapping builds a yaml.MappingNode with n distinct scalar
+// keys "k0".."k(n-1)", each mapped to a fixed scalar value, for the timed
+// duplicate-key-detection regression tests below.
+func buildDistinctKeyMapping(n int) *yaml.Node {
+	content := make([]*yaml.Node, 0, n*2)
+	for i := 0; i < n; i++ {
+		content = append(content, scalarNode(fmt.Sprintf("k%d", i)), scalarNode("v"))
+	}
+	return &yaml.Node{Kind: yaml.MappingNode, Content: content}
+}
+
+// TestValidateSourceGraphDuplicateKeyDetectionIsLinear is the discriminating
+// regression the O(k) map-based design (interpretation 12) needs and a
+// pairwise O(k^2) implementation cannot pass: a 100,000-distinct-key mapping
+// and a 100,000-key mapping whose last two keys collide must each resolve
+// within a five-second budget. A pairwise implementation needs on the order
+// of 5*10^9 comparisons for either case and would not return within budget.
+// Each subtest runs validateSourceGraph in a goroutine and races it against
+// an explicit time.Timer via select, so a hang fails the test rather than
+// blocking the suite.
+func TestValidateSourceGraphDuplicateKeyDetectionIsLinear(t *testing.T) {
+	const numKeys = 100000
+	const budget = 5 * time.Second
+
+	t.Run("100000 distinct keys returns nil", func(t *testing.T) {
+		root := buildDistinctKeyMapping(numKeys)
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+
+		result := make(chan *LoadError, 1)
+		go func() { result <- validateSourceGraph("p", doc) }()
+
+		timer := time.NewTimer(budget)
+		defer timer.Stop()
+		select {
+		case err := <-result:
+			if err != nil {
+				t.Fatalf("validateSourceGraph(100000 distinct keys) = %v, want nil", err)
+			}
+		case <-timer.C:
+			t.Fatalf("validateSourceGraph did not return within %s for 100000 distinct keys", budget)
+		}
+	})
+
+	t.Run("100000 keys with the last two identical returns KindParseType", func(t *testing.T) {
+		const path = "p"
+		root := buildDistinctKeyMapping(numKeys)
+		lastKeyIdx := len(root.Content) - 2
+		prevKeyIdx := lastKeyIdx - 2
+		root.Content[lastKeyIdx].Value = root.Content[prevKeyIdx].Value
+		doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
+
+		result := make(chan *LoadError, 1)
+		go func() { result <- validateSourceGraph(path, doc) }()
+
+		timer := time.NewTimer(budget)
+		defer timer.Stop()
+		select {
+		case err := <-result:
+			wantParseType(t, err, path)
+		case <-timer.C:
+			t.Fatalf("validateSourceGraph did not return within %s for a 100000-key mapping with a trailing duplicate", budget)
+		}
+	})
 }

--- a/internal/config/sourcegraph_test.go
+++ b/internal/config/sourcegraph_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestMergeKeyRecognition exercises isMergeKey directly against
+// gopkg.in/yaml.v3 v3.0.1 decode.go:isMerge's exact predicate: a
+// yaml.ScalarNode with Value "<<" and a Tag that is either absent, the bare
+// "!" non-specific tag, or resolves to the short merge tag "!!merge"
+// (whether already short or spelled out in canonical long form).
+func TestMergeKeyRecognition(t *testing.T) {
+	tests := []struct {
+		name string
+		node *yaml.Node
+		want bool
+	}{
+		{
+			name: "implicit tag",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: ""},
+			want: true,
+		},
+		{
+			name: "bare non-specific tag",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: "!"},
+			want: true,
+		},
+		{
+			name: "short merge tag",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: "!!merge"},
+			want: true,
+		},
+		{
+			name: "canonical long merge tag",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: "tag:yaml.org,2002:merge"},
+			want: true,
+		},
+		{
+			name: "quoted string tag is not a merge key",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "<<", Tag: "!!str"},
+			want: false,
+		},
+		{
+			name: "merge tag with different value is not a merge key",
+			node: &yaml.Node{Kind: yaml.ScalarNode, Value: "x", Tag: "!!merge"},
+			want: false,
+		},
+		{
+			name: "mapping node is not a merge key",
+			node: &yaml.Node{Kind: yaml.MappingNode, Value: "<<"},
+			want: false,
+		},
+		{
+			name: "sequence node is not a merge key",
+			node: &yaml.Node{Kind: yaml.SequenceNode, Value: "<<"},
+			want: false,
+		},
+		{
+			name: "alias node is not a merge key",
+			node: &yaml.Node{Kind: yaml.AliasNode, Value: "<<"},
+			want: false,
+		},
+		{
+			name: "nil node does not panic and is not a merge key",
+			node: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMergeKey(tt.node); got != tt.want {
+				t.Fatalf("isMergeKey(%+v) = %v, want %v", tt.node, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShortYAMLTagNormalization exercises shortYAMLTag directly against
+// gopkg.in/yaml.v3 v3.0.1 resolve.go:shortTag's rewrite of the canonical
+// "tag:yaml.org,2002:" prefix to yaml.v3's short "!!" form, and confirms
+// tags that don't carry that prefix — including a long tag under a
+// different authority — pass through unchanged.
+func TestShortYAMLTagNormalization(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{name: "canonical merge tag", tag: "tag:yaml.org,2002:merge", want: "!!merge"},
+		{name: "already-short merge tag", tag: "!!merge", want: "!!merge"},
+		{name: "empty tag", tag: "", want: ""},
+		{name: "bare non-specific tag", tag: "!", want: "!"},
+		{name: "custom tag", tag: "!custom", want: "!custom"},
+		{name: "canonical str tag", tag: "tag:yaml.org,2002:str", want: "!!str"},
+		{name: "long tag under a different authority", tag: "tag:example.com,2020:merge", want: "tag:example.com,2020:merge"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortYAMLTag(tt.tag); got != tt.want {
+				t.Fatalf("shortYAMLTag(%q) = %q, want %q", tt.tag, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/sourcegraph_test.go
+++ b/internal/config/sourcegraph_test.go
@@ -214,16 +214,25 @@ func TestValidateSourceGraphNodeIdentityNotValueEquality(t *testing.T) {
 		Content: []*yaml.Node{scalarNode("k"), scalarNode("v")},
 	}
 
+	scalarParentA := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("a"), sharedScalar},
+	}
+	scalarParentB := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("b"), sharedScalar},
+	}
+	mappingParentA := &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{sharedMapping},
+	}
+	mappingParentB := &yaml.Node{
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{sharedMapping},
+	}
 	root := &yaml.Node{
-		Kind: yaml.MappingNode,
-		Content: []*yaml.Node{
-			scalarNode("a"), sharedScalar,
-			scalarNode("b"), sharedScalar,
-			scalarNode("seq"), &yaml.Node{
-				Kind:    yaml.SequenceNode,
-				Content: []*yaml.Node{sharedMapping, sharedMapping, sharedMapping},
-			},
-		},
+		Kind:    yaml.SequenceNode,
+		Content: []*yaml.Node{scalarParentA, scalarParentB, mappingParentA, mappingParentB},
 	}
 	doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
 
@@ -303,7 +312,7 @@ func TestValidateSourceGraphMergeOperandAccepted(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			root := &yaml.Node{
 				Kind:    yaml.MappingNode,
-				Content: []*yaml.Node{mergeKeyNode(), tt.value, scalarNode("anchors"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{anchoredA, anchoredB}}},
+				Content: []*yaml.Node{mergeKeyNode(), tt.value, scalarNode("anchors"), {Kind: yaml.SequenceNode, Content: []*yaml.Node{anchoredA, anchoredB}}},
 			}
 			doc := &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{root}}
 			if err := validateSourceGraph("p", doc); err != nil {
@@ -378,7 +387,7 @@ func TestValidateSourceGraphMergeOperandRejected(t *testing.T) {
 				Kind: yaml.MappingNode,
 				Content: []*yaml.Node{
 					mergeKeyNode(), tt.value,
-					scalarNode("anchors"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+					scalarNode("anchors"), {Kind: yaml.SequenceNode, Content: []*yaml.Node{
 						anchoredMapping, anchoredSeq, anchoredScalar, aliasToMapping,
 					}},
 				},

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -154,7 +154,19 @@ func TestSourceConfigExportedSurface(t *testing.T) {
 					continue
 				}
 				if d.Recv != nil {
-					methods[d.Name.Name] = true
+					receiver := ""
+					switch typ := d.Recv.List[0].Type.(type) {
+					case *ast.Ident:
+						receiver = typ.Name
+					case *ast.StarExpr:
+						if id, ok := typ.X.(*ast.Ident); ok {
+							receiver = id.Name
+						}
+					}
+					if receiver == "" {
+						t.Fatalf("unsupported exported method receiver in %s: %T", name, d.Recv.List[0].Type)
+					}
+					methods[receiver+"."+d.Name.Name] = true
 				} else {
 					funcs[d.Name.Name] = true
 				}
@@ -180,7 +192,7 @@ func TestSourceConfigExportedSurface(t *testing.T) {
 	assertExactNameSet(t, "exported funcs", funcs,
 		[]string{"Load", "SchemaActionFields", "SchemaGroupFields", "SchemaGroups", "SchemaPages"})
 	assertExactNameSet(t, "exported methods", methods,
-		[]string{"Error", "GetGroupConfig", "IsGroupEnabled", "Unwrap"})
+		[]string{"Config.GetGroupConfig", "Config.IsGroupEnabled", "LoadError.Error", "LoadError.Unwrap"})
 	assertExactNameSet(t, "exported types", types,
 		[]string{"ActionConfig", "Config", "ErrorKind", "GroupConfig", "LoadError", "PageConfig"})
 	assertExactNameSet(t, "exported values", values,

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -1,0 +1,206 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// directCallAllowlist is the complete, frozen set of unexported
+// package-level functions that _test.go files in this package may name
+// directly (by identifier, not merely by exercising them through an
+// exported entry point). It is deliberately a permitted set rather than a
+// list of forbidden name patterns: any unexported production helper, no
+// matter what it is called, fails TestSourceHelperDirectCallSurface the
+// moment a _test.go file names it unless it is listed here.
+//
+//   - parseYAMLDocument and validateSourceGraph are the two package
+//     capabilities this multi-chunk slice adds and tests directly.
+//     validateSourceGraph does not exist yet as of this chunk; listing it
+//     now costs nothing and lets a later chunk add its direct test without
+//     touching this frozen allowlist.
+//   - isMergeKey and shortYAMLTag are the only two internal helpers the
+//     spec singles out for direct testing (exact merge-key recognition and
+//     YAML tag normalization). Like validateSourceGraph, they do not exist
+//     yet as of this chunk.
+//   - defaultConfig, loadFromPath, schemaPageGroups, yamlFieldNames and
+//     yamlTagName are a frozen pre-existing baseline: they were already
+//     named directly by config_test.go/schema_test.go before this chunk
+//     and are not widened or added to here.
+var directCallAllowlist = map[string]bool{
+	"parseYAMLDocument":   true,
+	"validateSourceGraph": true,
+	"isMergeKey":          true,
+	"shortYAMLTag":        true,
+	"defaultConfig":       true,
+	"loadFromPath":        true,
+	"schemaPageGroups":    true,
+	"yamlFieldNames":      true,
+	"yamlTagName":         true,
+}
+
+// packageGoFiles lists the *.go files directly in this package's directory
+// (the working directory `go test` runs in), split by whether they are
+// _test.go files.
+func packageGoFiles(t *testing.T, testFiles bool) []string {
+	t.Helper()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package directory: %v", err)
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") != testFiles {
+			continue
+		}
+		files = append(files, name)
+	}
+	sort.Strings(files)
+	return files
+}
+
+// TestSourceHelperDirectCallSurface is a frozen guard, in force from this
+// chunk onward: it computes the complete set of unexported package-level
+// functions declared in this package's non-_test.go files (production
+// helpers, with or without a receiver), the complete set of identifiers
+// named anywhere in this package's _test.go files, and fails - naming the
+// offenders - if any name is in both sets but not in directCallAllowlist.
+//
+// Declarations in _test.go files (test fixtures - graph builders, line
+// extractors, and the like) are intentionally out of scope: step 1 below
+// only ever parses non-_test.go files, so a test-fixture helper can never
+// enter the production set and never trips this guard, no matter what it
+// is called or how many _test.go files reference it.
+func TestSourceHelperDirectCallSurface(t *testing.T) {
+	fset := token.NewFileSet()
+
+	production := map[string]bool{}
+	for _, name := range packageGoFiles(t, false) {
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			if !fn.Name.IsExported() {
+				production[fn.Name.Name] = true
+			}
+		}
+	}
+
+	referenced := map[string]bool{}
+	for _, name := range packageGoFiles(t, true) {
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			if id, ok := n.(*ast.Ident); ok {
+				referenced[id.Name] = true
+			}
+			return true
+		})
+	}
+
+	var offenders []string
+	for name := range production {
+		if referenced[name] && !directCallAllowlist[name] {
+			offenders = append(offenders, name)
+		}
+	}
+	sort.Strings(offenders)
+	if len(offenders) > 0 {
+		t.Fatalf("test file(s) directly name unexported production helper(s) not in directCallAllowlist: %v", offenders)
+	}
+}
+
+// TestSourceConfigExportedSurface freezes this package's exported
+// package-level surface: the exact set of exported funcs, methods, types
+// and values declared in non-_test.go files. Adding any exported
+// identifier in this chunk or a later one fails this test, since the plan
+// wires no new capability into any exported API.
+func TestSourceConfigExportedSurface(t *testing.T) {
+	fset := token.NewFileSet()
+
+	funcs := map[string]bool{}
+	methods := map[string]bool{}
+	types := map[string]bool{}
+	values := map[string]bool{}
+
+	for _, name := range packageGoFiles(t, false) {
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", name, err)
+		}
+		for _, decl := range f.Decls {
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if !d.Name.IsExported() {
+					continue
+				}
+				if d.Recv != nil {
+					methods[d.Name.Name] = true
+				} else {
+					funcs[d.Name.Name] = true
+				}
+			case *ast.GenDecl:
+				for _, spec := range d.Specs {
+					switch s := spec.(type) {
+					case *ast.TypeSpec:
+						if s.Name.IsExported() {
+							types[s.Name.Name] = true
+						}
+					case *ast.ValueSpec:
+						for _, id := range s.Names {
+							if id.IsExported() {
+								values[id.Name] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	assertExactNameSet(t, "exported funcs", funcs,
+		[]string{"Load", "SchemaActionFields", "SchemaGroupFields", "SchemaGroups", "SchemaPages"})
+	assertExactNameSet(t, "exported methods", methods,
+		[]string{"Error", "GetGroupConfig", "IsGroupEnabled", "Unwrap"})
+	assertExactNameSet(t, "exported types", types,
+		[]string{"ActionConfig", "Config", "ErrorKind", "GroupConfig", "LoadError", "PageConfig"})
+	assertExactNameSet(t, "exported values", values,
+		[]string{"KindParseType", "KindRead", "KindSchema"})
+}
+
+// assertExactNameSet fails the test, naming both sides, unless got's keys
+// are exactly want (order-independent).
+func assertExactNameSet(t *testing.T, label string, got map[string]bool, want []string) {
+	t.Helper()
+	gotSlice := make([]string, 0, len(got))
+	for name := range got {
+		gotSlice = append(gotSlice, name)
+	}
+	sort.Strings(gotSlice)
+
+	wantSlice := append([]string(nil), want...)
+	sort.Strings(wantSlice)
+
+	if !reflect.DeepEqual(gotSlice, wantSlice) {
+		t.Fatalf("%s: got %v, want %v", label, gotSlice, wantSlice)
+	}
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -191,8 +191,8 @@ wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
 back to `defaultConfig()` on any read or parse failure, so there is no
 strict parsing and no fail-closed runtime behavior yet. This is the first
 of several package-private capabilities (document parsing, reachable
-source-graph shape validation, and merge-operand shape validation now;
-effective-merge construction, duplicate-key detection, and the
+source-graph shape validation, merge-operand shape validation, and
+duplicate-explicit-key detection now; effective-merge construction and the
 alias-hop/path-visit bounds in later changes) meant to eventually replace
 `loadFromPath()`'s current `yaml.Unmarshal` call with fail-closed,
 single-document, structurally validated loading — but none of that wiring
@@ -263,10 +263,11 @@ returns carries a nil `Err`; `LoadError.Error()` still renders the full
 between two anchored mappings are both rejected too, but as a byproduct of
 the same generic alias-cycle rule above rather than merge-specific code: the
 merge operand's alias is still in the `visiting` state by the time any
-merge-shape check would run, so the cycle rule fires first. Duplicate
-explicit keys inside a mapping and the alias-hop/path-visit bounds remain
-unimplemented as of this writing and are later work. `validateSourceGraph`
-is not wired into any call path yet either.
+merge-shape check would run, so the cycle rule fires first. Every reachable
+mapping's explicit keys must also be pairwise unique (see the duplicate-key
+paragraph below); the alias-hop/path-visit bounds remain unimplemented as of
+this writing and are later work. `validateSourceGraph` is not wired into any
+call path yet either.
 
 **Merge-operand shape validation (`internal/config/sourcegraph.go`).**
 Layered onto the traversal above: every mapping entry whose key
@@ -298,8 +299,37 @@ favor of a later `<<` entry — because this function proves every reachable
 node well-formed, not just the nodes an eventual effective-merge result
 would keep
 (`docs/agents/skills/discarded-merge-branches-still-need-validation.md`).
-Duplicate explicit keys inside a mapping and the alias-hop/path-visit
-bounds remain unimplemented as of this writing and are later work.
+
+**Duplicate explicit-key detection (`internal/config/sourcegraph.go`).**
+Every reachable mapping's explicit keys must be pairwise unique under
+`sourceKeyID{Kind, Value}` identity — a repeated key rejects the whole
+graph as `KindParseType`, naming the duplicated key's value and, when the
+parser recorded a positive line for it, that line. The identity
+deliberately compares only `Kind` and `Value`, reproducing `gopkg.in/yaml.v3`
+v3.0.1 `decode.go`'s own `uniqueKeys` predicate (inside `decoder.mapping`)
+exactly rather than the tag-aware key identity
+`docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md`
+requires elsewhere in this package for merge/dedup purposes — that rule is
+about a different, not-yet-implemented concern (merge-precedence identity)
+and does not apply here, because yaml.v3's own duplicate-key guard never
+looks at `Tag` either. Two surprising consequences follow directly: two
+`<<` merge-key entries in the same mapping collide as duplicates regardless
+of which of `isMergeKey`'s four accepted tag forms each carries (an
+implicit `<<` and one explicitly tagged `!!merge` are still "the same key"),
+and a bare `1` (yaml.v3 resolves it to `!!int`) collides with an explicitly
+quoted `"1"` (`!!str`) even though their `Tag`s differ, because neither
+`Kind` nor `Value` distinguishes them. Detection is per-mapping, not
+global — the same key value recurring in a sibling mapping, or in a nested
+mapping reachable through it, is never a duplicate — and it runs on every
+reachable mapping regardless of how it is reached: directly, as a merge
+operand's value, through an alias target, or inside a complex mapping key's
+own subtree. The implementation is one `map[sourceKeyID]struct{}` per
+mapping, sized from `len(n.Content)/2`, filled by a single linear pass over
+key indices — deliberately not yaml.v3's own nested-loop `uniqueKeys`
+comparison, which is pairwise (`O(k^2)` per mapping). This package's version
+is `O(k)` per mapping and `O(V+E)` over the whole graph, so a mapping with
+tens of thousands of keys does not make the validator's own running time
+blow up the way the pairwise loop would.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -190,14 +190,15 @@ As of this writing `parseYAMLDocument` and `validateSourceGraph` are not
 wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
 back to `defaultConfig()` on any read or parse failure, so there is no
 strict parsing and no fail-closed runtime behavior yet. This is the first
-of several package-private capabilities (document parsing and reachable
-source-graph shape validation now; effective-merge construction,
-duplicate-key detection, and the alias-hop/path-visit bounds in later
-changes) meant to eventually replace `loadFromPath()`'s
-current `yaml.Unmarshal` call with fail-closed, single-document, structurally
-validated loading — but none of that wiring exists yet, so `KindRead` and
-`KindSchema` still describe capabilities the package's vocabulary
-anticipates rather than ones any code path currently exercises.
+of several package-private capabilities (document parsing, reachable
+source-graph shape validation, and merge-operand shape validation now;
+effective-merge construction, duplicate-key detection, and the
+alias-hop/path-visit bounds in later changes) meant to eventually replace
+`loadFromPath()`'s current `yaml.Unmarshal` call with fail-closed,
+single-document, structurally validated loading — but none of that wiring
+exists yet, so `KindRead` and `KindSchema` still describe capabilities the
+package's vocabulary anticipates rather than ones any code path currently
+exercises.
 
 **Exact merge-key recognition and tag normalization
 (`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
@@ -258,13 +259,47 @@ cycle between two anchored mappings). Because pure shape/graph rejections
 have no underlying Go error to preserve, every `*LoadError` `validateSourceGraph`
 returns carries a nil `Err`; `LoadError.Error()` still renders the full
 `"config parse/type error: <path>: <detail>"` wording from `Path` and
-`Detail` alone. This slice covers structural well-formedness only:
-merge-operand shape (a merge value must be a mapping, an alias to a
-mapping, or a sequence of such), duplicate explicit keys inside a mapping,
-and the alias-hop/path-visit bounds are unimplemented as of this writing
-and are later work, so a self- or mutual-merge cycle and a malformed merge
-operand are not yet detected by this function. `validateSourceGraph` is not
-wired into any call path yet either.
+`Detail` alone. A self merge (`&a {<<: *a}`) and a mutual merge cycle
+between two anchored mappings are both rejected too, but as a byproduct of
+the same generic alias-cycle rule above rather than merge-specific code: the
+merge operand's alias is still in the `visiting` state by the time any
+merge-shape check would run, so the cycle rule fires first. Duplicate
+explicit keys inside a mapping and the alias-hop/path-visit bounds remain
+unimplemented as of this writing and are later work. `validateSourceGraph`
+is not wired into any call path yet either.
+
+**Merge-operand shape validation (`internal/config/sourcegraph.go`).**
+Layered onto the traversal above: every mapping entry whose key
+`isMergeKey` reports true additionally has its value checked as a merge
+operand by `validateMergeOperand`, reproducing `gopkg.in/yaml.v3` v3.0.1
+`decode.go`'s `merge`/`failWantMap` rule exactly rather than accepting any
+value ordinary YAML content would allow. A merge operand is accepted only
+as one of: a `yaml.MappingNode` literal; a `yaml.AliasNode` whose
+*immediate* `Alias` target is a `yaml.MappingNode`; or a `yaml.SequenceNode`
+each of whose entries is itself one of the two prior shapes. Everything
+else is rejected as `KindParseType` — a scalar operand, an alias to a
+sequence or a scalar, a sequence containing a scalar or a nested sequence,
+and a sequence containing an alias to a non-mapping all fail
+(`isMergeOperandMapping` is the single-alias-hop predicate both the direct
+and sequence-entry checks share). The immediate-target rule produces a
+deliberate asymmetry: an alias-to-alias-to-mapping chain is perfectly valid
+as an *ordinary* mapping value (the generic traversal above only requires a
+non-nil `Alias` target of any kind) but is rejected as a merge operand,
+because yaml.v3 itself only unwraps one alias hop before deciding a merge
+value is not a mapping. All four of `isMergeKey`'s recognized tag forms —
+implicit, `"!"`, `"!!merge"`, and the canonical long tag — trigger this
+check identically; a quoted `"<<"` key (tagged `"!!str"`) does not, so it
+may hold any otherwise-valid value, including a bare scalar. Merge operands
+are validated wherever the traversal reaches them — inside a complex
+mapping key's own subtree (complex keys are traversed like any other node
+but are not otherwise classified in this slice), and in a mapping entry a
+later, still-unimplemented merge-precedence pass would go on to discard in
+favor of a later `<<` entry — because this function proves every reachable
+node well-formed, not just the nodes an eventual effective-merge result
+would keep
+(`docs/agents/skills/discarded-merge-branches-still-need-validation.md`).
+Duplicate explicit keys inside a mapping and the alias-hop/path-visit
+bounds remain unimplemented as of this writing and are later work.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -192,9 +192,9 @@ back to `defaultConfig()` on any read or parse failure, so there is no
 strict parsing and no fail-closed runtime behavior yet. This is the first
 of several package-private capabilities (document parsing, reachable
 source-graph shape validation, merge-operand shape validation,
-duplicate-explicit-key detection, the memoized alias-hop bound with
-all-paths line attribution now; effective-merge construction and the
-128-source-node-visit bound in later changes) meant to eventually replace
+duplicate-explicit-key detection, the memoized alias-hop bound and the
+memoized source-node path-visit bound, both with all-paths line
+attribution, now; effective-merge construction in a later change) meant to eventually replace
 `loadFromPath()`'s current `yaml.Unmarshal` call with fail-closed,
 single-document, structurally validated loading — but none of that wiring
 exists yet, so `KindRead` and `KindSchema` still describe capabilities the
@@ -266,11 +266,10 @@ the same generic alias-cycle rule above rather than merge-specific code: the
 merge operand's alias is still in the `visiting` state by the time any
 merge-shape check would run, so the cycle rule fires first. Every reachable
 mapping's explicit keys must also be pairwise unique (see the duplicate-key
-paragraph below); the memoized 64-consecutive-alias-hop bound described
-below now runs as a second pass once these checks prove the graph acyclic,
-and the 128-source-node-visit bound remains unimplemented as of this
-writing and is later work. `validateSourceGraph` is not wired into any
-call path yet either.
+paragraph below); the memoized 64-consecutive-alias-hop bound and the
+memoized 128-source-node-path-visit bound, both described below, now run
+as a second pass once these checks prove the graph acyclic.
+`validateSourceGraph` is not wired into any call path yet either.
 
 **Merge-operand shape validation (`internal/config/sourcegraph.go`).**
 Layered onto the traversal above: every mapping entry whose key
@@ -335,7 +334,8 @@ tens of thousands of keys does not make the validator's own running time
 blow up the way the pairwise loop would.
 
 **Reachable inventory, all-paths line attribution, and the 64
-consecutive-alias-hop bound (`internal/config/sourcebounds.go`).** Once
+consecutive-alias-hop and 128-source-node-path-visit bounds
+(`internal/config/sourcebounds.go`).** Once
 `walkSourceNode`'s traversal and every check above have proven a source
 graph acyclic and well-formed, `validateSourceGraph`'s single call to
 `checkSourceGraphBounds` runs a second, purely additive pass — it never
@@ -365,7 +365,11 @@ same discipline that keeps a compact alias-sharing DAG linear rather than
 exponential. When two positive-line ancestors tie at the same minimum
 distance to a node, the node's first-encounter active ancestor wins if it
 is one of the tied candidates; otherwise the candidate reached through the
-parent with the lower discovery index wins.
+parent with the lower discovery index wins. An alias edge participates in
+this distance exactly like an ordinary content edge, so a node reachable
+one alias hop below a positive-line ancestor can out-distance — and so
+out-rank — a farther positive-line ancestor reached only through ordinary
+content.
 
 The alias-hop bound itself is a memoized dynamic program over node
 identity: `hops(n) = 1 + hops(n.Alias)` for a `yaml.AliasNode`, and `0` for
@@ -378,9 +382,42 @@ parents is computed once rather than once per path. `checkAliasHopLimit`
 rejects the first node (in discovery order) whose `aliasHopCount` exceeds
 64 as `KindParseType`, naming the 64-hop limit and reporting
 `attributeSourceLines`' line for that node; exactly 64 consecutive hops
-succeeds and 65 fails. Every error this pass returns has a nil `Err`, like
-every other `validateSourceGraph` rejection. The 128-source-node-visit
-bound is separate, unimplemented work.
+succeeds and 65 fails.
+
+The 128-source-node-path-visit bound is a second, separate memoized
+dynamic program over node identity: `pathVisitCount(n) = 1 +
+max(pathVisitCount(child))` over every content edge reachable directly
+from `n` — a document's, mapping's, or sequence's `Content` entries, or an
+alias node's single `Alias` target — and `1` for a node with no such
+children (an ordinary scalar). Every encountered node, including a
+mapping's own key nodes, contributes exactly one visit; "key", "value",
+and "alias target" only name which child is traversed next and add no
+separate charge, so a scalar used as a mapping key counts once, not once
+for being a scalar plus once for being a key, and an alias node plus its
+target contribute two visits together, not one. `pathVisitCount` memoizes
+by node pointer exactly like `aliasHopCount`, so wide siblings that all
+share one deep target are each checked once and do not accumulate a
+global count, and a compact alias-sharing DAG is evaluated in time linear
+in its node and edge count rather than once per exponentially-many
+root-to-leaf paths.
+
+Because `pathVisitCount` is monotonically non-decreasing from any node
+toward the root, once one node's count exceeds 128 every one of its
+ancestors up to the graph's root does too; `checkSourcePathVisitLimit`
+therefore does not report the first over-limit node found in discovery
+order (which would almost always be the root itself, carrying no useful
+attribution) but instead walks `inv.nodes` in discovery order for the
+*boundary* node — one whose own count exceeds 128 but whose every direct
+child does not, i.e. the exact point along an offending path where the
+count first crosses the limit — and reports `attributeSourceLines`' line
+for that node, naming the 128-visit limit; this stays deterministic even
+when more than one branch independently crosses the boundary, since
+discovery order breaks the tie. Exactly 128 source-node visits on a
+root-to-leaf path succeeds and 129 fails. When a graph violates both
+bounds, `checkSourceGraphBounds` checks the alias-hop bound first, so the
+alias-hop error is reported and the path-visit pass never runs. Every
+error either pass returns has a nil `Err`, like every other
+`validateSourceGraph` rejection.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -151,12 +151,46 @@ non-empty/non-nil), so the three `Kind` literals above always appear
 verbatim in the message. `LoadError.Unwrap()` returns `Err` unchanged
 (nil when there is none), which is what lets `errors.Is`/`errors.As` see
 through a `*LoadError` to a wrapped sentinel or recover the original value
-from a `fmt.Errorf("%w", ...)` wrapper. As of this writing nothing
-constructs a `LoadError` yet — `Load()` and `loadFromPath()` are unchanged
-and still fall back to `defaultConfig()` on any read or parse failure, so
-there is no strict parsing and no fail-closed runtime behavior yet; this
-vocabulary exists so a later change can start returning `*LoadError` values
-without redefining what "read", "parse/type", and "schema" mean.
+from a `fmt.Errorf("%w", ...)` wrapper.
+
+**Single-document YAML parsing (`internal/config/source.go`).** The
+unexported `parseYAMLDocument(path string, data []byte) (*yaml.Node,
+*LoadError)` is the first thing in this package that actually constructs a
+`LoadError`. It decodes `data` with `yaml.NewDecoder` and accepts exactly one
+YAML document, with a fixed cardinality outcome per input shape:
+
+- Empty input, and whitespace-only input, are both the valid empty result:
+  `(nil, nil)` — no document, no error. This matches `Load()`'s existing
+  "absent config" fallback semantics elsewhere in the package.
+- A single well-formed document returns its `*yaml.Node` (`Kind ==
+  yaml.DocumentNode`, one child under `Content`) and a nil `*LoadError`.
+- A malformed first document returns `(nil, err)` with `err.Kind ==
+  KindParseType`, `err.Path` copied verbatim, `err.Err` set to yaml.v3's own
+  parser error, and `err.Detail` set to that same error's message — which
+  yaml.v3 always renders as `"yaml: line N: ..."`, so the reported line is
+  visible in `Detail` without a second look at `Err`.
+- A trailing bare `---` is a second document, not a harmless end-of-stream
+  marker: yaml.v3 decodes it as a second, null document, and
+  `parseYAMLDocument` rejects it exactly like any other second document
+  (`KindParseType`, `Detail` naming its line) rather than accepting the
+  input as a single document.
+- Any other second document — well-formed or malformed — is rejected the
+  same way: a well-formed second document has no parser error to wrap, so
+  `Err` is left nil and `Detail` names that document's own starting line
+  instead; a malformed second document preserves *that* document's parser
+  error and line in `Err`/`Detail`, just like a malformed first document
+  would.
+
+As of this writing `parseYAMLDocument` is not wired into `Load()` or
+`loadFromPath()` — both are unchanged and still fall back to
+`defaultConfig()` on any read or parse failure, so there is no strict
+parsing and no fail-closed runtime behavior yet. This is the first of
+several package-private capabilities (document parsing now; source-graph
+validation in later changes) meant to eventually replace `loadFromPath()`'s
+current `yaml.Unmarshal` call with fail-closed, single-document, structurally
+validated loading — but none of that wiring exists yet, so `KindRead` and
+`KindSchema` still describe capabilities the package's vocabulary
+anticipates rather than ones any code path currently exercises.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -191,9 +191,10 @@ wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
 back to `defaultConfig()` on any read or parse failure, so there is no
 strict parsing and no fail-closed runtime behavior yet. This is the first
 of several package-private capabilities (document parsing, reachable
-source-graph shape validation, merge-operand shape validation, and
-duplicate-explicit-key detection now; effective-merge construction and the
-alias-hop/path-visit bounds in later changes) meant to eventually replace
+source-graph shape validation, merge-operand shape validation,
+duplicate-explicit-key detection, the memoized alias-hop bound with
+all-paths line attribution now; effective-merge construction and the
+128-source-node-visit bound in later changes) meant to eventually replace
 `loadFromPath()`'s current `yaml.Unmarshal` call with fail-closed,
 single-document, structurally validated loading — but none of that wiring
 exists yet, so `KindRead` and `KindSchema` still describe capabilities the
@@ -265,8 +266,10 @@ the same generic alias-cycle rule above rather than merge-specific code: the
 merge operand's alias is still in the `visiting` state by the time any
 merge-shape check would run, so the cycle rule fires first. Every reachable
 mapping's explicit keys must also be pairwise unique (see the duplicate-key
-paragraph below); the alias-hop/path-visit bounds remain unimplemented as of
-this writing and are later work. `validateSourceGraph` is not wired into any
+paragraph below); the memoized 64-consecutive-alias-hop bound described
+below now runs as a second pass once these checks prove the graph acyclic,
+and the 128-source-node-visit bound remains unimplemented as of this
+writing and is later work. `validateSourceGraph` is not wired into any
 call path yet either.
 
 **Merge-operand shape validation (`internal/config/sourcegraph.go`).**
@@ -330,6 +333,54 @@ comparison, which is pairwise (`O(k^2)` per mapping). This package's version
 is `O(k)` per mapping and `O(V+E)` over the whole graph, so a mapping with
 tens of thousands of keys does not make the validator's own running time
 blow up the way the pairwise loop would.
+
+**Reachable inventory, all-paths line attribution, and the 64
+consecutive-alias-hop bound (`internal/config/sourcebounds.go`).** Once
+`walkSourceNode`'s traversal and every check above have proven a source
+graph acyclic and well-formed, `validateSourceGraph`'s single call to
+`checkSourceGraphBounds` runs a second, purely additive pass — it never
+runs on a graph that failed an earlier check, so a cyclic or otherwise
+malformed graph still surfaces its original error (an alias cycle, a
+malformed merge operand, a duplicate key) rather than a bounds error.
+`collectSourceInventory` walks the already-proven-acyclic graph exactly
+once per unique node, in `Content` slice order, recording every reachable
+node in discovery order, every parent→child content edge reachable in the
+graph — including a second edge into a node reached through more than one
+parent, not just the edge the walk happened to follow first — and each
+node's first-encounter active nearest positive-line ancestor.
+
+`attributeSourceLines` gives every reachable node a source line to report
+in a bounds-limit error: a node's own `Line` when positive; otherwise the
+line of a positive-line ancestor at the minimum number of content edges
+from it over *all* root-reachable paths, not merely the path the traversal
+happened to discover it by first; otherwise `1`, the deterministic
+fallback for a wholly synthetic graph with no line metadata anywhere. This
+is a multi-source breadth-first search in the parent→child direction,
+seeded with every reachable positive-line node at distance zero attributing
+its own line and relaxing each edge `parent→child` with
+`(dist(parent)+1, line(parent))`; because it walks `collectSourceInventory`'s
+already-deduplicated node and edge lists, it visits each at most once and
+is `O(V+E)`, so it never re-expands a shared subgraph once per path — the
+same discipline that keeps a compact alias-sharing DAG linear rather than
+exponential. When two positive-line ancestors tie at the same minimum
+distance to a node, the node's first-encounter active ancestor wins if it
+is one of the tied candidates; otherwise the candidate reached through the
+parent with the lower discovery index wins.
+
+The alias-hop bound itself is a memoized dynamic program over node
+identity: `hops(n) = 1 + hops(n.Alias)` for a `yaml.AliasNode`, and `0` for
+every other kind, so descending from any non-alias node into ordinary
+content always resets the count for that child path — which is why more
+than 64 independent, shallow sibling aliases to the same anchored target
+all succeed even though there are far more than 64 of them in the graph.
+`aliasHopCount` memoizes by node pointer, so a node reachable through many
+parents is computed once rather than once per path. `checkAliasHopLimit`
+rejects the first node (in discovery order) whose `aliasHopCount` exceeds
+64 as `KindParseType`, naming the 64-hop limit and reporting
+`attributeSourceLines`' line for that node; exactly 64 consecutive hops
+succeeds and 65 fails. Every error this pass returns has a nil `Err`, like
+every other `validateSourceGraph` rejection. The 128-source-node-visit
+bound is separate, unimplemented work.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -192,6 +192,34 @@ validated loading — but none of that wiring exists yet, so `KindRead` and
 `KindSchema` still describe capabilities the package's vocabulary
 anticipates rather than ones any code path currently exercises.
 
+**Exact merge-key recognition and tag normalization
+(`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
+`shortYAMLTag(tag string) string` are deliberate line-for-line reproductions
+of two unexported predicates from `gopkg.in/yaml.v3` v3.0.1 itself —
+`decode.go:isMerge` and `resolve.go:shortTag` — rather than reimplementations
+from a description of YAML merge-key semantics, so this package's own
+merge-key walk (a later change) recognizes exactly the same nodes yaml.v3's
+own decoder would treat as a merge key, node for node. `isMergeKey` reports
+true only for a `yaml.ScalarNode` whose `Value` is exactly `"<<"` and whose
+`Tag` is one of: absent (`""`, the implicit/unresolved tag), the bare
+non-specific tag (`"!"`), the short merge tag (`"!!merge"`), or its canonical
+long form (`"tag:yaml.org,2002:merge"`) — the last two both recognized via
+`shortYAMLTag`. A quoted `"<<"` (explicitly tagged `"!!str"`) is therefore an
+ordinary key, not a merge key, and so is a merge-tagged scalar whose `Value`
+isn't literally `"<<"`; non-scalar nodes (mapping, sequence, alias) and a nil
+`*yaml.Node` are never merge keys either — `isMergeKey` is nil-safe rather
+than panicking. `shortYAMLTag` rewrites a canonical `"tag:yaml.org,2002:xxx"`
+tag to yaml.v3's short `"!!xxx"` form and returns any tag without that prefix
+unchanged (including the empty tag, `"!"`, an already-short `"!!xxx"` tag, a
+custom `"!xxx"` tag, and a long tag under a different authority such as
+`"tag:example.com,2020:merge"`). These are the only two unexported helpers in
+this package's source-graph slice that the spec singles out for a direct
+unit test (`TestMergeKeyRecognition`, `TestShortYAMLTagNormalization` in
+`sourcegraph_test.go`) rather than only exercising them through an exported
+entry point, per
+`docs/agents/skills/helper-functions-need-direct-test-calls.md`; neither
+helper is wired into any call path yet — that wiring is later work.
+
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,
 per page, group names by reflection — never by a second hand-maintained

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -203,7 +203,7 @@ exercises.
 
 **Exact merge-key recognition and tag normalization
 (`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
-`shortYAMLTag(tag string) string` are deliberate line-for-line reproductions
+`shortYAMLTag(tag string) string` are deliberate behaviorally exact reproductions
 of two unexported predicates from `gopkg.in/yaml.v3` v3.0.1 itself —
 `decode.go:isMerge` and `resolve.go:shortTag` — rather than reimplementations
 from a description of YAML merge-key semantics, so this package's own

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -140,8 +140,13 @@ stable `ErrorKind` enumerates why loading/validating a config file could
 fail: `KindRead` ("read") for a filesystem/read failure (e.g. permission
 denied opening the file — distinct from "file does not exist", which
 `Load()` treats as absent-and-fall-back, not an error); `KindParseType`
-("parse/type") for a YAML syntax error or a value that decodes to the wrong
-Go type; and `KindSchema` ("schema") for a validator-detected shape failure
+("parse/type") for a YAML syntax error, a value that decodes to the wrong
+Go type, or a malformed source graph detected by pure shape/graph
+inspection after the YAML parsed successfully (an unsupported node shape,
+an alias with no target, an alias cycle, etc.) — like `KindSchema` below,
+that shape-inspection case may legitimately carry a nil `Err`, since there
+is no underlying parser error to wrap; and `KindSchema` ("schema") for a
+validator-detected shape failure
 found only after the document parsed successfully — e.g. an unknown key or a
 value of the right YAML kind but the wrong shape — which may legitimately
 carry a nil `Err` since shape inspection alone can detect the problem with
@@ -181,12 +186,14 @@ YAML document, with a fixed cardinality outcome per input shape:
   error and line in `Err`/`Detail`, just like a malformed first document
   would.
 
-As of this writing `parseYAMLDocument` is not wired into `Load()` or
-`loadFromPath()` — both are unchanged and still fall back to
-`defaultConfig()` on any read or parse failure, so there is no strict
-parsing and no fail-closed runtime behavior yet. This is the first of
-several package-private capabilities (document parsing now; source-graph
-validation in later changes) meant to eventually replace `loadFromPath()`'s
+As of this writing `parseYAMLDocument` and `validateSourceGraph` are not
+wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
+back to `defaultConfig()` on any read or parse failure, so there is no
+strict parsing and no fail-closed runtime behavior yet. This is the first
+of several package-private capabilities (document parsing and reachable
+source-graph shape validation now; effective-merge construction,
+duplicate-key detection, and the alias-hop/path-visit bounds in later
+changes) meant to eventually replace `loadFromPath()`'s
 current `yaml.Unmarshal` call with fail-closed, single-document, structurally
 validated loading — but none of that wiring exists yet, so `KindRead` and
 `KindSchema` still describe capabilities the package's vocabulary
@@ -219,6 +226,45 @@ unit test (`TestMergeKeyRecognition`, `TestShortYAMLTagNormalization` in
 entry point, per
 `docs/agents/skills/helper-functions-need-direct-test-calls.md`; neither
 helper is wired into any call path yet — that wiring is later work.
+
+**Reachable source-graph shape validation
+(`internal/config/sourcegraph.go`).** `validateSourceGraph(path string, doc
+*yaml.Node) *LoadError` walks every node and content edge reachable from
+`doc` — through document content, mapping keys, mapping values, sequence
+entries, and alias targets, in each node's `Content` slice order — and
+rejects a malformed source graph as `KindParseType` rather than panicking,
+even against a synthetic `*yaml.Node` tree unreachable from real YAML text.
+`doc == nil` succeeds unconditionally: it is `parseYAMLDocument`'s valid
+empty-input result. Otherwise the checks are, in order:
+
+- the root must be a `yaml.DocumentNode` with exactly one non-nil child;
+- every reachable mapping must have an even number of content entries, and
+  neither a key nor a value in any key/value pair may be nil;
+- every reachable sequence must have no nil entries;
+- every reachable scalar must have no content children;
+- every reachable alias must have no content children and a non-nil
+  `Alias` target; and
+- every reachable node's `Kind` must be one of yaml.v3's five supported
+  kinds (an all-zero `Kind` or any other unsupported value is rejected).
+
+Node identity — the `*yaml.Node` pointer itself, not any decoded value —
+drives an unseen/visiting/done state map keyed on that pointer, so a node
+reached through several parents (a shared anchor aliased more than once, a
+scalar reused as several mapping values) is validated exactly once, and
+re-encountering a node still in the `visiting` state on the active
+depth-first path is rejected as an alias cycle (covering both a self cycle,
+where an anchored mapping's own value aliases back to itself, and a mutual
+cycle between two anchored mappings). Because pure shape/graph rejections
+have no underlying Go error to preserve, every `*LoadError` `validateSourceGraph`
+returns carries a nil `Err`; `LoadError.Error()` still renders the full
+`"config parse/type error: <path>: <detail>"` wording from `Path` and
+`Detail` alone. This slice covers structural well-formedness only:
+merge-operand shape (a merge value must be a mapping, an alias to a
+mapping, or a sequence of such), duplicate explicit keys inside a mapping,
+and the alias-hop/path-visit bounds are unimplemented as of this writing
+and are later work, so a self- or mutual-merge cycle and a malformed merge
+operand are not yet detected by this function. `validateSourceGraph` is not
+wired into any call path yet either.
 
 **Canonical page/group inventory (`internal/config/schema.go`).** `SchemaPages()`
 and `SchemaGroups(page)` derive the authoritative list of page names and,


### PR DESCRIPTION
Implements the source-graph validation slice of #69.

- parses exactly one YAML document with typed source diagnostics
- validates reachable YAML graph structure, aliases, merges, and duplicates
- enforces memoized 64-hop and 128-node path bounds with deterministic line attribution
- keeps the new helpers unwired until the loading slice

Validation: `make ci`

Refs #69