### PR TITLE
feat(config): build bounded effective YAML documents

### DIFF
--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -1,0 +1,88 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// resolveEffective validates doc as a source graph (validateSourceGraph)
+// and, on success, emits a fresh alias-free, anchor-free copy of it rooted
+// at a yaml.DocumentNode.
+//
+// Validation always runs first and its error, if any, is returned
+// unchanged: a caller of resolveEffective cannot bypass validateSourceGraph's
+// existing Detail/line contract by going through this entry point instead.
+// doc == nil succeeds validation and returns (nil, nil) — parseYAMLDocument's
+// valid empty-input result.
+//
+// On success the returned tree is a structural copy of doc: every emitted
+// node copies Kind, Style, Tag, Value, Line, Column, HeadComment,
+// LineComment and FootComment from the source node it was emitted for,
+// leaves Anchor as "" and Alias as nil, and recurses into Content in the
+// same order as the source. A yaml.AliasNode is never copied as itself;
+// instead its recursively dereferenced non-alias target is emitted in its
+// place, carrying the target's own metadata rather than the alias node's —
+// including when the alias appears in mapping key position. Because the
+// result must be alias-free, a target reached through more than one alias
+// becomes more than one independent fresh copy.
+//
+// This is an interim result, authorized by the spec for this chunk: a
+// recognized "<<" merge key (isMergeKey) is emitted as an ordinary mapping
+// entry with its operand value resolved like any other value, rather than
+// being consumed by merge-precedence resolution. A later chunk replaces
+// this with the real merge-precedence result.
+func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
+	if err := validateSourceGraph(path, doc); err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		return nil, nil
+	}
+	return emitEffectiveNode(doc), nil
+}
+
+// emitEffectiveNode dereferences n through dereferenceAliasTarget and
+// returns a fresh copy of the resulting non-alias node: its metadata via
+// emitNodeMetadata, plus its Content recursively emitted in the same
+// order. It assumes n comes from a graph validateSourceGraph has already
+// proven acyclic and well-formed, so it never needs its own cycle guard.
+func emitEffectiveNode(n *yaml.Node) *yaml.Node {
+	target := dereferenceAliasTarget(n)
+	out := emitNodeMetadata(target)
+	if len(target.Content) == 0 {
+		return out
+	}
+	out.Content = make([]*yaml.Node, len(target.Content))
+	for i, child := range target.Content {
+		out.Content[i] = emitEffectiveNode(child)
+	}
+	return out
+}
+
+// dereferenceAliasTarget follows n's yaml.AliasNode chain (however many
+// hops) to its non-alias target. It relies on validateSourceGraph having
+// already proven the graph acyclic and every alias's Alias field non-nil,
+// so it needs no cycle guard or nil check of its own beyond the loop
+// condition.
+func dereferenceAliasTarget(n *yaml.Node) *yaml.Node {
+	for n.Kind == yaml.AliasNode {
+		n = n.Alias
+	}
+	return n
+}
+
+// emitNodeMetadata copies n's Kind, Style, Tag, Value, Line, Column,
+// HeadComment, LineComment and FootComment into a freshly allocated
+// *yaml.Node, leaving Anchor as its zero value "" and Alias as its zero
+// value nil so the copy is never itself an anchor or an alias, and leaving
+// Content nil for the caller to fill in.
+func emitNodeMetadata(n *yaml.Node) *yaml.Node {
+	return &yaml.Node{
+		Kind:        n.Kind,
+		Style:       n.Style,
+		Tag:         n.Tag,
+		Value:       n.Value,
+		Line:        n.Line,
+		Column:      n.Column,
+		HeadComment: n.HeadComment,
+		LineComment: n.LineComment,
+		FootComment: n.FootComment,
+	}
+}

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -1,6 +1,27 @@
 package config
 
-import "gopkg.in/yaml.v3"
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// maxEffectiveOutputNodes is the maximum number of nodes
+// resolveEffective's emit path (emitEffectiveNode) may allocate for one
+// call. Every retained document, mapping, sequence, key and value node
+// counts exactly once, mirroring sourcebounds.go's pathVisitCount
+// accounting rule that "key", "value" and "alias target" only name which
+// child is traversed next and add no separate charge; each independent
+// copy produced by expanding a shared alias target is charged separately,
+// since the emitted tree is alias-free and each such copy is a distinct
+// allocation. The budget check happens immediately before a node would be
+// allocated — the first statements of the emit path for that node — so
+// the 100,001st attempted emission fails before its (and any descendant's)
+// allocation rather than after materializing an oversized tree; this is
+// what makes an exponential alias expansion abort at the boundary instead
+// of running to completion. Exactly maxEffectiveOutputNodes succeeds and
+// maxEffectiveOutputNodes+1 fails.
+const maxEffectiveOutputNodes = 100000
 
 // resolveEffective validates doc as a source graph (validateSourceGraph)
 // and, on success, emits a fresh alias-free, anchor-free copy of it rooted
@@ -28,6 +49,14 @@ import "gopkg.in/yaml.v3"
 // entry with its operand value resolved like any other value, rather than
 // being consumed by merge-precedence resolution. A later chunk replaces
 // this with the real merge-precedence result.
+//
+// The emit path is bounded by maxEffectiveOutputNodes: if emitting doc
+// would allocate more than that many nodes (an exponential alias
+// expansion is the mechanism that makes this reachable from a small,
+// well-formed source graph — see checkSourceGraphBounds' hop and
+// path-visit limits, which bound the *source* graph but not its expanded
+// output), resolveEffective returns a nil tree and a KindParseType
+// *LoadError naming the bound instead of completing the allocation.
 func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
 	if err := validateSourceGraph(path, doc); err != nil {
 		return nil, err
@@ -35,7 +64,23 @@ func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
 	if doc == nil {
 		return nil, nil
 	}
-	return emitEffectiveNode(doc), nil
+	st := &effectiveEmitState{}
+	out := emitEffectiveNode(doc, st)
+	if st.overflowed {
+		return nil, effectiveOutputLimitError(path, doc, st.overflowNode)
+	}
+	return out, nil
+}
+
+// effectiveEmitState tracks emitEffectiveNode's per-call node budget: count
+// is the number of nodes allocated so far, and overflowed/overflowNode
+// record the first node whose emission would exceed
+// maxEffectiveOutputNodes, so the recursion can unwind without doing any
+// further allocation or descending into any further Content.
+type effectiveEmitState struct {
+	count        int
+	overflowed   bool
+	overflowNode *yaml.Node
 }
 
 // emitEffectiveNode dereferences n through dereferenceAliasTarget and
@@ -43,17 +88,63 @@ func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
 // emitNodeMetadata, plus its Content recursively emitted in the same
 // order. It assumes n comes from a graph validateSourceGraph has already
 // proven acyclic and well-formed, so it never needs its own cycle guard.
-func emitEffectiveNode(n *yaml.Node) *yaml.Node {
+//
+// Before allocating anything for the dereferenced target, it increments
+// st.count and checks it against maxEffectiveOutputNodes; once st.count
+// would exceed the budget, it records the offending node and returns nil
+// immediately, without allocating a node for it or recursing into its
+// Content. Once st.overflowed is set (by this call or an earlier sibling
+// call), every subsequent call returns nil immediately without doing any
+// further work, so an oversized or exponential expansion is bounded by the
+// budget rather than run to completion.
+func emitEffectiveNode(n *yaml.Node, st *effectiveEmitState) *yaml.Node {
+	if st.overflowed {
+		return nil
+	}
 	target := dereferenceAliasTarget(n)
+	st.count++
+	if st.count > maxEffectiveOutputNodes {
+		st.overflowed = true
+		st.overflowNode = target
+		return nil
+	}
 	out := emitNodeMetadata(target)
 	if len(target.Content) == 0 {
 		return out
 	}
 	out.Content = make([]*yaml.Node, len(target.Content))
 	for i, child := range target.Content {
-		out.Content[i] = emitEffectiveNode(child)
+		out.Content[i] = emitEffectiveNode(child, st)
+		if st.overflowed {
+			return nil
+		}
 	}
 	return out
+}
+
+// effectiveOutputLimitError builds the KindParseType *LoadError
+// resolveEffective returns when emitting doc would exceed
+// maxEffectiveOutputNodes. It reuses sourcebounds.go's
+// collectSourceInventory and attributeSourceLines on the validated source
+// document doc — the same all-paths line attribution
+// checkSourceGraphBounds uses (a node's own line, else its nearest
+// positive-line ancestor over all paths, else 1) — computing that
+// inventory exactly once for the call, rather than writing a second line
+// attribution implementation, so the reported line for overflowNode (the
+// source node whose emission would have been the 100,001st) is always
+// positive.
+func effectiveOutputLimitError(path string, doc *yaml.Node, overflowNode *yaml.Node) *LoadError {
+	inv := collectSourceInventory(doc)
+	lines := attributeSourceLines(inv)
+	line := lines[overflowNode]
+	if line <= 0 {
+		line = 1
+	}
+	detail := fmt.Sprintf(
+		"effective output exceeds the maximum of %d emitted nodes (line %d)",
+		maxEffectiveOutputNodes, line,
+	)
+	return sourceGraphError(path, detail)
 }
 
 // dereferenceAliasTarget follows n's yaml.AliasNode chain (however many

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -74,18 +74,30 @@ func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
 	if st.overflowed {
 		return nil, effectiveOutputLimitError(path, doc, st.overflowNode)
 	}
+	if st.collided {
+		return nil, effectiveIdentityCollisionError(path, doc, st.collisionKey)
+	}
 	return out, nil
 }
 
-// effectiveEmitState tracks emitEffectiveNode's per-call node budget: count
-// is the number of nodes allocated so far, and overflowed/overflowNode
-// record the first node whose emission would exceed
-// maxEffectiveOutputNodes, so the recursion can unwind without doing any
-// further allocation or descending into any further Content.
+// effectiveEmitState tracks emitEffectiveNode's per-call node budget and
+// its per-call identity-collision detection: count is the number of nodes
+// allocated so far, and overflowed/overflowNode record the first node
+// whose emission would exceed maxEffectiveOutputNodes, so the recursion
+// can unwind without doing any further allocation or descending into any
+// further Content. collided/collisionKey record, similarly, the first
+// pair of explicit keys of one source mapping found to normalize to the
+// same effectiveKeyIdentity (effectivemerge.go's explicitKeyCollision),
+// so the recursion can unwind without inventorying or emitting any
+// further mapping. Both conditions are terminal for the whole
+// resolveEffective call once set: emitEffectiveNode checks both before
+// doing any further work.
 type effectiveEmitState struct {
 	count        int
 	overflowed   bool
 	overflowNode *yaml.Node
+	collided     bool
+	collisionKey *yaml.Node
 }
 
 // emitEffectiveNode dereferences n through dereferenceAliasTarget and
@@ -110,7 +122,7 @@ type effectiveEmitState struct {
 // further work, so an oversized or exponential expansion is bounded by the
 // budget rather than run to completion.
 func emitEffectiveNode(n *yaml.Node, st *effectiveEmitState) *yaml.Node {
-	if st.overflowed {
+	if st.overflowed || st.collided {
 		return nil
 	}
 	target := dereferenceAliasTarget(n)
@@ -122,7 +134,10 @@ func emitEffectiveNode(n *yaml.Node, st *effectiveEmitState) *yaml.Node {
 	}
 	out := emitNodeMetadata(target)
 	if target.Kind == yaml.MappingNode {
-		entries := effectiveEntries(target)
+		entries := effectiveEntries(target, st)
+		if st.collided {
+			return nil
+		}
 		if len(entries) == 0 {
 			return out
 		}
@@ -174,6 +189,40 @@ func effectiveOutputLimitError(path string, doc *yaml.Node, overflowNode *yaml.N
 	detail := fmt.Sprintf(
 		"effective output exceeds the maximum of %d emitted nodes (line %d)",
 		maxEffectiveOutputNodes, line,
+	)
+	return sourceGraphError(path, detail)
+}
+
+// effectiveIdentityCollisionError builds the KindParseType *LoadError
+// resolveEffective returns when two EXPLICIT keys of the same source
+// mapping normalize to the same effectiveKeyIdentity after alias
+// dereferencing (effectivemerge.go's explicitKeyCollision). This is a
+// separate, post-alias rule layered on top of — not a replacement for —
+// sourcegraph.go's tag-blind Kind+Value duplicate-key validation
+// (checkDuplicateMappingKeys), which validateSourceGraph already runs
+// first and unchanged: that check alone does not catch, for example, an
+// alias key and a direct scalar key that dereference to the same
+// effectiveKeyIdentity, since the alias node's own Kind and Value differ
+// from its target's. It applies only to two explicit keys of one source
+// mapping; an inherited merge candidate colliding with an explicit key is
+// ordinary suppression (effectiveEntriesWithMemo's dedup pass), not this
+// error.
+//
+// Like effectiveOutputLimitError, it reuses collectSourceInventory and
+// attributeSourceLines on the validated source document doc so the
+// reported line for laterKey (the second of the two colliding keys,
+// found in source Content order) is always positive: laterKey's own
+// line, else its nearest positive-line ancestor over all paths, else 1.
+func effectiveIdentityCollisionError(path string, doc *yaml.Node, laterKey *yaml.Node) *LoadError {
+	inv := collectSourceInventory(doc)
+	lines := attributeSourceLines(inv)
+	line := lines[laterKey]
+	if line <= 0 {
+		line = 1
+	}
+	detail := fmt.Sprintf(
+		"mapping key collides with another explicit key of the same mapping after alias resolution (line %d)",
+		line,
 	)
 	return sourceGraphError(path, detail)
 }

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -44,11 +44,16 @@ const maxEffectiveOutputNodes = 100000
 // result must be alias-free, a target reached through more than one alias
 // becomes more than one independent fresh copy.
 //
-// This is an interim result, authorized by the spec for this chunk: a
-// recognized "<<" merge key (isMergeKey) is emitted as an ordinary mapping
-// entry with its operand value resolved like any other value, rather than
-// being consumed by merge-precedence resolution. A later chunk replaces
-// this with the real merge-precedence result.
+// A mapping node's Content is not copied verbatim: it is replaced by its
+// effective entries (effectiveEntries, effectivemerge.go), so only winning
+// keys and winning values — explicit-over-merged, earlier-sequence-operand-
+// over-later, in effectiveEntries' documented deterministic order — are
+// ever resolved and emitted. A losing candidate's value is never cloned
+// and never charged against maxEffectiveOutputNodes below. A recognized
+// "<<" merge key is therefore never itself emitted as a key, and the
+// result contains no recognized merge directive anywhere, including
+// within a retained mapping key's own subtree or a retained value's own
+// nested merge.
 //
 // The emit path is bounded by maxEffectiveOutputNodes: if emitting doc
 // would allocate more than that many nodes (an exponential alias
@@ -86,7 +91,14 @@ type effectiveEmitState struct {
 // emitEffectiveNode dereferences n through dereferenceAliasTarget and
 // returns a fresh copy of the resulting non-alias node: its metadata via
 // emitNodeMetadata, plus its Content recursively emitted in the same
-// order. It assumes n comes from a graph validateSourceGraph has already
+// order — except for a mapping node, whose emitted entries come from
+// effectiveEntries instead of its raw Content, so only winning keys and
+// values are ever resolved (see resolveEffective's doc comment).
+// effectiveEntries' own memo (effectivemerge.go) is scoped to that one
+// call and its recursion into merge operands, so a mapping node reached
+// as a merge operand through several parents or aliases within the same
+// mapping's inventory computation is inventoried once, not once per
+// parent. It assumes n comes from a graph validateSourceGraph has already
 // proven acyclic and well-formed, so it never needs its own cycle guard.
 //
 // Before allocating anything for the dereferenced target, it increments
@@ -109,6 +121,25 @@ func emitEffectiveNode(n *yaml.Node, st *effectiveEmitState) *yaml.Node {
 		return nil
 	}
 	out := emitNodeMetadata(target)
+	if target.Kind == yaml.MappingNode {
+		entries := effectiveEntries(target)
+		if len(entries) == 0 {
+			return out
+		}
+		out.Content = make([]*yaml.Node, 0, len(entries)*2)
+		for _, e := range entries {
+			keyOut := emitEffectiveNode(e.key, st)
+			if st.overflowed {
+				return nil
+			}
+			valOut := emitEffectiveNode(e.value, st)
+			if st.overflowed {
+				return nil
+			}
+			out.Content = append(out.Content, keyOut, valOut)
+		}
+		return out
+	}
 	if len(target.Content) == 0 {
 		return out
 	}

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -69,7 +69,7 @@ func resolveEffective(path string, doc *yaml.Node) (*yaml.Node, *LoadError) {
 	if doc == nil {
 		return nil, nil
 	}
-	st := &effectiveEmitState{}
+	st := &effectiveEmitState{mergeMemo: make(effectiveMergeMemo)}
 	out := emitEffectiveNode(doc, st)
 	if st.overflowed {
 		return nil, effectiveOutputLimitError(path, doc, st.overflowNode)
@@ -98,6 +98,7 @@ type effectiveEmitState struct {
 	overflowNode *yaml.Node
 	collided     bool
 	collisionKey *yaml.Node
+	mergeMemo    effectiveMergeMemo
 }
 
 // emitEffectiveNode dereferences n through dereferenceAliasTarget and
@@ -106,12 +107,11 @@ type effectiveEmitState struct {
 // order — except for a mapping node, whose emitted entries come from
 // effectiveEntries instead of its raw Content, so only winning keys and
 // values are ever resolved (see resolveEffective's doc comment).
-// effectiveEntries' own memo (effectivemerge.go) is scoped to that one
-// call and its recursion into merge operands, so a mapping node reached
-// as a merge operand through several parents or aliases within the same
-// mapping's inventory computation is inventoried once, not once per
-// parent. It assumes n comes from a graph validateSourceGraph has already
-// proven acyclic and well-formed, so it never needs its own cycle guard.
+// effectiveEntries' memo lives on st for the whole resolveEffective call,
+// so a mapping node reached through several emitted parents or aliases is
+// inventoried once for the complete resolution, not once per emission.
+// It assumes n comes from a graph validateSourceGraph has already proven
+// acyclic and well-formed, so it never needs its own cycle guard.
 //
 // Before allocating anything for the dereferenced target, it increments
 // st.count and checks it against maxEffectiveOutputNodes; once st.count

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -104,9 +104,14 @@ func walkEffectiveNodes(n *yaml.Node, visit func(*yaml.Node)) {
 // yaml.AliasNode.
 func TestResolveEffectiveOutputHasNoAnchorsOrAliases(t *testing.T) {
 	anchoredKey := &yaml.Node{Kind: yaml.ScalarNode, Anchor: "k", Value: "anchored-key"}
+	anchoredKeyTarget := &yaml.Node{Kind: yaml.ScalarNode, Anchor: "k2", Value: "aliased-key"}
 	anchoredValue := &yaml.Node{Kind: yaml.MappingNode, Anchor: "v", Content: []*yaml.Node{scalarNode("inner"), scalarNode("value")}}
 
-	aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredKey}
+	// aliasKey targets a distinct anchored scalar (not anchoredKey) so its
+	// effectiveKeyIdentity does not collide with anchoredKey's: this test
+	// exercises alias-in-key-position metadata copying, not the separate
+	// effective-identity collision rule (see effectiveidentity_test.go).
+	aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredKeyTarget}
 	aliasValue := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredValue}
 
 	root := &yaml.Node{

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -280,42 +280,6 @@ func TestResolveEffectiveAliasExpansionCopiesTargetMetadata(t *testing.T) {
 	assertTargetMetadata(t, outRoot.Content[4])
 }
 
-// TestResolveEffectiveMergeDirectiveRetainedForNow documents the
-// authorized interim state for this chunk: a recognized "<<" merge
-// directive is still present in resolveEffective's result as an ordinary
-// key, with its operand value resolved like any other value. This is
-// replaced by real merge-precedence resolution in a later chunk, which
-// must also update this test (see
-// docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md).
-func TestResolveEffectiveMergeDirectiveRetainedForNow(t *testing.T) {
-	operand := simpleMapping("from-merge", "value")
-	root := &yaml.Node{
-		Kind:    yaml.MappingNode,
-		Content: []*yaml.Node{mergeKeyNode(), operand, scalarNode("own-key"), scalarNode("own-value")},
-	}
-
-	out, err := resolveEffective("merge.yml", docOf(root))
-	if err != nil {
-		t.Fatalf("resolveEffective returned unexpected error: %v", err)
-	}
-
-	outRoot := out.Content[0]
-	if len(outRoot.Content) != 4 {
-		t.Fatalf("len(outRoot.Content) = %d, want 4 (merge key retained as an ordinary entry)", len(outRoot.Content))
-	}
-	if outRoot.Content[0].Value != "<<" {
-		t.Fatalf("outRoot.Content[0].Value = %q, want \"<<\"", outRoot.Content[0].Value)
-	}
-	mergeValue := outRoot.Content[1]
-	if mergeValue.Kind != yaml.MappingNode || len(mergeValue.Content) != 2 ||
-		mergeValue.Content[0].Value != "from-merge" || mergeValue.Content[1].Value != "value" {
-		t.Fatalf("merge operand not resolved as an ordinary value: %+v", mergeValue)
-	}
-	if outRoot.Content[2].Value != "own-key" || outRoot.Content[3].Value != "own-value" {
-		t.Fatalf("own-key/own-value entry missing or altered: %+v/%+v", outRoot.Content[2], outRoot.Content[3])
-	}
-}
-
 // TestResolveEffectiveQuotedMergeKeyIsOrdinary confirms a !!str-tagged
 // "<<" key and a merge-tagged scalar whose value is not "<<" both survive
 // as ordinary effective keys — a contract unaffected by merge-precedence

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -1,0 +1,366 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestResolveEffectiveNilDocumentReturnsNilNil confirms nil doc is the
+// valid empty-input result for resolveEffective, exactly like
+// parseYAMLDocument and validateSourceGraph.
+func TestResolveEffectiveNilDocumentReturnsNilNil(t *testing.T) {
+	node, err := resolveEffective("cfg.yml", nil)
+	if node != nil {
+		t.Fatalf("resolveEffective(\"cfg.yml\", nil) node = %v, want nil", node)
+	}
+	if err != nil {
+		t.Fatalf("resolveEffective(\"cfg.yml\", nil) err = %v, want nil", err)
+	}
+}
+
+// docOf wraps content in a well-formed yaml.DocumentNode root.
+func docOf(content *yaml.Node) *yaml.Node {
+	return &yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{content}}
+}
+
+// TestResolveEffectiveValidatesSourceGraphFirst is table-driven over four
+// already-rejected source graphs (an alias cycle, an alias with a nil
+// target, a duplicate explicit key, and a merge operand that is a scalar)
+// and confirms resolveEffective returns a nil *yaml.Node and passes
+// validateSourceGraph's Detail and Path through byte-identically, proving
+// resolveEffective cannot be used to bypass source-graph validation.
+func TestResolveEffectiveValidatesSourceGraphFirst(t *testing.T) {
+	const path = "/etc/chairlift/rejected.yml"
+
+	aliasCycle := &yaml.Node{Kind: yaml.MappingNode, Anchor: "self"}
+	selfAlias := &yaml.Node{Kind: yaml.AliasNode, Alias: aliasCycle}
+	aliasCycle.Content = []*yaml.Node{scalarNode("key"), selfAlias}
+
+	aliasNilTarget := &yaml.Node{Kind: yaml.AliasNode, Alias: nil}
+
+	duplicateKey := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("dup"), scalarNode("first"), scalarNode("dup"), scalarNode("second")},
+	}
+
+	mergeScalarOperand := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{mergeKeyNode(), scalarNode("not-a-mapping")},
+	}
+
+	tests := []struct {
+		name string
+		root *yaml.Node
+	}{
+		{name: "alias cycle", root: aliasCycle},
+		{name: "alias with nil target", root: aliasNilTarget},
+		{name: "duplicate explicit key", root: duplicateKey},
+		{name: "merge operand is a scalar", root: mergeScalarOperand},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := docOf(tt.root)
+
+			wantErr := validateSourceGraph(path, doc)
+			wantParseType(t, wantErr, path)
+
+			gotNode, gotErr := resolveEffective(path, doc)
+			if gotNode != nil {
+				t.Fatalf("resolveEffective(%q, ...) node = %v, want nil", path, gotNode)
+			}
+			if gotErr == nil {
+				t.Fatalf("resolveEffective(%q, ...) err = nil, want a *LoadError", path)
+			}
+			if gotErr.Detail != wantErr.Detail {
+				t.Fatalf("resolveEffective Detail = %q, want %q (from validateSourceGraph)", gotErr.Detail, wantErr.Detail)
+			}
+			if gotErr.Path != wantErr.Path {
+				t.Fatalf("resolveEffective Path = %q, want %q (from validateSourceGraph)", gotErr.Path, wantErr.Path)
+			}
+		})
+	}
+}
+
+// walkEffectiveNodes calls visit for n and every node reachable from n
+// through Content, in Content slice order. It never follows an Alias
+// field, since a well-formed resolveEffective result has no AliasNode to
+// follow in the first place.
+func walkEffectiveNodes(n *yaml.Node, visit func(*yaml.Node)) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	for _, child := range n.Content {
+		walkEffectiveNodes(child, visit)
+	}
+}
+
+// TestResolveEffectiveOutputHasNoAnchorsOrAliases builds a fixture using
+// anchors and aliases in both mapping key and mapping value position and
+// confirms every node in resolveEffective's output — document, mappings,
+// sequences, keys, and values — has no Anchor, no Alias, and is never a
+// yaml.AliasNode.
+func TestResolveEffectiveOutputHasNoAnchorsOrAliases(t *testing.T) {
+	anchoredKey := &yaml.Node{Kind: yaml.ScalarNode, Anchor: "k", Value: "anchored-key"}
+	anchoredValue := &yaml.Node{Kind: yaml.MappingNode, Anchor: "v", Content: []*yaml.Node{scalarNode("inner"), scalarNode("value")}}
+
+	aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredKey}
+	aliasValue := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredValue}
+
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			anchoredKey, scalarNode("first-value"),
+			scalarNode("second-key"), anchoredValue,
+			aliasKey, scalarNode("via-alias-key"),
+			scalarNode("third-key"), aliasValue,
+			scalarNode("seq"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{aliasValue, scalarNode("plain")}},
+		},
+	}
+
+	doc := docOf(root)
+	out, err := resolveEffective("anchors.yml", doc)
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+
+	count := 0
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		count++
+		if n.Anchor != "" {
+			t.Errorf("node %+v has non-empty Anchor %q", n, n.Anchor)
+		}
+		if n.Alias != nil {
+			t.Errorf("node %+v has non-nil Alias", n)
+		}
+		if n.Kind == yaml.AliasNode {
+			t.Errorf("node %+v has Kind == yaml.AliasNode", n)
+		}
+	})
+	if count == 0 {
+		t.Fatalf("walkEffectiveNodes visited no nodes")
+	}
+}
+
+// TestResolveEffectivePreservesNodeMetadata confirms that for a scalar, a
+// sequence, and a mapping node, the emitted copy shares Kind, Style, Tag,
+// Value, Line, Column, HeadComment, LineComment, and FootComment with the
+// source node, and that the emitted node is a distinct pointer (mutating
+// the result does not mutate the input).
+func TestResolveEffectivePreservesNodeMetadata(t *testing.T) {
+	assertMetadataPreserved := func(t *testing.T, source, emitted *yaml.Node) {
+		t.Helper()
+		if emitted == source {
+			t.Fatalf("emitted node is the same pointer as the source node")
+		}
+		if emitted.Kind != source.Kind {
+			t.Errorf("Kind = %v, want %v", emitted.Kind, source.Kind)
+		}
+		if emitted.Style != source.Style {
+			t.Errorf("Style = %v, want %v", emitted.Style, source.Style)
+		}
+		if emitted.Tag != source.Tag {
+			t.Errorf("Tag = %q, want %q", emitted.Tag, source.Tag)
+		}
+		if emitted.Value != source.Value {
+			t.Errorf("Value = %q, want %q", emitted.Value, source.Value)
+		}
+		if emitted.Line != source.Line {
+			t.Errorf("Line = %d, want %d", emitted.Line, source.Line)
+		}
+		if emitted.Column != source.Column {
+			t.Errorf("Column = %d, want %d", emitted.Column, source.Column)
+		}
+		if emitted.HeadComment != source.HeadComment {
+			t.Errorf("HeadComment = %q, want %q", emitted.HeadComment, source.HeadComment)
+		}
+		if emitted.LineComment != source.LineComment {
+			t.Errorf("LineComment = %q, want %q", emitted.LineComment, source.LineComment)
+		}
+		if emitted.FootComment != source.FootComment {
+			t.Errorf("FootComment = %q, want %q", emitted.FootComment, source.FootComment)
+		}
+		// Mutating the emitted node must not mutate the source.
+		originalValue := source.Value
+		emitted.Value = "mutated"
+		if source.Value != originalValue {
+			t.Fatalf("mutating emitted node mutated the source node")
+		}
+	}
+
+	t.Run("scalar", func(t *testing.T) {
+		source := &yaml.Node{
+			Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Tag: "!!str", Value: "hello",
+			Line: 3, Column: 5, HeadComment: "# head", LineComment: "# line", FootComment: "# foot",
+		}
+		out, err := resolveEffective("scalar.yml", docOf(source))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		assertMetadataPreserved(t, source, out.Content[0])
+	})
+
+	t.Run("sequence", func(t *testing.T) {
+		source := &yaml.Node{
+			Kind: yaml.SequenceNode, Style: yaml.FlowStyle, Tag: "!!seq",
+			Line: 7, Column: 2, HeadComment: "# seqhead", LineComment: "# seqline", FootComment: "# seqfoot",
+			Content: []*yaml.Node{scalarNode("a"), scalarNode("b")},
+		}
+		out, err := resolveEffective("sequence.yml", docOf(source))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		assertMetadataPreserved(t, source, out.Content[0])
+	})
+
+	t.Run("mapping", func(t *testing.T) {
+		source := &yaml.Node{
+			Kind: yaml.MappingNode, Style: yaml.FlowStyle, Tag: "!!map",
+			Line: 11, Column: 9, HeadComment: "# maphead", LineComment: "# mapline", FootComment: "# mapfoot",
+			Content: []*yaml.Node{scalarNode("k"), scalarNode("v")},
+		}
+		out, err := resolveEffective("mapping.yml", docOf(source))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		assertMetadataPreserved(t, source, out.Content[0])
+	})
+}
+
+// TestResolveEffectiveAliasExpansionCopiesTargetMetadata confirms that an
+// expanded alias's emitted node carries the dereferenced target's
+// Line/Column/Tag/Style/comments, not the alias node's own (near-zero)
+// metadata, both for an alias in mapping value position and for an alias
+// used as a mapping key.
+func TestResolveEffectiveAliasExpansionCopiesTargetMetadata(t *testing.T) {
+	target := &yaml.Node{
+		Kind: yaml.ScalarNode, Style: yaml.DoubleQuotedStyle, Tag: "!!str", Value: "target-value",
+		Anchor: "shared", Line: 42, Column: 17,
+		HeadComment: "# target head", LineComment: "# target line", FootComment: "# target foot",
+	}
+	// The alias node itself carries no meaningful metadata of its own -
+	// deliberately different Line/Column so a bug that copies the alias
+	// node's own metadata instead of the target's would be caught.
+	aliasAsValue := &yaml.Node{Kind: yaml.AliasNode, Alias: target, Line: 1, Column: 1}
+	aliasAsKey := &yaml.Node{Kind: yaml.AliasNode, Alias: target, Line: 2, Column: 2}
+
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("anchored"), target,
+			scalarNode("via-value"), aliasAsValue,
+			aliasAsKey, scalarNode("via-key"),
+		},
+	}
+
+	out, err := resolveEffective("alias-metadata.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+
+	outRoot := out.Content[0]
+	assertTargetMetadata := func(t *testing.T, n *yaml.Node) {
+		t.Helper()
+		if n.Line != target.Line || n.Column != target.Column {
+			t.Fatalf("Line/Column = %d/%d, want target's %d/%d", n.Line, n.Column, target.Line, target.Column)
+		}
+		if n.Tag != target.Tag || n.Style != target.Style || n.Value != target.Value {
+			t.Fatalf("Tag/Style/Value = %q/%v/%q, want target's %q/%v/%q", n.Tag, n.Style, n.Value, target.Tag, target.Style, target.Value)
+		}
+		if n.HeadComment != target.HeadComment || n.LineComment != target.LineComment || n.FootComment != target.FootComment {
+			t.Fatalf("comments = %q/%q/%q, want target's %q/%q/%q", n.HeadComment, n.LineComment, n.FootComment, target.HeadComment, target.LineComment, target.FootComment)
+		}
+	}
+
+	// entry index 2 (0-based: "via-value" key at index 2, alias value at index 3)
+	assertTargetMetadata(t, outRoot.Content[3])
+	// entry index 4 (alias key), index 5 ("via-key" value)
+	assertTargetMetadata(t, outRoot.Content[4])
+}
+
+// TestResolveEffectiveMergeDirectiveRetainedForNow documents the
+// authorized interim state for this chunk: a recognized "<<" merge
+// directive is still present in resolveEffective's result as an ordinary
+// key, with its operand value resolved like any other value. This is
+// replaced by real merge-precedence resolution in a later chunk, which
+// must also update this test (see
+// docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md).
+func TestResolveEffectiveMergeDirectiveRetainedForNow(t *testing.T) {
+	operand := simpleMapping("from-merge", "value")
+	root := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{mergeKeyNode(), operand, scalarNode("own-key"), scalarNode("own-value")},
+	}
+
+	out, err := resolveEffective("merge.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 4 {
+		t.Fatalf("len(outRoot.Content) = %d, want 4 (merge key retained as an ordinary entry)", len(outRoot.Content))
+	}
+	if outRoot.Content[0].Value != "<<" {
+		t.Fatalf("outRoot.Content[0].Value = %q, want \"<<\"", outRoot.Content[0].Value)
+	}
+	mergeValue := outRoot.Content[1]
+	if mergeValue.Kind != yaml.MappingNode || len(mergeValue.Content) != 2 ||
+		mergeValue.Content[0].Value != "from-merge" || mergeValue.Content[1].Value != "value" {
+		t.Fatalf("merge operand not resolved as an ordinary value: %+v", mergeValue)
+	}
+	if outRoot.Content[2].Value != "own-key" || outRoot.Content[3].Value != "own-value" {
+		t.Fatalf("own-key/own-value entry missing or altered: %+v/%+v", outRoot.Content[2], outRoot.Content[3])
+	}
+}
+
+// TestResolveEffectiveQuotedMergeKeyIsOrdinary confirms a !!str-tagged
+// "<<" key and a merge-tagged scalar whose value is not "<<" both survive
+// as ordinary effective keys — a contract unaffected by merge-precedence
+// work landing in a later chunk.
+func TestResolveEffectiveQuotedMergeKeyIsOrdinary(t *testing.T) {
+	quotedMergeKey := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "<<"}
+	nonMergeValueTaggedMerge := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!merge", Value: "not-merge"}
+
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			quotedMergeKey, scalarNode("quoted-value"),
+			nonMergeValueTaggedMerge, scalarNode("tagged-value"),
+		},
+	}
+
+	out, err := resolveEffective("quoted-merge.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 4 {
+		t.Fatalf("len(outRoot.Content) = %d, want 4", len(outRoot.Content))
+	}
+	if outRoot.Content[0].Tag != "!!str" || outRoot.Content[0].Value != "<<" {
+		t.Fatalf("quoted merge key not preserved as ordinary: %+v", outRoot.Content[0])
+	}
+	if outRoot.Content[2].Tag != "!!merge" || outRoot.Content[2].Value != "not-merge" {
+		t.Fatalf("merge-tagged non-\"<<\" key not preserved as ordinary: %+v", outRoot.Content[2])
+	}
+}
+
+// TestResolveEffectiveDocumentRootShape confirms a valid document's result
+// is rooted at a node with Kind == yaml.DocumentNode and exactly one entry
+// in Content.
+func TestResolveEffectiveDocumentRootShape(t *testing.T) {
+	out, err := resolveEffective("root-shape.yml", docOf(simpleMapping("k", "v")))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	if out.Kind != yaml.DocumentNode {
+		t.Fatalf("out.Kind = %v, want yaml.DocumentNode", out.Kind)
+	}
+	if len(out.Content) != 1 {
+		t.Fatalf("len(out.Content) = %d, want 1", len(out.Content))
+	}
+}

--- a/internal/config/effectivebound_test.go
+++ b/internal/config/effectivebound_test.go
@@ -1,0 +1,163 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// buildWideMapping returns a well-formed yaml.MappingNode with exactly
+// pairs key/value entries, each a distinct plain scalar with no Line set,
+// for exercising resolveEffective's maxEffectiveOutputNodes boundary: the
+// emitted node count for docOf(buildWideMapping(pairs)) is exactly
+// 1 (document) + 1 (mapping) + 2*pairs (keys and values).
+func buildWideMapping(pairs int) *yaml.Node {
+	content := make([]*yaml.Node, 0, pairs*2)
+	for i := 0; i < pairs; i++ {
+		content = append(content,
+			newSourceScalarNode("k"+strconv.Itoa(i)), newSourceScalarNode("v"),
+		)
+	}
+	return newSourceMappingNode(content...)
+}
+
+// countEffectiveNodes returns the number of nodes reachable from n via
+// walkEffectiveNodes.
+func countEffectiveNodes(n *yaml.Node) int {
+	count := 0
+	walkEffectiveNodes(n, func(*yaml.Node) { count++ })
+	return count
+}
+
+// TestResolveEffectiveOutputNodeLimitBoundary confirms the
+// 100,000/100,001 emitted-node boundary exactly: a document containing a
+// single mapping of exactly 49,999 key/value pairs emits exactly
+// 1 (document) + 1 (mapping) + 2*49,999 = 100,000 nodes and succeeds,
+// while 50,000 pairs (100,002 nodes) fails with a nil result and a
+// non-nil *LoadError.
+func TestResolveEffectiveOutputNodeLimitBoundary(t *testing.T) {
+	const path = "/etc/chairlift/output-node-boundary.yml"
+
+	t.Run("exactly 100000 nodes succeeds", func(t *testing.T) {
+		doc := newSourceDocNode(buildWideMapping(49999))
+		out, err := resolveEffective(path, doc)
+		if err != nil {
+			t.Fatalf("resolveEffective(49999 pairs) err = %v, want nil", err)
+		}
+		if got := countEffectiveNodes(out); got != maxEffectiveOutputNodes {
+			t.Fatalf("countEffectiveNodes = %d, want %d", got, maxEffectiveOutputNodes)
+		}
+	})
+
+	t.Run("100002 nodes fails", func(t *testing.T) {
+		doc := newSourceDocNode(buildWideMapping(50000))
+		out, err := resolveEffective(path, doc)
+		if out != nil {
+			t.Fatalf("resolveEffective(50000 pairs) node = %v, want nil", out)
+		}
+		if err == nil {
+			t.Fatalf("resolveEffective(50000 pairs) err = nil, want a *LoadError")
+		}
+	})
+}
+
+// TestResolveEffectiveOutputLimitErrorShape confirms the shape of the
+// *LoadError resolveEffective returns when the emitted-node budget is
+// exceeded: KindParseType, Path copied from the path argument, a nil Err,
+// a Detail naming the maxEffectiveOutputNodes bound, and a positive "line
+// N" substring in Detail.
+func TestResolveEffectiveOutputLimitErrorShape(t *testing.T) {
+	const path = "/etc/chairlift/output-limit-shape.yml"
+
+	doc := newSourceDocNode(buildWideMapping(50000))
+	out, err := resolveEffective(path, doc)
+	if out != nil {
+		t.Fatalf("resolveEffective node = %v, want nil", out)
+	}
+	wantParseType(t, err, path)
+	if err.Err != nil {
+		t.Fatalf("err.Err = %v, want nil", err.Err)
+	}
+	if err.Path != path {
+		t.Fatalf("err.Path = %q, want %q", err.Path, path)
+	}
+	if !strings.Contains(err.Detail, "100000") {
+		t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "100000")
+	}
+	if got := sourceDetailLine(t, err); got <= 0 {
+		t.Fatalf("attributed line = %d, want > 0", got)
+	}
+}
+
+// runResolveEffectiveWithin runs resolveEffective(path, doc) on a
+// goroutine and fails the test if it has not returned within timeout,
+// mirroring runSourceValidateWithin: the only way to prove a
+// non-terminating (exponential) emission fails the test instead of simply
+// hanging the test binary.
+func runResolveEffectiveWithin(t *testing.T, path string, doc *yaml.Node, timeout time.Duration) (*yaml.Node, *LoadError) {
+	t.Helper()
+	type result struct {
+		node *yaml.Node
+		err  *LoadError
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		node, err := resolveEffective(path, doc)
+		resultCh <- result{node: node, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case r := <-resultCh:
+		return r.node, r.err
+	case <-timer.C:
+		t.Fatalf("resolveEffective(%q, ...) did not return within %s", path, timeout)
+		return nil, nil
+	}
+}
+
+// TestResolveEffectiveAliasExpansionChargedPerCopy builds a compact
+// alias-sharing DAG (buildSourceSharingDAG) of 40 doubling levels: its
+// *source* graph is tiny (three nodes per level, well under both
+// maxSourcePathVisits=128 and maxAliasHops=64), but its alias-free
+// *expanded* output would need on the order of 2^40 nodes if fully
+// materialized, since each level's two aliases both dereference to (and
+// so each independently re-emit a full copy of) the same shared previous
+// level. This confirms resolveEffective returns the output-limit error —
+// not a hang and not success — and, because emitEffectiveNode aborts as
+// soon as its budget is exceeded rather than continuing to expand, does
+// so well within a five-second bounded timeout.
+func TestResolveEffectiveAliasExpansionChargedPerCopy(t *testing.T) {
+	const path = "/etc/chairlift/alias-expansion-charged.yml"
+
+	doc := newSourceDocNode(buildSourceSharingDAG(40))
+	out, err := runResolveEffectiveWithin(t, path, doc, 5*time.Second)
+	if out != nil {
+		t.Fatalf("resolveEffective(compact alias-sharing DAG) node = %v, want nil", out)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "100000") {
+		t.Fatalf("err.Detail = %q, want the literal %q", err.Detail, "100000")
+	}
+}
+
+// TestResolveEffectiveOutputLimitLineFallsBackToOne confirms that for a
+// wholly synthetic over-limit graph with no positive Line metadata
+// anywhere, the reported line falls back to 1 — attributeSourceLines'
+// documented fallback for a graph with no positive-line node reachable on
+// any path — proving the error's line is always positive even when no
+// source node offers one.
+func TestResolveEffectiveOutputLimitLineFallsBackToOne(t *testing.T) {
+	const path = "/etc/chairlift/output-limit-line-fallback.yml"
+
+	doc := newSourceDocNode(buildWideMapping(50000))
+	_, err := resolveEffective(path, doc)
+	wantParseType(t, err, path)
+	if got := sourceDetailLine(t, err); got != 1 {
+		t.Fatalf("attributed line = %d, want 1 (wholly synthetic fallback)", got)
+	}
+}

--- a/internal/config/effectiveidentity_test.go
+++ b/internal/config/effectiveidentity_test.go
@@ -1,0 +1,310 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestResolveEffectiveAliasKeyCollidesWithDirectScalarKey builds a mapping
+// with two explicit keys — a direct scalar "foo" and an alias to an
+// anchored scalar "foo" — that sourceKeyID's tag-blind Kind+Value
+// comparison does not catch as a duplicate (the alias node's own Kind is
+// yaml.AliasNode and its own Value is "", both different from the direct
+// scalar key's yaml.ScalarNode/"foo"), so validateSourceGraph accepts the
+// fixture. It confirms resolveEffective's post-alias effective-identity
+// collision rule catches it anyway: a nil result and a *LoadError with
+// Kind == KindParseType, Path copied from the passed path, a nil Err, and
+// a Detail whose parsed line equals the LATER key's (the alias key's) own
+// positive Line.
+func TestResolveEffectiveAliasKeyCollidesWithDirectScalarKey(t *testing.T) {
+	const path = "/etc/chairlift/alias-key-collision.yml"
+
+	anchoredFoo := &yaml.Node{Kind: yaml.ScalarNode, Anchor: "foo-anchor", Value: "foo", Line: 5}
+	directKey := &yaml.Node{Kind: yaml.ScalarNode, Value: "foo", Line: 3}
+	aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredFoo, Line: 9}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("def"), anchoredFoo,
+			directKey, scalarNode("direct-value"),
+			aliasKey, scalarNode("alias-value"),
+		},
+	}
+	doc := docOf(root)
+
+	if err := validateSourceGraph(path, doc); err != nil {
+		t.Fatalf("validateSourceGraph unexpectedly rejected fixture: %v", err)
+	}
+
+	out, err := resolveEffective(path, doc)
+	if out != nil {
+		t.Fatalf("resolveEffective(...) node = %v, want nil", out)
+	}
+	wantParseType(t, err, path)
+	if err.Err != nil {
+		t.Fatalf("err.Err = %v, want nil", err.Err)
+	}
+	if got := sourceDetailLine(t, err); got != aliasKey.Line {
+		t.Fatalf("attributed line = %d, want the later key's own line %d", got, aliasKey.Line)
+	}
+}
+
+// TestResolveEffectiveCollisionLineFallsBackWhenUnpositioned confirms the
+// collision error's reported line uses the same own-line / nearest-
+// positive-line-ancestor / 1-fallback contract as the c3 output-limit
+// error: when the later colliding key has no positive Line of its own,
+// the reported line is its nearest positive-line ancestor over all paths,
+// and 1 when the whole graph carries no line metadata at all. The
+// reported line is > 0 in every case.
+func TestResolveEffectiveCollisionLineFallsBackWhenUnpositioned(t *testing.T) {
+	t.Run("falls back to nearest positive-line ancestor", func(t *testing.T) {
+		const path = "/etc/chairlift/collision-line-ancestor-fallback.yml"
+
+		anchoredFoo := &yaml.Node{Kind: yaml.ScalarNode, Value: "foo"}
+		directKey := &yaml.Node{Kind: yaml.ScalarNode, Value: "foo"}
+		aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredFoo}
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Line: 11,
+			Content: []*yaml.Node{
+				scalarNode("def"), anchoredFoo,
+				directKey, scalarNode("direct-value"),
+				aliasKey, scalarNode("alias-value"),
+			},
+		}
+		doc := docOf(root)
+
+		if err := validateSourceGraph(path, doc); err != nil {
+			t.Fatalf("validateSourceGraph unexpectedly rejected fixture: %v", err)
+		}
+
+		out, err := resolveEffective(path, doc)
+		if out != nil {
+			t.Fatalf("resolveEffective(...) node = %v, want nil", out)
+		}
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 11 {
+			t.Fatalf("attributed line = %d, want the nearest positive-line ancestor's line 11", got)
+		}
+	})
+
+	t.Run("falls back to 1 when no line metadata anywhere", func(t *testing.T) {
+		const path = "/etc/chairlift/collision-line-one-fallback.yml"
+
+		anchoredFoo := &yaml.Node{Kind: yaml.ScalarNode, Value: "foo"}
+		directKey := &yaml.Node{Kind: yaml.ScalarNode, Value: "foo"}
+		aliasKey := &yaml.Node{Kind: yaml.AliasNode, Alias: anchoredFoo}
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				scalarNode("def"), anchoredFoo,
+				directKey, scalarNode("direct-value"),
+				aliasKey, scalarNode("alias-value"),
+			},
+		}
+		doc := docOf(root)
+
+		if err := validateSourceGraph(path, doc); err != nil {
+			t.Fatalf("validateSourceGraph unexpectedly rejected fixture: %v", err)
+		}
+
+		out, err := resolveEffective(path, doc)
+		if out != nil {
+			t.Fatalf("resolveEffective(...) node = %v, want nil", out)
+		}
+		wantParseType(t, err, path)
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want the wholly synthetic fallback 1", got)
+		}
+	})
+}
+
+// TestResolveEffectiveInheritedCollisionIsSuppressionNotError asserts an
+// explicit key colliding with an INHERITED merge candidate of the same
+// effective identity returns no error and keeps the explicit value,
+// proving the collision rule applies only to two EXPLICIT keys of one
+// source mapping, not to an explicit key suppressing an inherited one.
+func TestResolveEffectiveInheritedCollisionIsSuppressionNotError(t *testing.T) {
+	operand := simpleMapping("shared", "inherited-value")
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("shared"), scalarNode("explicit-value"),
+			mergeKeyNode(), operand,
+		},
+	}
+
+	out, err := resolveEffective("inherited-collision-suppression.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+	}
+	if outRoot.Content[0].Value != "shared" || outRoot.Content[1].Value != "explicit-value" {
+		t.Fatalf("got key=%q value=%q, want shared=explicit-value", outRoot.Content[0].Value, outRoot.Content[1].Value)
+	}
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		if n.Value == "inherited-value" {
+			t.Fatalf("suppressed inherited value leaked into the result")
+		}
+	})
+}
+
+// TestResolveEffectiveValidExplicitOverridesInvalidInherited asserts the
+// explicit valid value is present in the result, and the invalid
+// inherited value's content — a shape the next strict-schema slice would
+// reject — appears nowhere in the emitted tree, because it is suppressed
+// and so never resolved or emitted.
+func TestResolveEffectiveValidExplicitOverridesInvalidInherited(t *testing.T) {
+	invalidInherited := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{scalarNode("invalid-inherited-content")}}
+	operand := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("k"), invalidInherited}}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), operand,
+			scalarNode("k"), scalarNode("valid-explicit-value"),
+		},
+	}
+
+	out, err := resolveEffective("valid-overrides-invalid.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+	}
+	if outRoot.Content[0].Value != "k" || outRoot.Content[1].Value != "valid-explicit-value" {
+		t.Fatalf("got key=%q value=%q, want k=valid-explicit-value", outRoot.Content[0].Value, outRoot.Content[1].Value)
+	}
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		if n.Value == "invalid-inherited-content" {
+			t.Fatalf("invalid inherited content leaked into the result")
+		}
+	})
+}
+
+// TestResolveEffectiveInvalidLosingSequenceValueUnmaterialized asserts a
+// later sequence operand's structurally odd/invalid-for-ChairLift value
+// never appears in the result and produces no error, because a losing
+// merge candidate's value is never resolved or emitted regardless of its
+// own shape.
+func TestResolveEffectiveInvalidLosingSequenceValueUnmaterialized(t *testing.T) {
+	a := simpleMapping("k", "valid-from-a")
+	invalidB := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{scalarNode("invalid-losing-content")}}
+	b := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("k"), invalidB}}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		newSourceAliasNode(a), newSourceAliasNode(b),
+	}}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{mergeKeyNode(), seq}}
+
+	out, err := resolveEffective("invalid-losing-sequence-value.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+	}
+	if outRoot.Content[0].Value != "k" || outRoot.Content[1].Value != "valid-from-a" {
+		t.Fatalf("got key=%q value=%q, want k=valid-from-a", outRoot.Content[0].Value, outRoot.Content[1].Value)
+	}
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		if n.Value == "invalid-losing-content" {
+			t.Fatalf("invalid losing operand content leaked into the result")
+		}
+	})
+}
+
+// TestResolveEffectiveInvalidWinningValueRetained asserts a winning value
+// that the next strict-schema slice would reject (a sequence where a
+// mapping is expected) is present in the result verbatim and produces no
+// error from resolveEffective, which performs no schema validation of its
+// own.
+func TestResolveEffectiveInvalidWinningValueRetained(t *testing.T) {
+	invalidWinning := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{scalarNode("unexpected-sequence-element")}}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("pages"), invalidWinning}}
+
+	out, err := resolveEffective("invalid-winning-retained.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2: %+v", len(outRoot.Content), outRoot.Content)
+	}
+	valueOut := outRoot.Content[1]
+	if valueOut.Kind != yaml.SequenceNode || len(valueOut.Content) != 1 || valueOut.Content[0].Value != "unexpected-sequence-element" {
+		t.Fatalf("winning value not retained verbatim: %+v", valueOut)
+	}
+}
+
+// TestResolveEffectiveSharedAliasDAGInLosingBranchTerminates builds a
+// compact alias-sharing DAG (buildSourceSharingDAG, deep enough that naive
+// per-path expansion is exponential, while staying within the
+// 64-alias-hop and 128-path-visit source bounds) inside a complex key of
+// a merge-LOSING value: per interpretation 7, a complex key can never
+// itself lose a precedence contest (distinct complex-key nodes have
+// distinct pointer identities), so the DAG is placed as the complex key
+// of a mapping that is itself the value of a merge candidate suppressed
+// by an explicit key of the same identity. Because a losing candidate's
+// value is never resolved or emitted, that mapping — and the DAG inside
+// its complex key — is never inventoried, dereferenced, or expanded at
+// all.
+//
+// It asserts the call returns a nil error and a non-nil result, that the
+// result contains the winning explicit value and no node from the losing
+// branch, that the whole call completes in under five seconds measured
+// with runResolveEffectiveWithin (the test fails, not hangs, if the
+// deadline is exceeded), and that the result's total emitted node count
+// is far below maxEffectiveOutputNodes — proving the discarded temporary
+// work was never charged to the output-node budget even though expanding
+// it would exceed that budget.
+func TestResolveEffectiveSharedAliasDAGInLosingBranchTerminates(t *testing.T) {
+	const path = "/etc/chairlift/losing-branch-shared-dag.yml"
+
+	sharedDAG := buildSourceSharingDAG(60)
+	losingValue := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{sharedDAG, scalarNode("losing-complex-key-value")},
+	}
+	mergeOperand := &yaml.Node{
+		Kind:    yaml.MappingNode,
+		Content: []*yaml.Node{scalarNode("shared"), losingValue},
+	}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("shared"), scalarNode("winning-value"),
+			mergeKeyNode(), mergeOperand,
+		},
+	}
+	doc := docOf(root)
+
+	out, err := runResolveEffectiveWithin(t, path, doc, 5*time.Second)
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	if out == nil {
+		t.Fatalf("resolveEffective(...) node = nil, want a non-nil result")
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+	}
+	if outRoot.Content[0].Value != "shared" || outRoot.Content[1].Value != "winning-value" {
+		t.Fatalf("got key=%q value=%q, want shared=winning-value", outRoot.Content[0].Value, outRoot.Content[1].Value)
+	}
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		if n.Value == "losing-complex-key-value" {
+			t.Fatalf("losing branch content leaked into the result")
+		}
+	})
+	if got := countEffectiveNodes(out); got >= maxEffectiveOutputNodes {
+		t.Fatalf("countEffectiveNodes = %d, want far below maxEffectiveOutputNodes (%d)", got, maxEffectiveOutputNodes)
+	}
+}

--- a/internal/config/effectivekeys.go
+++ b/internal/config/effectivekeys.go
@@ -1,0 +1,60 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// effectiveKeyID is a comparable identity for a mapping key used by
+// merge-precedence resolution (a later chunk's resolveEffective), as
+// distinct from sourceKeyID's tag-blind duplicate-key detection in
+// sourcegraph.go. Two effectiveKeyID values compare equal, and therefore
+// collide as map keys, exactly when effectiveKeyIdentity considers their
+// source nodes "the same key" for merge-precedence purposes: see
+// effectiveKeyIdentity's doc comment for the scalar and complex identity
+// rules, and
+// docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md
+// for why a scalar identity must include its resolved tag, not just Value.
+type effectiveKeyID struct {
+	kind    yaml.Kind
+	tag     string
+	value   string
+	complex *yaml.Node
+}
+
+// effectiveKeyIdentity computes n's effectiveKeyID for merge-precedence
+// key comparison. It first follows n's yaml.AliasNode chain to its
+// non-alias target, guarded by a local seen-set keyed on node pointer so a
+// synthetic self-referential (or otherwise cyclic) alias handed directly
+// to this helper terminates instead of looping forever; real callers only
+// ever pass nodes from a graph validateSourceGraph has already proven
+// acyclic, so that guard is a defense-in-depth backstop, not a path any
+// production caller is expected to hit. A nil n, or an alias chain that
+// dead-ends on a nil Alias, yields the zero effectiveKeyID.
+//
+// Once resolved to a non-alias target: a yaml.ScalarNode target yields
+// {kind: yaml.ScalarNode, tag: target.ShortTag(), value: target.Value} —
+// target.ShortTag() is used (rather than the raw Tag field) because
+// gopkg.in/yaml.v3 v3.0.1's yaml.go implements ShortTag to resolve an
+// unset or "!" tag from the node's own properties (resolve("", n.Value)
+// for scalars), so two scalars with the same Kind, resolved tag, and
+// Value are the same key regardless of whether either wrote its tag
+// explicitly. A yaml.MappingNode or yaml.SequenceNode target yields
+// {complex: target}: identity is the target node's pointer alone, with no
+// structural expansion of the complex key's contents — two distinct nodes
+// that happen to look alike are different keys, and two aliases sharing
+// one target are the same key.
+func effectiveKeyIdentity(n *yaml.Node) effectiveKeyID {
+	seen := make(map[*yaml.Node]bool)
+	for n != nil && n.Kind == yaml.AliasNode {
+		if seen[n] {
+			return effectiveKeyID{}
+		}
+		seen[n] = true
+		n = n.Alias
+	}
+	if n == nil {
+		return effectiveKeyID{}
+	}
+	if n.Kind == yaml.MappingNode || n.Kind == yaml.SequenceNode {
+		return effectiveKeyID{complex: n}
+	}
+	return effectiveKeyID{kind: n.Kind, tag: n.ShortTag(), value: n.Value}
+}

--- a/internal/config/effectivekeys_test.go
+++ b/internal/config/effectivekeys_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestEffectiveKeyIdentityScalarTagAware exercises effectiveKeyIdentity
+// directly against scalar nodes, proving identity is tag-aware (Kind +
+// resolved ShortTag + Value), not Value alone
+// (docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md).
+func TestEffectiveKeyIdentityScalarTagAware(t *testing.T) {
+	bareOne := scalarNode("1")
+	taggedIntOne := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "1"}
+	taggedStrOne := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "1"}
+	zeroOne := scalarNode("01")
+
+	bareID := effectiveKeyIdentity(bareOne)
+	taggedIntID := effectiveKeyIdentity(taggedIntOne)
+	taggedStrID := effectiveKeyIdentity(taggedStrOne)
+	zeroOneID := effectiveKeyIdentity(zeroOne)
+
+	if bareID != taggedIntID {
+		t.Fatalf("effectiveKeyIdentity(bare 1) = %+v, effectiveKeyIdentity(!!int 1) = %+v, want equal", bareID, taggedIntID)
+	}
+	if bareID == taggedStrID {
+		t.Fatalf("effectiveKeyIdentity(bare 1) = %+v, effectiveKeyIdentity(!!str \"1\") = %+v, want unequal", bareID, taggedStrID)
+	}
+	if bareID == zeroOneID {
+		t.Fatalf("effectiveKeyIdentity(1) = %+v, effectiveKeyIdentity(01) = %+v, want unequal", bareID, zeroOneID)
+	}
+
+	// effectiveKeyID must be usable directly as a map key.
+	seen := map[effectiveKeyID]struct{}{
+		bareID:      {},
+		taggedStrID: {},
+		zeroOneID:   {},
+	}
+	if len(seen) != 3 {
+		t.Fatalf("map[effectiveKeyID]struct{} collapsed distinct identities: got %d entries, want 3", len(seen))
+	}
+	if _, ok := seen[taggedIntID]; !ok {
+		t.Fatalf("map[effectiveKeyID]struct{} lookup for equal identity (bare 1 vs !!int 1) missed")
+	}
+}
+
+// TestEffectiveKeyIdentityAliasToScalarMatchesDirectScalar asserts that
+// effectiveKeyIdentity dereferences alias chains to their scalar target
+// before computing identity, including a two-hop alias-to-alias-to-scalar
+// chain.
+func TestEffectiveKeyIdentityAliasToScalarMatchesDirectScalar(t *testing.T) {
+	direct := scalarNode("foo")
+	target := scalarNode("foo")
+	alias := &yaml.Node{Kind: yaml.AliasNode, Alias: target}
+
+	directID := effectiveKeyIdentity(direct)
+	aliasID := effectiveKeyIdentity(alias)
+	if directID != aliasID {
+		t.Fatalf("effectiveKeyIdentity(direct scalar) = %+v, effectiveKeyIdentity(alias->scalar) = %+v, want equal", directID, aliasID)
+	}
+
+	aliasToAlias := &yaml.Node{Kind: yaml.AliasNode, Alias: alias}
+	twoHopID := effectiveKeyIdentity(aliasToAlias)
+	if directID != twoHopID {
+		t.Fatalf("effectiveKeyIdentity(direct scalar) = %+v, effectiveKeyIdentity(alias->alias->scalar) = %+v, want equal", directID, twoHopID)
+	}
+}
+
+// TestEffectiveKeyIdentityComplexKeysUsePointerIdentity asserts that
+// mapping/sequence key identity is pointer-based with no structural
+// expansion: distinct-but-identical-looking complex nodes are unequal,
+// aliases sharing one complex target are equal, a sequence and a mapping
+// with the same (empty) shape stay distinct, and a complex identity never
+// equals any scalar identity.
+func TestEffectiveKeyIdentityComplexKeysUsePointerIdentity(t *testing.T) {
+	m1 := &yaml.Node{Kind: yaml.MappingNode}
+	m2 := &yaml.Node{Kind: yaml.MappingNode}
+	if effectiveKeyIdentity(m1) == effectiveKeyIdentity(m2) {
+		t.Fatalf("two distinct structurally-identical mapping nodes produced equal identities, want unequal")
+	}
+
+	aliasToM1a := &yaml.Node{Kind: yaml.AliasNode, Alias: m1}
+	aliasToM1b := &yaml.Node{Kind: yaml.AliasNode, Alias: m1}
+	if effectiveKeyIdentity(aliasToM1a) != effectiveKeyIdentity(aliasToM1b) {
+		t.Fatalf("two aliases pointing at the same complex target produced unequal identities, want equal")
+	}
+
+	seq := &yaml.Node{Kind: yaml.SequenceNode}
+	mapNode := &yaml.Node{Kind: yaml.MappingNode}
+	if effectiveKeyIdentity(seq) == effectiveKeyIdentity(mapNode) {
+		t.Fatalf("a sequence key and a mapping key produced equal identities, want distinct (pointer identity)")
+	}
+
+	scalar := scalarNode("")
+	if effectiveKeyIdentity(m1) == effectiveKeyIdentity(scalar) {
+		t.Fatalf("complex identity equaled a scalar identity, want always distinct")
+	}
+}
+
+// TestEffectiveKeyIdentitySelfAliasTerminates proves the local seen-set
+// guard lets effectiveKeyIdentity terminate on a synthetic self-referential
+// alias handed directly to it, rather than hanging. Real callers only ever
+// pass nodes from a graph validateSourceGraph has already proven acyclic;
+// this test covers the defense-in-depth backstop for synthetic input.
+func TestEffectiveKeyIdentitySelfAliasTerminates(t *testing.T) {
+	self := &yaml.Node{Kind: yaml.AliasNode}
+	self.Alias = self
+
+	done := make(chan effectiveKeyID, 1)
+	go func() { done <- effectiveKeyIdentity(self) }()
+
+	select {
+	case got := <-done:
+		if got != (effectiveKeyID{}) {
+			t.Fatalf("effectiveKeyIdentity(self-referential alias) = %+v, want zero value", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("effectiveKeyIdentity(self-referential alias) did not return within 2s")
+	}
+}

--- a/internal/config/effectivemerge.go
+++ b/internal/config/effectivemerge.go
@@ -1,0 +1,159 @@
+package config
+
+import "gopkg.in/yaml.v3"
+
+// effectiveEntry is one candidate mapping entry discovered while computing
+// a mapping node's effective (post-merge) inventory: id is the entry key's
+// effectiveKeyIdentity, used to decide whether two candidates from
+// different sources are "the same key" for merge-precedence purposes; key
+// and value are the source nodes (not yet emitted/copied) for that
+// candidate's key and value.
+type effectiveEntry struct {
+	id    effectiveKeyID
+	key   *yaml.Node
+	value *yaml.Node
+}
+
+// effectiveMergeMemo memoizes effectiveEntries results by mapping-node
+// pointer identity for the duration of one effectiveEntries call and its
+// recursion into merge operands. A mapping reached as a merge operand
+// through more than one parent within that recursion, or through more
+// than one alias to the same anchor, has its candidate inventory computed
+// once and reused, rather than recomputed once per parent — this is what
+// keeps a shared-operand fan-out, or a doubling merge DAG like the one
+// TestResolveEffectiveSharedOperandInventoriedOnce builds, linear in the
+// number of distinct mapping nodes rather than exponential in fan-out
+// depth. Memoizing after the recursive call below (rather than before) is
+// safe without its own cycle guard because validateSourceGraph has already
+// proven the whole source graph acyclic before resolveEffective ever
+// calls this.
+type effectiveMergeMemo map[*yaml.Node][]effectiveEntry
+
+// effectiveEntries computes m's complete, ordered, deduplicated effective
+// entry inventory: retained explicit entries first, in m's source Content
+// order, excluding recognized merge directives (isMergeKey); then
+// inherited winners in merge-candidate discovery order — discovered by
+// merge directives in source Content order, sequence operands left to
+// right, and each operand mapping's own effectiveEntries computed
+// recursively (so a nested merge inside a merge operand is flattened
+// before its candidates are considered here).
+//
+// Candidates are deduplicated by effectiveKeyIdentity keeping the FIRST
+// candidate encountered in that discovery order. Because retained explicit
+// entries are always listed first, this yields explicit-over-merged
+// precedence; because merge candidates are discovered in source Content
+// and sequence-operand order, it yields earlier-operand-wins precedence;
+// and because the explicit pass runs before the merge pass regardless of
+// where the `<<` directive appears in m's Content, an explicit key
+// suppresses a matching inherited candidate whether the directive comes
+// before or after that explicit key in the source.
+//
+// This reproduces gopkg.in/yaml.v3 v3.0.1 decode.go's decoder.mapping /
+// decoder.merge behavior exactly: mapping decodes explicit entries first
+// and skips isMerge keys, then merge seeds mergedFields from every
+// explicit parent key before consuming operands in Content order and
+// marking each merged key as it is consumed — with nested merges
+// inheriting the accumulated set rather than resetting it, which is why
+// this function's own recursive calls flatten rather than re-seed.
+//
+// effectiveEntries creates a fresh effectiveMergeMemo scoped to this one
+// call (and delegates to effectiveEntriesWithMemo, which threads it
+// through the recursion below): resolveEffective's emission path
+// (effective.go) calls this once per mapping node it emits, so a mapping
+// node reached only as a merge operand deep inside another mapping's
+// inventory is inventoried at most once per top-level emitted mapping
+// that reaches it, not once per parent within that recursion.
+func effectiveEntries(m *yaml.Node) []effectiveEntry {
+	return effectiveEntriesWithMemo(m, make(effectiveMergeMemo))
+}
+
+// effectiveEntriesWithMemo is effectiveEntries' real implementation,
+// threading a shared memo across recursive merge-operand lookups so a
+// mapping node's inventory is computed at most once per top-level
+// effectiveEntries call no matter how many operands or aliases reach it
+// within that call's recursion.
+func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo) []effectiveEntry {
+	if m == nil {
+		return nil
+	}
+	if cached, ok := memo[m]; ok {
+		return cached
+	}
+
+	var candidates []effectiveEntry
+
+	// Pass 1: retained explicit entries, source Content order, excluding
+	// recognized merge directives.
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		key, value := m.Content[i], m.Content[i+1]
+		if isMergeKey(key) {
+			continue
+		}
+		candidates = append(candidates, effectiveEntry{
+			id:    effectiveKeyIdentity(key),
+			key:   key,
+			value: value,
+		})
+	}
+
+	// Pass 2: inherited candidates from merge directives, source Content
+	// order, sequence operands left to right, each operand's own
+	// effectiveEntries recursively.
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		key, value := m.Content[i], m.Content[i+1]
+		if !isMergeKey(key) {
+			continue
+		}
+		for _, operand := range mergeOperandMappings(value) {
+			candidates = append(candidates, effectiveEntriesWithMemo(operand, memo)...)
+		}
+	}
+
+	seen := make(map[effectiveKeyID]bool, len(candidates))
+	result := make([]effectiveEntry, 0, len(candidates))
+	for _, c := range candidates {
+		if seen[c.id] {
+			continue
+		}
+		seen[c.id] = true
+		result = append(result, c)
+	}
+
+	memo[m] = result
+	return result
+}
+
+// mergeOperandMappings returns, in left-to-right order, the underlying
+// mapping node for each operand a validated merge value carries: a single
+// entry for a direct mapping or an alias to one, or one entry per element
+// for a sequence of those, per validateMergeOperand's already-established
+// accepted shapes. It assumes value has already passed
+// validateMergeOperand, so no shape is rejected here.
+func mergeOperandMappings(value *yaml.Node) []*yaml.Node {
+	if value == nil {
+		return nil
+	}
+	if value.Kind == yaml.SequenceNode {
+		out := make([]*yaml.Node, 0, len(value.Content))
+		for _, entry := range value.Content {
+			out = append(out, mergeOperandMapping(entry))
+		}
+		return out
+	}
+	return []*yaml.Node{mergeOperandMapping(value)}
+}
+
+// mergeOperandMapping unwraps a single merge operand (a mapping, or an
+// alias whose immediate target is a mapping — validateMergeOperand's
+// isMergeOperandMapping already proved this is one of those two shapes)
+// to its underlying *yaml.Node mapping, following at most one alias hop,
+// matching isMergeOperandMapping's own single-hop rule.
+func mergeOperandMapping(n *yaml.Node) *yaml.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.AliasNode {
+		return n.Alias
+	}
+	return n
+}

--- a/internal/config/effectivemerge.go
+++ b/internal/config/effectivemerge.go
@@ -15,18 +15,14 @@ type effectiveEntry struct {
 }
 
 // effectiveMergeMemo memoizes effectiveEntries results by mapping-node
-// pointer identity for the duration of one effectiveEntries call and its
-// recursion into merge operands. A mapping reached as a merge operand
-// through more than one parent within that recursion, or through more
-// than one alias to the same anchor, has its candidate inventory computed
-// once and reused, rather than recomputed once per parent — this is what
-// keeps a shared-operand fan-out, or a doubling merge DAG like the one
-// TestResolveEffectiveSharedOperandInventoriedOnce builds, linear in the
-// number of distinct mapping nodes rather than exponential in fan-out
-// depth. Memoizing after the recursive call below (rather than before) is
-// safe without its own cycle guard because validateSourceGraph has already
-// proven the whole source graph acyclic before resolveEffective ever
-// calls this.
+// pointer identity for one complete resolveEffective call. It is stored on
+// effectiveEmitState, so a mapping reached as a merge operand through more
+// than one emitted parent, or through more than one alias to the same anchor,
+// has its candidate inventory computed once and reused. This keeps both
+// shared-operand fan-out and doubling merge DAGs linear in the number of
+// distinct mapping nodes. Memoizing after the recursive call below is safe
+// without a separate cycle guard because validateSourceGraph has already
+// proven the whole source graph acyclic.
 type effectiveMergeMemo map[*yaml.Node][]effectiveEntry
 
 // effectiveEntries computes m's complete, ordered, deduplicated effective
@@ -56,13 +52,10 @@ type effectiveMergeMemo map[*yaml.Node][]effectiveEntry
 // inheriting the accumulated set rather than resetting it, which is why
 // this function's own recursive calls flatten rather than re-seed.
 //
-// effectiveEntries creates a fresh effectiveMergeMemo scoped to this one
-// call (and delegates to effectiveEntriesWithMemo, which threads it
-// through the recursion below): resolveEffective's emission path
-// (effective.go) calls this once per mapping node it emits, so a mapping
-// node reached only as a merge operand deep inside another mapping's
-// inventory is inventoried at most once per top-level emitted mapping
-// that reaches it, not once per parent within that recursion.
+// effectiveEntries delegates to effectiveEntriesWithMemo using the memo
+// carried by st for the entire resolveEffective call. The defensive nil
+// initialization also keeps the helper safe if a future internal caller
+// constructs an effectiveEmitState without using resolveEffective.
 //
 // It also threads st (effective.go's effectiveEmitState) through the
 // recursion so an effective-identity collision between two of m's own
@@ -72,14 +65,16 @@ type effectiveMergeMemo map[*yaml.Node][]effectiveEntry
 // rest of the inventory computation without inventorying or emitting
 // anything further.
 func effectiveEntries(m *yaml.Node, st *effectiveEmitState) []effectiveEntry {
-	return effectiveEntriesWithMemo(m, make(effectiveMergeMemo), st)
+	if st.mergeMemo == nil {
+		st.mergeMemo = make(effectiveMergeMemo)
+	}
+	return effectiveEntriesWithMemo(m, st.mergeMemo, st)
 }
 
 // effectiveEntriesWithMemo is effectiveEntries' real implementation,
-// threading a shared memo across recursive merge-operand lookups so a
-// mapping node's inventory is computed at most once per top-level
-// effectiveEntries call no matter how many operands or aliases reach it
-// within that call's recursion, and threading st so an identity collision
+// threading a shared memo across every emitted mapping and recursive
+// merge-operand lookup so a mapping node's inventory is computed at most
+// once per resolveEffective call, and threading st so an identity collision
 // discovered anywhere in that recursion halts the whole computation.
 func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo, st *effectiveEmitState) []effectiveEntry {
 	if m == nil || st.collided {

--- a/internal/config/effectivemerge.go
+++ b/internal/config/effectivemerge.go
@@ -63,21 +63,36 @@ type effectiveMergeMemo map[*yaml.Node][]effectiveEntry
 // node reached only as a merge operand deep inside another mapping's
 // inventory is inventoried at most once per top-level emitted mapping
 // that reaches it, not once per parent within that recursion.
-func effectiveEntries(m *yaml.Node) []effectiveEntry {
-	return effectiveEntriesWithMemo(m, make(effectiveMergeMemo))
+//
+// It also threads st (effective.go's effectiveEmitState) through the
+// recursion so an effective-identity collision between two of m's own
+// explicit keys — or between two explicit keys of any mapping reached as
+// a merge operand within this recursion — is detected and recorded on st
+// exactly like emitEffectiveNode's own node-budget overflow, aborting the
+// rest of the inventory computation without inventorying or emitting
+// anything further.
+func effectiveEntries(m *yaml.Node, st *effectiveEmitState) []effectiveEntry {
+	return effectiveEntriesWithMemo(m, make(effectiveMergeMemo), st)
 }
 
 // effectiveEntriesWithMemo is effectiveEntries' real implementation,
 // threading a shared memo across recursive merge-operand lookups so a
 // mapping node's inventory is computed at most once per top-level
 // effectiveEntries call no matter how many operands or aliases reach it
-// within that call's recursion.
-func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo) []effectiveEntry {
-	if m == nil {
+// within that call's recursion, and threading st so an identity collision
+// discovered anywhere in that recursion halts the whole computation.
+func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo, st *effectiveEmitState) []effectiveEntry {
+	if m == nil || st.collided {
 		return nil
 	}
 	if cached, ok := memo[m]; ok {
 		return cached
+	}
+
+	if laterKey, ok := explicitKeyCollision(m); ok {
+		st.collided = true
+		st.collisionKey = laterKey
+		return nil
 	}
 
 	var candidates []effectiveEntry
@@ -105,7 +120,10 @@ func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo) []effective
 			continue
 		}
 		for _, operand := range mergeOperandMappings(value) {
-			candidates = append(candidates, effectiveEntriesWithMemo(operand, memo)...)
+			candidates = append(candidates, effectiveEntriesWithMemo(operand, memo, st)...)
+			if st.collided {
+				return nil
+			}
 		}
 	}
 
@@ -121,6 +139,39 @@ func effectiveEntriesWithMemo(m *yaml.Node, memo effectiveMergeMemo) []effective
 
 	memo[m] = result
 	return result
+}
+
+// explicitKeyCollision scans m's retained explicit entries (source
+// Content order, excluding recognized merge directives, exactly the same
+// entries effectiveEntriesWithMemo's pass 1 collects) for two whose
+// effectiveKeyIdentity compare equal, returning the SECOND (later) key
+// node of the first such pair found, and true. This is a post-alias rule:
+// sourcegraph.go's checkDuplicateMappingKeys already rejects two explicit
+// keys with the same tag-blind Kind+Value before resolveEffective is ever
+// reached, but does not catch two explicit keys whose Kind and Value
+// differ syntactically yet dereference (through one or more aliases) to
+// the same effectiveKeyIdentity — e.g. a direct scalar key and an alias
+// key targeting an anchored scalar with the same resolved tag and value.
+//
+// It reports nothing about a collision between an explicit key and a
+// merge-inherited candidate of the same identity: that case is ordinary
+// suppression, handled by effectiveEntriesWithMemo's dedup loop below,
+// not this error condition, since only two EXPLICIT keys of one source
+// mapping are ever compared here.
+func explicitKeyCollision(m *yaml.Node) (*yaml.Node, bool) {
+	seen := make(map[effectiveKeyID]bool)
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		key := m.Content[i]
+		if isMergeKey(key) {
+			continue
+		}
+		id := effectiveKeyIdentity(key)
+		if seen[id] {
+			return key, true
+		}
+		seen[id] = true
+	}
+	return nil, false
 }
 
 // mergeOperandMappings returns, in left-to-right order, the underlying

--- a/internal/config/effectivemerge_test.go
+++ b/internal/config/effectivemerge_test.go
@@ -442,3 +442,58 @@ func TestResolveEffectiveSharedOperandInventoriedOnce(t *testing.T) {
 		t.Fatalf("outRoot.Content = %+v, want a single leaf=leaf-value entry", outRoot.Content)
 	}
 }
+
+// TestResolveEffectiveSharedOperandMemoSpansEmittedMappings proves the
+// candidate-inventory memo belongs to the whole resolveEffective call, not
+// merely to one top-level mapping inventory. Thousands of distinct retained
+// parent mappings all merge the same expensive shared operand. Each parent
+// explicitly suppresses the operand's sole effective key, keeping output
+// small; without a resolver-wide memo, the shared operand's wide inventory
+// would be rebuilt once per parent and the test would exceed its timeout.
+func TestResolveEffectiveSharedOperandMemoSpansEmittedMappings(t *testing.T) {
+	const (
+		path   = "shared-operand-across-emitted-mappings.yml"
+		fanout = 8000
+	)
+
+	operandMappings := make([]*yaml.Node, 0, fanout)
+	for i := 0; i < fanout; i++ {
+		operandMappings = append(operandMappings, &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				scalarNode("shared"), scalarNode("losing"),
+			},
+		})
+	}
+	sharedOperand := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), {Kind: yaml.SequenceNode, Content: operandMappings},
+		},
+	}
+
+	parents := make([]*yaml.Node, 0, fanout)
+	for i := 0; i < fanout; i++ {
+		parents = append(parents, &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				mergeKeyNode(), {Kind: yaml.AliasNode, Alias: sharedOperand},
+				scalarNode("shared"), scalarNode("winner"),
+			},
+		})
+	}
+	doc := docOf(&yaml.Node{Kind: yaml.SequenceNode, Content: parents})
+
+	out, err := runResolveEffectiveWithin(t, path, doc, 5*time.Second)
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	if got := len(out.Content[0].Content); got != fanout {
+		t.Fatalf("emitted parent count = %d, want %d", got, fanout)
+	}
+	for i, parent := range out.Content[0].Content {
+		if len(parent.Content) != 2 || parent.Content[0].Value != "shared" || parent.Content[1].Value != "winner" {
+			t.Fatalf("parent %d content = %#v, want only explicit shared: winner", i, parent.Content)
+		}
+	}
+}

--- a/internal/config/effectivemerge_test.go
+++ b/internal/config/effectivemerge_test.go
@@ -264,6 +264,59 @@ func TestResolveEffectiveEntryOrderIsDeterministic(t *testing.T) {
 	}
 }
 
+// TestResolveEffectiveEntryOrderIsDeterministicThroughNestedOperand asserts
+// the same ordering contract as
+// TestResolveEffectiveEntryOrderIsDeterministic still holds when a merge
+// operand's own effective entries are themselves recursively computed
+// from a nested merge, rather than being only explicit entries: opA here
+// merges from opAInner, so opA's own effective order (its explicit "p"
+// and "q" first, then its inherited "s") must be discovered correctly
+// before it is spliced into root's inherited entries in operand order.
+func TestResolveEffectiveEntryOrderIsDeterministicThroughNestedOperand(t *testing.T) {
+	opAInner := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("s"), scalarNode("s-from-inner"),
+	}}
+	opA := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		mergeKeyNode(), opAInner,
+		scalarNode("p"), scalarNode("p-from-a"),
+		scalarNode("q"), scalarNode("q-from-a"),
+	}}
+	opB := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("q"), scalarNode("q-from-b"),
+		scalarNode("r"), scalarNode("r-from-b"),
+	}}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{opA, opB}}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("explicit1"), scalarNode("e1"),
+			mergeKeyNode(), seq,
+			scalarNode("explicit2"), scalarNode("e2"),
+		},
+	}
+	doc := docOf(root)
+
+	want := []string{"explicit1", "explicit2", "p", "q", "s", "r"}
+
+	out, err := resolveEffective("order-deterministic-nested.yml", doc)
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	var got []string
+	for i := 0; i+1 < len(outRoot.Content); i += 2 {
+		got = append(got, outRoot.Content[i].Value)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got key order %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got key order %v, want %v", got, want)
+		}
+	}
+}
+
 // TestResolveEffectiveMergedKeyIdentityIsTagAware asserts an inherited
 // integer key `1` and an explicit quoted string key "1" both survive as
 // separate entries (proving effectiveKeyIdentity, not sourceKeyID, drives

--- a/internal/config/effectivemerge_test.go
+++ b/internal/config/effectivemerge_test.go
@@ -1,0 +1,391 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestResolveEffectiveExplicitOverridesMerged confirms an explicit key
+// wins over the same key inherited through "<<", both when the "<<"
+// directive precedes the explicit key in source Content order and when it
+// follows it — proving explicit-over-merged precedence does not depend on
+// where the merge directive appears.
+func TestResolveEffectiveExplicitOverridesMerged(t *testing.T) {
+	t.Run("merge directive precedes explicit key", func(t *testing.T) {
+		operand := simpleMapping("k", "merge-value")
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				mergeKeyNode(), operand,
+				scalarNode("k"), scalarNode("explicit-value"),
+			},
+		}
+
+		out, err := resolveEffective("explicit-after-merge.yml", docOf(root))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		outRoot := out.Content[0]
+		if len(outRoot.Content) != 2 {
+			t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+		}
+		if outRoot.Content[0].Value != "k" || outRoot.Content[1].Value != "explicit-value" {
+			t.Fatalf("got key=%q value=%q, want k=explicit-value", outRoot.Content[0].Value, outRoot.Content[1].Value)
+		}
+	})
+
+	t.Run("merge directive follows explicit key", func(t *testing.T) {
+		operand := simpleMapping("k", "merge-value2")
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				scalarNode("k"), scalarNode("explicit-value2"),
+				mergeKeyNode(), operand,
+			},
+		}
+
+		out, err := resolveEffective("explicit-before-merge.yml", docOf(root))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		outRoot := out.Content[0]
+		if len(outRoot.Content) != 2 {
+			t.Fatalf("len(outRoot.Content) = %d, want 2 (single winning entry): %+v", len(outRoot.Content), outRoot.Content)
+		}
+		if outRoot.Content[0].Value != "k" || outRoot.Content[1].Value != "explicit-value2" {
+			t.Fatalf("got key=%q value=%q, want k=explicit-value2", outRoot.Content[0].Value, outRoot.Content[1].Value)
+		}
+	})
+}
+
+// TestResolveEffectiveEarlierSequenceOperandWins confirms that for
+// "<<: [*a, *b]" where both operands define the same key, the value from
+// *a appears in the result and *b's value does not appear anywhere in the
+// result.
+func TestResolveEffectiveEarlierSequenceOperandWins(t *testing.T) {
+	a := simpleMapping("k", "from-a")
+	b := simpleMapping("k", "from-b")
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		newSourceAliasNode(a), newSourceAliasNode(b),
+	}}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{mergeKeyNode(), seq}}
+
+	out, err := resolveEffective("seq-operand-precedence.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 {
+		t.Fatalf("len(outRoot.Content) = %d, want 2: %+v", len(outRoot.Content), outRoot.Content)
+	}
+	if outRoot.Content[0].Value != "k" || outRoot.Content[1].Value != "from-a" {
+		t.Fatalf("got key=%q value=%q, want k=from-a", outRoot.Content[0].Value, outRoot.Content[1].Value)
+	}
+	walkEffectiveNodes(out, func(n *yaml.Node) {
+		if n.Value == "from-b" {
+			t.Fatalf("later sequence operand's value %q leaked into the result", n.Value)
+		}
+	})
+}
+
+// TestResolveEffectiveResultIsMergeFree walks every node of a result
+// combining a mapping-literal merge operand, an alias merge operand, a
+// sequence merge operand, a nested merge inside a retained value, and a
+// merge inside a retained mapping key, and asserts isMergeKey reports
+// false for every emitted mapping key and no emitted node is a
+// yaml.AliasNode.
+func TestResolveEffectiveResultIsMergeFree(t *testing.T) {
+	litOperand := simpleMapping("lit", "lit-value")
+	aliasTarget := simpleMapping("ali", "ali-value")
+	seqValue := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		litOperand,
+		newSourceAliasNode(aliasTarget),
+	}}
+
+	nestedOperand := simpleMapping("nx", "nested-from-merge")
+	nestedValue := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), nestedOperand,
+			scalarNode("own"), scalarNode("own-value"),
+		},
+	}
+
+	keyOperand := simpleMapping("kk-merged", "kk-merged-value")
+	complexKey := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), keyOperand,
+			scalarNode("kk"), scalarNode("kk-value"),
+		},
+	}
+
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), seqValue,
+			scalarNode("nested"), nestedValue,
+			complexKey, scalarNode("value-for-complex-key"),
+		},
+	}
+
+	out, err := resolveEffective("merge-free-result.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+
+	visited := 0
+	var walk func(n *yaml.Node)
+	walk = func(n *yaml.Node) {
+		if n == nil {
+			return
+		}
+		visited++
+		if n.Kind == yaml.AliasNode {
+			t.Fatalf("result contains a yaml.AliasNode: %+v", n)
+		}
+		if n.Kind == yaml.MappingNode {
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				if isMergeKey(n.Content[i]) {
+					t.Fatalf("result mapping key is a recognized merge key: %+v", n.Content[i])
+				}
+			}
+		}
+		for _, c := range n.Content {
+			walk(c)
+		}
+	}
+	walk(out)
+	if visited == 0 {
+		t.Fatalf("walk visited no nodes")
+	}
+}
+
+// TestResolveEffectiveNestedMergeInRetainedValue asserts a retained value
+// that is itself a mapping with its own "<<" is fully resolved, with that
+// inner mapping's own explicit-over-merged and earlier-operand precedence
+// applied: an explicit "x" wins over both sequence operands' "x", the
+// first operand's "y" (unique to it) is inherited, and the second
+// operand's "z" (unique to it) is inherited too.
+func TestResolveEffectiveNestedMergeInRetainedValue(t *testing.T) {
+	a := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("x"), scalarNode("x-from-a"),
+		scalarNode("y"), scalarNode("y-from-a"),
+	}}
+	b := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("x"), scalarNode("x-from-b"),
+		scalarNode("z"), scalarNode("z-from-b"),
+	}}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+		newSourceAliasNode(a), newSourceAliasNode(b),
+	}}
+	inner := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			mergeKeyNode(), seq,
+			scalarNode("x"), scalarNode("explicit-x"),
+		},
+	}
+	root := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{scalarNode("outer"), inner}}
+
+	out, err := resolveEffective("nested-merge-in-value.yml", docOf(root))
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 || outRoot.Content[0].Value != "outer" {
+		t.Fatalf("unexpected outer shape: %+v", outRoot.Content)
+	}
+
+	innerOut := outRoot.Content[1]
+	got := map[string]string{}
+	for i := 0; i+1 < len(innerOut.Content); i += 2 {
+		got[innerOut.Content[i].Value] = innerOut.Content[i+1].Value
+	}
+	want := map[string]string{"x": "explicit-x", "y": "y-from-a", "z": "z-from-b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("got[%q] = %q, want %q (full: %v)", k, got[k], v, got)
+		}
+	}
+}
+
+// TestResolveEffectiveEntryOrderIsDeterministic asserts the emitted
+// mapping's key order is exactly: retained explicit entries in source
+// Content order (merge directives excluded), then inherited winners in
+// merge-candidate discovery order (directives in Content order, sequence
+// operands first to last, each operand's own effective entry order). It
+// runs the same fixture twice and asserts identical order both times.
+func TestResolveEffectiveEntryOrderIsDeterministic(t *testing.T) {
+	opA := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("p"), scalarNode("p-from-a"),
+		scalarNode("q"), scalarNode("q-from-a"),
+	}}
+	opB := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+		scalarNode("q"), scalarNode("q-from-b"),
+		scalarNode("r"), scalarNode("r-from-b"),
+	}}
+	seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{opA, opB}}
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			scalarNode("explicit1"), scalarNode("e1"),
+			mergeKeyNode(), seq,
+			scalarNode("explicit2"), scalarNode("e2"),
+		},
+	}
+	doc := docOf(root)
+
+	want := []string{"explicit1", "explicit2", "p", "q", "r"}
+
+	for run := 0; run < 2; run++ {
+		out, err := resolveEffective("order-deterministic.yml", doc)
+		if err != nil {
+			t.Fatalf("run %d: resolveEffective returned unexpected error: %v", run, err)
+		}
+		outRoot := out.Content[0]
+		var got []string
+		for i := 0; i+1 < len(outRoot.Content); i += 2 {
+			got = append(got, outRoot.Content[i].Value)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("run %d: got key order %v, want %v", run, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: got key order %v, want %v", run, got, want)
+			}
+		}
+	}
+}
+
+// TestResolveEffectiveMergedKeyIdentityIsTagAware asserts an inherited
+// integer key `1` and an explicit quoted string key "1" both survive as
+// separate entries (proving effectiveKeyIdentity, not sourceKeyID, drives
+// merge precedence), and that an inherited bare `1` is suppressed by an
+// explicit !!int-tagged `1`.
+func TestResolveEffectiveMergedKeyIdentityIsTagAware(t *testing.T) {
+	t.Run("distinct tags both survive", func(t *testing.T) {
+		bareOneOperand := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			scalarNode("1"), scalarNode("from-merge"),
+		}}
+		explicitQuotedOne := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "1"}
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				mergeKeyNode(), bareOneOperand,
+				explicitQuotedOne, scalarNode("explicit-value"),
+			},
+		}
+
+		out, err := resolveEffective("tag-aware-distinct.yml", docOf(root))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		outRoot := out.Content[0]
+		if len(outRoot.Content) != 4 {
+			t.Fatalf("len(outRoot.Content) = %d, want 4 (both survive as distinct entries): %+v", len(outRoot.Content), outRoot.Content)
+		}
+		var sawBareInt, sawQuotedStr bool
+		for i := 0; i+1 < len(outRoot.Content); i += 2 {
+			key, value := outRoot.Content[i], outRoot.Content[i+1]
+			switch {
+			case key.Tag == "!!str" && key.Value == "1":
+				sawQuotedStr = true
+				if value.Value != "explicit-value" {
+					t.Fatalf("quoted \"1\" entry value = %q, want %q", value.Value, "explicit-value")
+				}
+			case key.Value == "1":
+				sawBareInt = true
+				if value.Value != "from-merge" {
+					t.Fatalf("bare 1 entry value = %q, want %q", value.Value, "from-merge")
+				}
+			}
+		}
+		if !sawBareInt || !sawQuotedStr {
+			t.Fatalf("outRoot.Content = %+v, want both a bare-1 and a quoted-\"1\" entry", outRoot.Content)
+		}
+	})
+
+	t.Run("matching tag suppresses inherited", func(t *testing.T) {
+		bareOneOperand := &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+			scalarNode("1"), scalarNode("from-merge2"),
+		}}
+		explicitTaggedIntOne := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!int", Value: "1"}
+		root := &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				explicitTaggedIntOne, scalarNode("explicit-value2"),
+				mergeKeyNode(), bareOneOperand,
+			},
+		}
+
+		out, err := resolveEffective("tag-aware-suppressed.yml", docOf(root))
+		if err != nil {
+			t.Fatalf("resolveEffective returned unexpected error: %v", err)
+		}
+		outRoot := out.Content[0]
+		if len(outRoot.Content) != 2 {
+			t.Fatalf("len(outRoot.Content) = %d, want 2 (inherited bare 1 suppressed): %+v", len(outRoot.Content), outRoot.Content)
+		}
+		if outRoot.Content[0].Value != "1" || outRoot.Content[1].Value != "explicit-value2" {
+			t.Fatalf("got key=%q value=%q, want 1=explicit-value2", outRoot.Content[0].Value, outRoot.Content[1].Value)
+		}
+		walkEffectiveNodes(out, func(n *yaml.Node) {
+			if n.Value == "from-merge2" {
+				t.Fatalf("suppressed inherited value %q leaked into the result", n.Value)
+			}
+		})
+	})
+}
+
+// buildMergeSharingDAG returns a well-formed yaml.MappingNode built as a
+// chain of levels, each merging two aliases to the same previous level via
+// a sequence merge operand: level 0 is a small mapping with one key/value
+// pair, and level i (i>0) is "<<: [*level(i-1), *level(i-1)]". Its
+// *source* graph is a tiny, compact DAG well within
+// checkSourceGraphBounds' 64-consecutive-alias-hop and
+// 128-source-node-path-visit limits (mirroring buildSourceSharingDAG's
+// construction), but a naive, non-memoized computation of a mapping's
+// effectiveEntries would recompute level (i-1)'s inventory twice per
+// level — 2^levels total recursive computations — while a memoized one
+// (keyed by mapping-node pointer identity) computes each level's
+// inventory exactly once, giving
+// TestResolveEffectiveSharedOperandInventoriedOnce a bounded runtime only
+// the memoized implementation can meet.
+func buildMergeSharingDAG(levels int) *yaml.Node {
+	level := simpleMapping("leaf", "leaf-value")
+	for i := 0; i < levels; i++ {
+		seq := &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{
+			newSourceAliasNode(level), newSourceAliasNode(level),
+		}}
+		level = &yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{mergeKeyNode(), seq}}
+	}
+	return level
+}
+
+// TestResolveEffectiveSharedOperandInventoriedOnce builds one operand
+// mapping merged into many parent mappings (buildMergeSharingDAG's
+// 40-level doubling chain) and asserts resolveEffective completes within a
+// bounded timeout, demonstrating the memoized inventory: without
+// memoization this would require on the order of 2^40 recursive
+// effectiveEntries computations and would not return within any
+// reasonable timeout.
+func TestResolveEffectiveSharedOperandInventoriedOnce(t *testing.T) {
+	const path = "/etc/chairlift/shared-operand-inventoried-once.yml"
+	doc := newSourceDocNode(buildMergeSharingDAG(40))
+
+	out, err := runResolveEffectiveWithin(t, path, doc, 5*time.Second)
+	if err != nil {
+		t.Fatalf("resolveEffective returned unexpected error: %v", err)
+	}
+	outRoot := out.Content[0]
+	if len(outRoot.Content) != 2 || outRoot.Content[0].Value != "leaf" || outRoot.Content[1].Value != "leaf-value" {
+		t.Fatalf("outRoot.Content = %+v, want a single leaf=leaf-value entry", outRoot.Content)
+	}
+}

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -32,16 +32,26 @@ import (
 //     yamlTagName are a frozen pre-existing baseline: they were already
 //     named directly by config_test.go/schema_test.go before this chunk
 //     and are not widened or added to here.
+//   - resolveEffective and effectiveKeyIdentity are the exactly two
+//     additions this slice's spec authorizes, added in this chunk before
+//     either function exists so no later chunk needs to touch this frozen
+//     guard again. resolveEffective does not exist yet as of this chunk;
+//     effectiveKeyIdentity does, and effectivekeys_test.go names it
+//     directly. Every other new resolver helper this slice adds in a later
+//     chunk must be exercised only indirectly, through resolveEffective —
+//     it must not be added to this allowlist.
 var directCallAllowlist = map[string]bool{
-	"parseYAMLDocument":   true,
-	"validateSourceGraph": true,
-	"isMergeKey":          true,
-	"shortYAMLTag":        true,
-	"defaultConfig":       true,
-	"loadFromPath":        true,
-	"schemaPageGroups":    true,
-	"yamlFieldNames":      true,
-	"yamlTagName":         true,
+	"parseYAMLDocument":    true,
+	"validateSourceGraph":  true,
+	"isMergeKey":           true,
+	"shortYAMLTag":         true,
+	"defaultConfig":        true,
+	"loadFromPath":         true,
+	"schemaPageGroups":     true,
+	"yamlFieldNames":       true,
+	"yamlTagName":          true,
+	"resolveEffective":     true,
+	"effectiveKeyIdentity": true,
 }
 
 // packageGoFiles lists the *.go files directly in this package's directory

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -41,16 +41,26 @@ import (
 //     chunk must be exercised only indirectly, through resolveEffective —
 //     it must not be added to this allowlist.
 var directCallAllowlist = map[string]bool{
-	"parseYAMLDocument":    true,
-	"validateSourceGraph":  true,
-	"isMergeKey":           true,
-	"shortYAMLTag":         true,
-	"defaultConfig":        true,
-	"loadFromPath":         true,
-	"schemaPageGroups":     true,
-	"yamlFieldNames":       true,
-	"yamlTagName":          true,
-	"resolveEffective":     true,
+	"parseYAMLDocument": true,
+
+	"validateSourceGraph": true,
+
+	"isMergeKey": true,
+
+	"shortYAMLTag": true,
+
+	"defaultConfig": true,
+
+	"loadFromPath": true,
+
+	"schemaPageGroups": true,
+
+	"yamlFieldNames": true,
+
+	"yamlTagName": true,
+
+	"resolveEffective": true,
+
 	"effectiveKeyIdentity": true,
 }
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -448,10 +448,10 @@ crossed it. That line comes from reusing `sourcebounds.go`'s existing
 `collectSourceInventory` and `attributeSourceLines` pair on the validated
 source document — the same all-paths line attribution
 (`checkSourceGraphBounds` uses it too) rather than a second, separate line-
-attribution implementation — computed once per `resolveEffective` call: a
-node's own line when positive, otherwise its nearest positive-line ancestor
-over all root-reachable paths, otherwise `1` for a wholly synthetic graph
-with no line metadata anywhere, so the reported line is always positive.
+attribution implementation — computed once when constructing the resolver
+error: a node's own line when positive, otherwise its nearest positive-line
+ancestor over all root-reachable paths, otherwise `1` for a wholly synthetic
+graph with no line metadata anywhere, so the reported line is always positive.
 
 **Merge precedence, memoized candidate inventory, merge-free output
 (`internal/config/effectivemerge.go`).** `effectiveEntries(m *yaml.Node)
@@ -501,20 +501,24 @@ order both times.
 
 `effectiveEntries` delegates to the unexported `effectiveEntriesWithMemo`,
 threading an `effectiveMergeMemo` (`map[*yaml.Node][]effectiveEntry`) keyed
-by mapping-node pointer identity through the recursion described above,
-scoped to that one `effectiveEntries` call: a mapping node reached as a
-merge operand through more than one parent, or through more than one alias
-to the same anchor, within that recursion has its candidate inventory
-computed once and reused rather than recomputed once per parent —
+by mapping-node pointer identity through the recursion described above. The
+memo lives on `effectiveEmitState` for one complete `resolveEffective` call:
+a mapping node reached as a merge operand through more than one emitted
+parent, or through more than one alias to the same anchor, has its candidate
+inventory computed once and reused rather than recomputed once per parent —
 `TestResolveEffectiveSharedOperandInventoriedOnce`'s 40-level doubling merge
 chain (mirroring `buildSourceSharingDAG`'s construction, but merging via
 `<<: [*prev, *prev]` at each level instead of plain aliasing) would need on
 the order of `2^40` recursive computations without this memo and completes
-in well under a bounded timeout with it. A losing candidate's value is
-never resolved by this pass either — `effectiveEntries` only ever returns
-the source nodes for winning entries, so `emitEffectiveNode` never clones,
-and never charges against `maxEffectiveOutputNodes`, anything a merge
-discarded.
+in well under a bounded timeout with it.
+`TestResolveEffectiveSharedOperandMemoSpansEmittedMappings` separately pins
+the memo lifetime: thousands of distinct retained parent mappings merge one
+wide shared operand, which would rebuild that inventory for every parent if
+the memo were scoped only to a top-level `effectiveEntries` call. A losing
+candidate's value is never resolved by this pass either — `effectiveEntries`
+only ever returns the source nodes for winning entries, so
+`emitEffectiveNode` never clones, and never charges against
+`maxEffectiveOutputNodes`, anything a merge discarded.
 
 The post-alias key-identity-collision rule is layered on top of, not a
 replacement for, `checkDuplicateMappingKeys`'s tag-blind `Kind`+`Value`

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -311,8 +311,8 @@ deliberately compares only `Kind` and `Value`, reproducing `gopkg.in/yaml.v3`
 v3.0.1 `decode.go`'s own `uniqueKeys` predicate (inside `decoder.mapping`)
 exactly rather than the tag-aware key identity
 `docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md`
-requires elsewhere in this package for merge/dedup purposes — that rule is
-about a different, not-yet-implemented concern (merge-precedence identity)
+requires elsewhere in this package for merge-precedence purposes — that rule
+is about a different concern (`effectiveKeyIdentity`, described just below)
 and does not apply here, because yaml.v3's own duplicate-key guard never
 looks at `Tag` either. Two surprising consequences follow directly: two
 `<<` merge-key entries in the same mapping collide as duplicates regardless
@@ -332,6 +332,42 @@ comparison, which is pairwise (`O(k^2)` per mapping). This package's version
 is `O(k)` per mapping and `O(V+E)` over the whole graph, so a mapping with
 tens of thousands of keys does not make the validator's own running time
 blow up the way the pairwise loop would.
+
+**Effective (merge-precedence) key identity
+(`internal/config/effectivekeys.go`).** A separate, standalone helper,
+`effectiveKeyIdentity`, computes a comparable `effectiveKeyID` for a mapping
+key node — the identity a later merge-precedence resolver
+(`resolveEffective`, not implemented in this slice yet) needs to decide
+whether two keys from different merge sources are "the same key" and must
+therefore resolve to one effective value rather than two. It is
+deliberately a different type and a different comparison from
+`sourceKeyID` above: `effectiveKeyIdentity` first follows `n`'s
+`yaml.AliasNode` chain (any number of hops, guarded by a local
+node-pointer seen-set so a synthetic self-referential alias handed to it
+directly terminates instead of hanging) to its non-alias target, then
+branches on that target's `Kind`. A `yaml.ScalarNode` target yields `{kind:
+yaml.ScalarNode, tag: target.ShortTag(), value: target.Value}` —
+`ShortTag()` is used rather than the raw `Tag` field because
+`gopkg.in/yaml.v3` v3.0.1's `yaml.go` implements it to resolve an unset or
+`"!"` tag from the node's own value (`resolve("", n.Value)` for scalars),
+so this rule is exactly the tag-aware identity
+`docs/agents/skills/yaml-scalar-key-identity-needs-tag-not-just-value.md`
+requires: a bare `1` and an explicitly `!!int`-tagged `1` are the same
+key, but a bare `1` and an explicitly `!!str`-tagged (quoted) `"1"` are not,
+and `01` and `1` are not (different `Value`). A `yaml.MappingNode` or
+`yaml.SequenceNode` target instead yields `{complex: target}` — pointer
+identity on the target node alone, with no structural expansion of the
+complex key's contents: two distinct nodes that look alike are different
+keys, two aliases sharing one complex target are the same key, and a
+complex identity is never equal to any scalar identity (the zero
+`*yaml.Node` complex field only appears alongside the zero scalar fields
+for a nil or dead-ended-alias input, and a real complex node's pointer is
+never nil). This is the tag-blind `sourceKeyID` above's direct
+counterpart, not a reuse of it: `sourceKeyID` intentionally omits `Tag` to
+reproduce yaml.v3's own duplicate-key guard exactly, while
+`effectiveKeyIdentity` intentionally includes it because merge-precedence
+resolution must not let a `!!str "1"` entry silently discard or be
+discarded by an `!!int 1` entry from another merge source.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -196,9 +196,8 @@ capabilities (document parsing, reachable source-graph shape validation,
 merge-operand shape validation, duplicate-explicit-key detection, the
 memoized alias-hop bound and the memoized source-node path-visit bound
 (both with all-paths line attribution), and now a validate-first
-alias/anchor-resolving, merge-precedence-resolving emitter — complete
-except for the post-alias key-identity-collision rule and a small set of
-bounded-work regressions the next chunk still owes) meant to
+alias/anchor-resolving, merge-precedence-resolving, bounded-output emitter
+with its own post-alias key-identity-collision rule) meant to
 eventually replace `loadFromPath()`'s current `yaml.Unmarshal` call with
 fail-closed, single-document, structurally validated loading — but none of
 that wiring exists yet, so `KindRead` and `KindSchema` still describe
@@ -372,7 +371,16 @@ counterpart, not a reuse of it: `sourceKeyID` intentionally omits `Tag` to
 reproduce yaml.v3's own duplicate-key guard exactly, while
 `effectiveKeyIdentity` intentionally includes it because merge-precedence
 resolution must not let a `!!str "1"` entry silently discard or be
-discarded by an `!!int 1` entry from another merge source.
+discarded by an `!!int 1` entry from another merge source. A complex key's
+identity is used only to decide *precedence* — which candidate wins, and
+whether two explicit complex keys collide (see below) — never to compute
+it: a *winning* complex key is still fully resolved and emitted
+structurally, alias-free, by `emitEffectiveNode` like any other node
+(charged against `maxEffectiveOutputNodes` like everything else it
+emits), while a *losing* complex key (impossible for two candidates to
+tie on, since distinct complex-key nodes always have distinct pointers,
+but reachable when the complex key belongs to a losing merge candidate's
+value) is never dereferenced, resolved, or emitted at all.
 
 **Validate-first, alias-resolving effective emitter
 (`internal/config/effective.go`).** `resolveEffective(path string, doc
@@ -508,28 +516,46 @@ the source nodes for winning entries, so `emitEffectiveNode` never clones,
 and never charges against `maxEffectiveOutputNodes`, anything a merge
 discarded.
 
-The post-alias key-identity-collision rule and a small set of
-bounded-work regressions are deliberately deferred to the next chunk: until
-then, two *explicit* keys that happen to collide under
-`effectiveKeyIdentity` only after alias dereferencing (for example, one
-written as a literal scalar and the other as an alias to that exact same
-scalar) are deduplicated by the same first-candidate rule as any other
-collision, and no test in this slice asserts that specific edge case's
-behavior.
+The post-alias key-identity-collision rule is layered on top of, not a
+replacement for, `checkDuplicateMappingKeys`'s tag-blind `Kind`+`Value`
+duplicate-key validation above, which `validateSourceGraph` still runs
+first, unchanged: `effectiveEntriesWithMemo` additionally scans each
+mapping's own retained explicit entries (the same entries its first pass
+collects) for two whose `effectiveKeyIdentity` compare equal *after* alias
+dereferencing — catching, for example, a literal scalar key and an alias
+key targeting an anchored scalar with the same resolved tag and value,
+which `checkDuplicateMappingKeys` cannot catch because the alias node's
+own `Kind` and `Value` differ from its target's. Finding such a pair sets
+`effectiveEmitState.collided` and records the *later* key (in source
+`Content` order) as `collisionKey`, aborting the whole `resolveEffective`
+call — exactly like a node-budget overflow aborts it — without
+inventorying or emitting anything further; `resolveEffective` then returns
+`effectiveIdentityCollisionError(path, doc, st.collisionKey)`, a
+`KindParseType` `*LoadError` with a nil `Err` and a `Detail` reusing the
+same `collectSourceInventory`/`attributeSourceLines` line-attribution pair
+(own line, else nearest positive-line ancestor over all paths, else `1`)
+as the output-limit error above. The rule applies only to two *explicit*
+keys of one source mapping: an inherited merge candidate colliding with an
+explicit key of the same identity is ordinary suppression (the existing
+first-candidate dedup pass), not this error, since only an explicit
+key can ever be the "other side" of a genuine ambiguity about which of two
+literally-written keys in the same mapping was meant.
 
 `emitEffectiveNode`, `dereferenceAliasTarget`/`emitNodeMetadata`, the
-`effectiveEmitState` counter type, `effectiveOutputLimitError`,
-`effectiveEntry`, `effectiveMergeMemo`, `effectiveEntriesWithMemo`, and
-`mergeOperandMappings`/`mergeOperandMapping` are all unexported helpers
-reachable only from `resolveEffective`; per the frozen `directCallAllowlist`
-in `sourcesurface_test.go`, no `_test.go` file names any of them directly —
-`effective_test.go`, `effectivebound_test.go`, and `effectivemerge_test.go`
-exercise them only through `resolveEffective` itself, alongside
-`resolveEffective` and `effectiveKeyIdentity`, the two additions that
-allowlist authorizes. `resolveEffective` itself is still not wired into
-`Load()`, `loadFromPath()`, or ChairLift's strict schema validation — it
-remains a standalone capability, like `parseYAMLDocument` and
-`validateSourceGraph` before it.
+`effectiveEmitState` counter/collision-tracking type,
+`effectiveOutputLimitError`, `effectiveIdentityCollisionError`,
+`effectiveEntry`, `effectiveMergeMemo`, `effectiveEntriesWithMemo`,
+`explicitKeyCollision`, and `mergeOperandMappings`/`mergeOperandMapping`
+are all unexported helpers reachable only from `resolveEffective`; per the
+frozen `directCallAllowlist` in `sourcesurface_test.go`, no `_test.go` file
+names any of them directly — `effective_test.go`, `effectivebound_test.go`,
+`effectivemerge_test.go`, and `effectiveidentity_test.go` exercise them
+only through `resolveEffective` itself, alongside `resolveEffective` and
+`effectiveKeyIdentity`, the two additions that allowlist authorizes.
+`resolveEffective` itself is still not yet wired into `Load()`,
+`loadFromPath()`, or ChairLift's strict schema validation — it remains a
+standalone capability, like `parseYAMLDocument` and `validateSourceGraph`
+before it.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -399,8 +399,39 @@ chain to the non-alias target first, and the emitted node carries that
 whether the alias appears in mapping value position or as a mapping key.
 Because the output must stay alias-free, a single source node reached
 through more than one alias becomes more than one independent fresh copy in
-the result; the per-emission budget that keeps that expansion from being
-unbounded is added in a later chunk, not this one.
+the result, and each such copy is charged separately against the
+`maxEffectiveOutputNodes` budget described just below.
+
+`resolveEffective`'s emit path is bounded by the unexported `const
+maxEffectiveOutputNodes = 100000`: every retained document, mapping,
+sequence, key and value node counts exactly once toward it, mirroring
+`sourcebounds.go`'s `pathVisitCount` accounting rule that "key", "value" and
+"alias target" only name which child is traversed next and add no separate
+charge, and each independent copy an expanded alias produces is charged
+separately (an alias node itself is never charged, since it is dereferenced
+to its target before the budget check runs). The check happens in
+`emitEffectiveNode`'s first statements for each node — incrementing and
+comparing a per-call counter *before* allocating a `*yaml.Node` for that
+node or recursing into its `Content` — so the 100,001st attempted emission
+fails before its own allocation and before any of its descendants are ever
+visited, which is what makes an exponential alias expansion (a compact,
+small source graph whose alias-free output would otherwise need on the
+order of `2^n` nodes) abort at the boundary rather than run to completion.
+Once the budget is exceeded on any call, every other pending call in the
+same `resolveEffective` invocation also returns immediately without further
+allocation or recursion. Exactly `maxEffectiveOutputNodes` emitted nodes
+succeeds; `maxEffectiveOutputNodes`+1 fails. On overflow `resolveEffective`
+returns a nil tree and a `KindParseType` `*LoadError` with `Path` copied
+from the `path` argument, a nil `Err`, and a `Detail` naming the
+100,000-node bound and a source line for the node whose emission would have
+crossed it. That line comes from reusing `sourcebounds.go`'s existing
+`collectSourceInventory` and `attributeSourceLines` pair on the validated
+source document — the same all-paths line attribution
+(`checkSourceGraphBounds` uses it too) rather than a second, separate line-
+attribution implementation — computed once per `resolveEffective` call: a
+node's own line when positive, otherwise its nearest positive-line ancestor
+over all root-reachable paths, otherwise `1` for a wholly synthetic graph
+with no line metadata anywhere, so the reported line is always positive.
 
 This chunk deliberately leaves two things unfinished, both authorized by
 the spec and tracked forward: a recognized `<<` merge key (`isMergeKey`)
@@ -415,12 +446,14 @@ standalone, still-unwired capability like `parseYAMLDocument` and
 `!!merge`-tagged scalar whose `Value` isn't literally `"<<"` both survive
 as ordinary effective keys today and are expected to keep doing so once
 merge precedence is implemented, since `isMergeKey` never recognizes either
-shape. `emitEffectiveNode` and `dereferenceAliasTarget`/`emitNodeMetadata`
-are unexported helpers reachable only from `resolveEffective` in this same
-chunk; per the frozen `directCallAllowlist` in `sourcesurface_test.go`, no
-`_test.go` file names them directly — `effective_test.go` exercises them
-only through `resolveEffective` itself, alongside `resolveEffective` and
-`effectiveKeyIdentity`, the two additions that allowlist authorizes.
+shape. `emitEffectiveNode`, `dereferenceAliasTarget`/`emitNodeMetadata`, the
+`effectiveEmitState` counter type, and `effectiveOutputLimitError` are all
+unexported helpers reachable only from `resolveEffective`; per the frozen
+`directCallAllowlist` in `sourcesurface_test.go`, no `_test.go` file names
+any of them directly — `effective_test.go` and `effectivebound_test.go`
+exercise them only through `resolveEffective` itself, alongside
+`resolveEffective` and `effectiveKeyIdentity`, the two additions that
+allowlist authorizes.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -196,8 +196,9 @@ capabilities (document parsing, reachable source-graph shape validation,
 merge-operand shape validation, duplicate-explicit-key detection, the
 memoized alias-hop bound and the memoized source-node path-visit bound
 (both with all-paths line attribution), and now a validate-first
-alias/anchor-resolving emitter whose merge precedence and final output
-shape are still being built out across the next two chunks) meant to
+alias/anchor-resolving, merge-precedence-resolving emitter — complete
+except for the post-alias key-identity-collision rule and a small set of
+bounded-work regressions the next chunk still owes) meant to
 eventually replace `loadFromPath()`'s current `yaml.Unmarshal` call with
 fail-closed, single-document, structurally validated loading — but none of
 that wiring exists yet, so `KindRead` and `KindSchema` still describe
@@ -210,8 +211,9 @@ path currently exercises.
 of two unexported predicates from `gopkg.in/yaml.v3` v3.0.1 itself —
 `decode.go:isMerge` and `resolve.go:shortTag` — rather than reimplementations
 from a description of YAML merge-key semantics, so this package's own
-merge-key walk (a later change) recognizes exactly the same nodes yaml.v3's
-own decoder would treat as a merge key, node for node. `isMergeKey` reports
+merge-key walk (`effectiveEntries`, described below) recognizes exactly the
+same nodes yaml.v3's own decoder would treat as a merge key, node for node.
+`isMergeKey` reports
 true only for a `yaml.ScalarNode` whose `Value` is exactly `"<<"` and whose
 `Tag` is one of: absent (`""`, the implicit/unresolved tag), the bare
 non-specific tag (`"!"`), the short merge tag (`"!!merge"`), or its canonical
@@ -339,8 +341,8 @@ blow up the way the pairwise loop would.
 **Effective (merge-precedence) key identity
 (`internal/config/effectivekeys.go`).** A separate, standalone helper,
 `effectiveKeyIdentity`, computes a comparable `effectiveKeyID` for a mapping
-key node — the identity a later merge-precedence resolver
-(`resolveEffective`, not implemented in this slice yet) needs to decide
+key node — the identity the merge-precedence resolver `effectiveEntries`
+(`internal/config/effectivemerge.go`, described below) uses to decide
 whether two keys from different merge sources are "the same key" and must
 therefore resolve to one effective value rather than two. It is
 deliberately a different type and a different comparison from
@@ -402,6 +404,16 @@ through more than one alias becomes more than one independent fresh copy in
 the result, and each such copy is charged separately against the
 `maxEffectiveOutputNodes` budget described just below.
 
+For a mapping node specifically, `emitEffectiveNode` does not copy the
+target's raw `Content` — it emits `effectiveEntries(target)`'s winning
+entries instead (`internal/config/effectivemerge.go`, described in the next
+section), so only a winning key and its winning value are ever resolved and
+charged against the budget; a losing merge candidate's value is never
+cloned. A recognized `<<` merge key is therefore never itself emitted as a
+key, and the result contains no recognized merge directive and no
+`yaml.AliasNode` anywhere, at any depth — including inside a retained
+mapping key's own subtree or a retained value's own nested merge.
+
 `resolveEffective`'s emit path is bounded by the unexported `const
 maxEffectiveOutputNodes = 100000`: every retained document, mapping,
 sequence, key and value node counts exactly once toward it, mirroring
@@ -433,27 +445,91 @@ node's own line when positive, otherwise its nearest positive-line ancestor
 over all root-reachable paths, otherwise `1` for a wholly synthetic graph
 with no line metadata anywhere, so the reported line is always positive.
 
-This chunk deliberately leaves two things unfinished, both authorized by
-the spec and tracked forward: a recognized `<<` merge key (`isMergeKey`)
-is still emitted as an ordinary mapping entry with its operand value
-resolved like any other value, rather than being consumed by
-merge-precedence resolution (`TestResolveEffectiveMergeDirectiveRetainedForNow`
-pins this down and is one of the tests a later chunk must update when real
-merge precedence lands); and `resolveEffective` is not wired into `Load()`,
-`loadFromPath()`, or ChairLift's strict schema validation — it is a
-standalone, still-unwired capability like `parseYAMLDocument` and
-`validateSourceGraph` before it. A `!!str`-tagged `"<<"` key and a
-`!!merge`-tagged scalar whose `Value` isn't literally `"<<"` both survive
-as ordinary effective keys today and are expected to keep doing so once
-merge precedence is implemented, since `isMergeKey` never recognizes either
-shape. `emitEffectiveNode`, `dereferenceAliasTarget`/`emitNodeMetadata`, the
-`effectiveEmitState` counter type, and `effectiveOutputLimitError` are all
-unexported helpers reachable only from `resolveEffective`; per the frozen
-`directCallAllowlist` in `sourcesurface_test.go`, no `_test.go` file names
-any of them directly — `effective_test.go` and `effectivebound_test.go`
+**Merge precedence, memoized candidate inventory, merge-free output
+(`internal/config/effectivemerge.go`).** `effectiveEntries(m *yaml.Node)
+[]effectiveEntry` computes a mapping node's complete, ordered, deduplicated
+inventory of winning entries — the real, yaml.v3-compatible merge-precedence
+result `emitEffectiveNode`'s mapping branch emits from, replacing the
+earlier chunk's interim "retain the `<<` key as an ordinary entry" behavior.
+An `effectiveEntry` is an `{id effectiveKeyID, key, value *yaml.Node}`
+triple: `id` is the candidate's `effectiveKeyIdentity` (`effectivekeys.go`),
+used to decide whether two candidates from different sources are "the same
+key"; `key` and `value` are the source nodes for that candidate, not yet
+copied.
+
+The inventory is built in two passes, then deduplicated once: first, every
+retained explicit entry, in `m`'s source `Content` order, skipping any
+recognized merge directive (`isMergeKey`); second, every inherited
+candidate, discovered by merge directives in source `Content` order, each
+directive's sequence operands left to right (`mergeOperandMappings`
+unwraps a direct mapping, or an alias's *immediate* target, matching
+`validateMergeOperand`'s already-accepted shapes), and each operand
+mapping's own `effectiveEntries` computed recursively — so a merge nested
+inside a merge operand is fully flattened before its candidates are
+considered here. The combined candidate list is then deduplicated by
+`effectiveKeyIdentity`, keeping the *first* candidate for each identity.
+Because explicit entries are always listed first, this yields
+explicit-over-merged precedence; because merge candidates are discovered in
+directive-then-sequence-then-recursive order, it yields
+earlier-sequence-operand-over-later precedence; and because the explicit
+pass runs unconditionally before the merge pass regardless of where the
+`<<` directive appears in `m`'s `Content`, an explicit key suppresses a
+matching inherited candidate whether the directive comes before or after
+that explicit key in the source. This matches `gopkg.in/yaml.v3` v3.0.1
+`decode.go`'s `decoder.mapping`/`decoder.merge` behavior exactly:
+`mapping` decodes explicit entries first and skips `isMerge` keys, then
+`merge` seeds its `mergedFields` set from every explicit parent key before
+consuming operands in `Content` order and marking each merged key as
+consumed — with nested merges inheriting that accumulated set rather than
+resetting it, which is why `effectiveEntries`' own recursive calls flatten
+rather than re-seed.
+
+The emitted mapping's key order is therefore fully deterministic: retained
+explicit entries in source `Content` order, then inherited winners in
+merge-candidate discovery order (directives in `Content` order, sequence
+operands first to last, each operand's own effective entry order) —
+running the same fixture through `resolveEffective` twice yields identical
+order both times.
+
+`effectiveEntries` delegates to the unexported `effectiveEntriesWithMemo`,
+threading an `effectiveMergeMemo` (`map[*yaml.Node][]effectiveEntry`) keyed
+by mapping-node pointer identity through the recursion described above,
+scoped to that one `effectiveEntries` call: a mapping node reached as a
+merge operand through more than one parent, or through more than one alias
+to the same anchor, within that recursion has its candidate inventory
+computed once and reused rather than recomputed once per parent —
+`TestResolveEffectiveSharedOperandInventoriedOnce`'s 40-level doubling merge
+chain (mirroring `buildSourceSharingDAG`'s construction, but merging via
+`<<: [*prev, *prev]` at each level instead of plain aliasing) would need on
+the order of `2^40` recursive computations without this memo and completes
+in well under a bounded timeout with it. A losing candidate's value is
+never resolved by this pass either — `effectiveEntries` only ever returns
+the source nodes for winning entries, so `emitEffectiveNode` never clones,
+and never charges against `maxEffectiveOutputNodes`, anything a merge
+discarded.
+
+The post-alias key-identity-collision rule and a small set of
+bounded-work regressions are deliberately deferred to the next chunk: until
+then, two *explicit* keys that happen to collide under
+`effectiveKeyIdentity` only after alias dereferencing (for example, one
+written as a literal scalar and the other as an alias to that exact same
+scalar) are deduplicated by the same first-candidate rule as any other
+collision, and no test in this slice asserts that specific edge case's
+behavior.
+
+`emitEffectiveNode`, `dereferenceAliasTarget`/`emitNodeMetadata`, the
+`effectiveEmitState` counter type, `effectiveOutputLimitError`,
+`effectiveEntry`, `effectiveMergeMemo`, `effectiveEntriesWithMemo`, and
+`mergeOperandMappings`/`mergeOperandMapping` are all unexported helpers
+reachable only from `resolveEffective`; per the frozen `directCallAllowlist`
+in `sourcesurface_test.go`, no `_test.go` file names any of them directly —
+`effective_test.go`, `effectivebound_test.go`, and `effectivemerge_test.go`
 exercise them only through `resolveEffective` itself, alongside
 `resolveEffective` and `effectiveKeyIdentity`, the two additions that
-allowlist authorizes.
+allowlist authorizes. `resolveEffective` itself is still not wired into
+`Load()`, `loadFromPath()`, or ChairLift's strict schema validation — it
+remains a standalone capability, like `parseYAMLDocument` and
+`validateSourceGraph` before it.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -186,20 +186,23 @@ YAML document, with a fixed cardinality outcome per input shape:
   error and line in `Err`/`Detail`, just like a malformed first document
   would.
 
-As of this writing `parseYAMLDocument` and `validateSourceGraph` are not
-wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
-back to `defaultConfig()` on any read or parse failure, so there is no
-strict parsing and no fail-closed runtime behavior yet. This is the first
-of several package-private capabilities (document parsing, reachable
-source-graph shape validation, merge-operand shape validation,
-duplicate-explicit-key detection, the memoized alias-hop bound and the
-memoized source-node path-visit bound, both with all-paths line
-attribution, now; effective-merge construction in a later change) meant to eventually replace
-`loadFromPath()`'s current `yaml.Unmarshal` call with fail-closed,
-single-document, structurally validated loading — but none of that wiring
-exists yet, so `KindRead` and `KindSchema` still describe capabilities the
-package's vocabulary anticipates rather than ones any code path currently
-exercises.
+As of this writing `parseYAMLDocument`, `validateSourceGraph`, and
+`resolveEffective` are not wired into `Load()` or `loadFromPath()` — both
+are unchanged and still fall back to `defaultConfig()` on any read or parse
+failure, so there is no strict parsing and no fail-closed runtime behavior
+yet, and `resolveEffective`'s output does not feed ChairLift's strict
+schema validation either. This is the first of several package-private
+capabilities (document parsing, reachable source-graph shape validation,
+merge-operand shape validation, duplicate-explicit-key detection, the
+memoized alias-hop bound and the memoized source-node path-visit bound
+(both with all-paths line attribution), and now a validate-first
+alias/anchor-resolving emitter whose merge precedence and final output
+shape are still being built out across the next two chunks) meant to
+eventually replace `loadFromPath()`'s current `yaml.Unmarshal` call with
+fail-closed, single-document, structurally validated loading — but none of
+that wiring exists yet, so `KindRead` and `KindSchema` still describe
+capabilities the package's vocabulary anticipates rather than ones any code
+path currently exercises.
 
 **Exact merge-key recognition and tag normalization
 (`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
@@ -368,6 +371,56 @@ reproduce yaml.v3's own duplicate-key guard exactly, while
 `effectiveKeyIdentity` intentionally includes it because merge-precedence
 resolution must not let a `!!str "1"` entry silently discard or be
 discarded by an `!!int 1` entry from another merge source.
+
+**Validate-first, alias-resolving effective emitter
+(`internal/config/effective.go`).** `resolveEffective(path string, doc
+*yaml.Node) (*yaml.Node, *LoadError)` is the slice's entry point toward an
+"effective" (post-merge) configuration tree, and imports only
+`gopkg.in/yaml.v3` plus stdlib. It always calls `validateSourceGraph(path,
+doc)` first and returns that error unchanged on failure — Detail and Path
+byte-identical to what `validateSourceGraph` itself would return for the
+same input — so a caller cannot use `resolveEffective` to bypass
+source-graph validation, and `doc == nil` returns `(nil, nil)` only *after*
+that successful validation, matching `parseYAMLDocument`'s valid
+empty-input result.
+
+On success `resolveEffective` emits a fresh copy of `doc` via the
+unexported `emitEffectiveNode`: the result is rooted at a `yaml.DocumentNode`
+copy with exactly one resolved child, and every emitted node — document,
+mappings, sequences, keys, and values — copies exactly `Kind`, `Style`,
+`Tag`, `Value`, `Line`, `Column`, `HeadComment`, `LineComment`, and
+`FootComment` from the source node it corresponds to, via the unexported
+`emitNodeMetadata`, leaving `Anchor` as `""` and `Alias` as `nil` on every
+copy and allocating a distinct `*yaml.Node` each time (mutating the result
+never mutates `doc`). A `yaml.AliasNode` is never copied as itself: the
+unexported `dereferenceAliasTarget` follows its (possibly multi-hop) `Alias`
+chain to the non-alias target first, and the emitted node carries that
+*target's* metadata, not the alias node's own — this applies identically
+whether the alias appears in mapping value position or as a mapping key.
+Because the output must stay alias-free, a single source node reached
+through more than one alias becomes more than one independent fresh copy in
+the result; the per-emission budget that keeps that expansion from being
+unbounded is added in a later chunk, not this one.
+
+This chunk deliberately leaves two things unfinished, both authorized by
+the spec and tracked forward: a recognized `<<` merge key (`isMergeKey`)
+is still emitted as an ordinary mapping entry with its operand value
+resolved like any other value, rather than being consumed by
+merge-precedence resolution (`TestResolveEffectiveMergeDirectiveRetainedForNow`
+pins this down and is one of the tests a later chunk must update when real
+merge precedence lands); and `resolveEffective` is not wired into `Load()`,
+`loadFromPath()`, or ChairLift's strict schema validation — it is a
+standalone, still-unwired capability like `parseYAMLDocument` and
+`validateSourceGraph` before it. A `!!str`-tagged `"<<"` key and a
+`!!merge`-tagged scalar whose `Value` isn't literally `"<<"` both survive
+as ordinary effective keys today and are expected to keep doing so once
+merge precedence is implemented, since `isMergeKey` never recognizes either
+shape. `emitEffectiveNode` and `dereferenceAliasTarget`/`emitNodeMetadata`
+are unexported helpers reachable only from `resolveEffective` in this same
+chunk; per the frozen `directCallAllowlist` in `sourcesurface_test.go`, no
+`_test.go` file names them directly — `effective_test.go` exercises them
+only through `resolveEffective` itself, alongside `resolveEffective` and
+`effectiveKeyIdentity`, the two additions that allowlist authorizes.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds


### PR DESCRIPTION
Implements the effective-YAML resolution slice of #69.

- resolves aliases and YAML merges with deterministic precedence
- preserves source metadata while clearing anchors and aliases
- memoizes candidate inventories for the complete resolver call
- rejects post-alias explicit-key collisions
- limits effective output to 100,000 retained nodes
- remains unwired until strict schema validation and loading land

Validation: `make ci`

Refs #69