### PR TITLE
feat(config): validate configuration schema and types

### DIFF
--- a/docs/agents/skills/assert-line-numbers-are-parsed-and-positive-not-substring-matched.md
+++ b/docs/agents/skills/assert-line-numbers-are-parsed-and-positive-not-substring-matched.md
@@ -1,0 +1,25 @@
+# Assertions on a generated "line N" detail must parse and check N, not just check the substring is present
+
+**When it applies:** Writing or reviewing a test that asserts an error
+message/detail contains a dynamically computed line number (e.g. a validator
+or parser error like `"unknown page (line 3)"`), especially in table-driven
+tests generated across many rows/levels where the same assertion helper is
+reused.
+
+**What to do:** Don't assert only `strings.Contains(detail, "line ")` (or an
+equivalent loose substring/regex with no capture). That passes even when the
+implementation emits a wrong, non-positive, or hardcoded value (e.g.
+`"line 0"` or `"line -1"`), silently defeating the assertion's actual
+purpose — proving the reported line matches the offending node. Extract the
+number (regex capture or `fmt.Sscanf`) and assert it is a specific expected
+value, or at minimum `> 0`, for every row that claims to check "a positive
+line number." When a single assertion helper is shared across many
+table-driven cases, verify it actually fails for a deliberately-wrong
+fixture (line 0, negative, or omitted) before trusting it across the whole
+matrix.
+
+**Learned from:** issue #69 phase1c1 mill run, chunk 3 revision round 1 — a
+reviewer objection found that several `Path`/line assertions in
+`validate_test.go` only checked for the substring `"line "`, which would
+silently accept `"line 0"` or a negative value at multiple table rows (row
+12, row 14, and the validator-shape path matrix).

--- a/docs/agents/skills/chunk-diff-budgets-scale-with-decision-table-rows.md
+++ b/docs/agents/skills/chunk-diff-budgets-scale-with-decision-table-rows.md
@@ -1,0 +1,28 @@
+# Chunk diff-size budgets must scale with decision-table row count, not a flat per-chunk guess
+
+**When it applies:** Planning or executing a chunk whose acceptance criteria
+require test coverage for every applicable cell of a decision table (e.g. one
+schema-name/shape/declared-type assertion per validation level, or one row
+per collection entry), while the plan also states a flat estimated line count
+(e.g. "≈ 300–400 lines") for that chunk.
+
+**What to do:** A flat per-chunk line estimate made before enumerating the
+table's applicable cells is close to meaningless once the cells are counted:
+each cell typically needs its own fixture, assertion block, and often a
+`Path`/line check, so the real diff size is roughly (applicable cells ×
+lines-per-assertion-block) plus the shared traversal/dispatch code, not a
+constant. Before committing to a chunk boundary, count the exact cells that
+chunk owns (using the "yes" cells of the applicable-category matrix, not the
+full N×M product) and multiply by the measured cost of one existing
+assertion block in the same file/style. If that product already approaches
+or exceeds the plan's stated budget, split the chunk along a real seam
+(e.g. by schema level, or structural-walk vs. field-decode) before
+implementation starts, rather than discovering the overrun only when the
+gate rejects an oversized diff.
+
+**Learned from:** issue #69 phase1c1 mill run, chunk 3 revision round 1 — the
+plan estimated the actions/action-field chunk at ≈ 390 lines, but the actual
+diff was 634 changed lines (608 additions), rejected by the reviewer as far
+exceeding the 300–400-line scope; the overrun traced directly to the number
+of decision-table cells (schema-name, shape, declared-type across multiple
+levels) the chunk's tests needed to cover.

--- a/docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md
+++ b/docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md
@@ -1,0 +1,26 @@
+# A spec that authorizes widening one frozen allowlist/list for exactly one named entry does not cover any other identifier
+
+**When it applies:** Planning or reviewing any chunk that calls an unexported
+helper directly from a test file guarded by a frozen allowlist/list constant
+(e.g. `directCallAllowlist` in `internal/config/sourcesurface_test.go`), where
+the spec text explicitly authorizes adding exactly one new named entry to that
+list for one new function.
+
+**What to do:** Treat that authorization as scoped to the single identifier
+named in the spec, not as blanket permission for the chunk (or a later chunk)
+to call any other unexported helper directly. Before writing a chunk that has
+a test directly call a second unexported function (e.g. `mergeConfig`) and
+claims "it's already in the allowlist," grep the actual list literal in the
+test file to confirm that identifier is really present. If it isn't, either
+add a new, separately-justified authorization to the plan (the spec is
+frozen, so this usually means restructuring the chunk to exercise that helper
+indirectly through the authorized entry point) rather than asserting it's
+already covered.
+
+**Learned from:** issue #69 phase1c mill run — plan round 1's chunk c5 called
+the unexported `mergeConfig` from `validatemerge_test.go`, claiming it was
+already in `directCallAllowlist`. The spec had authorized only
+`"parseAndValidate": true` for that list; `mergeConfig` was never added,
+`TestSourceHelperDirectCallSurface` would fail, and the chunk explicitly
+forbade changing `sourcesurface_test.go` to fix it, making the chunk
+unplannable as written.

--- a/docs/agents/skills/trace-one-concrete-input-through-pipeline-order.md
+++ b/docs/agents/skills/trace-one-concrete-input-through-pipeline-order.md
@@ -1,0 +1,31 @@
+# A layered validator's ordering/scope constraints can make two acceptance criteria mutually unsatisfiable — trace one concrete input through the whole pipeline before accepting the plan
+
+**When it applies:** Planning or reviewing a chunk that implements a
+multi-stage validation pipeline where an early stage performs synthetic
+shape checks (e.g. "reject a non-mapping page value") before falling through
+to a later, delegated stage (e.g. a library `Decode` call) — and separate
+acceptance criteria (a) require a specific error signature (a wrapped
+library error type, reachable via `errors.As`) that only the delegated stage
+can produce, while (b) scope that chunk's own test file to assert nothing
+about errors originating below the level the early stage already checked.
+
+**What to do:** A decision table fixing the Kind boundary (see
+`multi-tier-error-classification-needs-a-decision-table.md`) is necessary but
+not sufficient. Once the table is fixed, pick one concrete malformed input
+per criterion that names a specific mechanism (an error type, a wrapped
+error, a call-stack shape) and hand-trace it through the pipeline in the
+exact stage order the spec/chunk defines. If the early stage's synthetic
+checks would catch that input before the delegated stage ever runs — or if
+the only inputs that reach the delegated stage are barred from assertion by
+a separate scope rule in the same chunk — the criteria are unsatisfiable as
+written and the plan must change which chunk owns that input/assertion
+before writing any code, not after gates fail.
+
+**Learned from:** issue #69 phase1c mill run — plan round 4's chunk c1
+required a final whole-document `Decode` failure classified `KindParseType`
+with `errors.As` reaching `*yaml.TypeError` (criterion 26), while a separate
+criterion (31) forbade `validate_test.go` from asserting any `ErrorKind`
+produced below page level. Because c1's own page-shape checks intercept
+top-level scalar/sequence failures synthetically (with no `*yaml.TypeError`)
+before `Decode` runs, no input could satisfy both criteria at once; this was
+only discovered in round 4 of 4, exhausting `plan_rounds` and failing the run.

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -40,6 +40,12 @@ import (
 //     directly. Every other new resolver helper this slice adds in a later
 //     chunk must be exercised only indirectly, through resolveEffective —
 //     it must not be added to this allowlist.
+//   - parseAndValidate is the single addition phase1c1's chunk c1 spec
+//     authorizes, spending that chunk's one frozen-allowlist entry per
+//     docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md.
+//     No other new production helper c1 adds (validatorShapeError,
+//     validatorDecodeError, effectiveNodeLine) may be added here; they are
+//     exercised only indirectly, through parseAndValidate.
 var directCallAllowlist = map[string]bool{
 	"parseYAMLDocument": true,
 
@@ -62,6 +68,8 @@ var directCallAllowlist = map[string]bool{
 	"resolveEffective": true,
 
 	"effectiveKeyIdentity": true,
+
+	"parseAndValidate": true,
 }
 
 // packageGoFiles lists the *.go files directly in this package's directory

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -43,8 +43,7 @@ import (
 //   - parseAndValidate is the single addition phase1c1's chunk c1 spec
 //     authorizes, spending that chunk's one frozen-allowlist entry per
 //     docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md.
-//     No other new production helper c1 adds (validatorShapeError,
-//     validatorDecodeError, effectiveNodeLine) may be added here; they are
+//     No other new production helper c1 adds may be added here; they are
 //     exercised only indirectly, through parseAndValidate.
 var directCallAllowlist = map[string]bool{
 	"parseYAMLDocument": true,

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// parseAndValidate is the package-private entry point tying together the
+// four validation stages built up across this slice: stage 1
+// (parseYAMLDocument, source.go) parses data as YAML; stage 2
+// (resolveEffective, effective.go) validates the resulting source graph
+// (validateSourceGraph, sourcegraph.go, including its
+// checkSourceGraphBounds pass, sourcebounds.go) and, on success, emits a
+// fresh alias-free, merge-resolved effective document; this function's own
+// document-level shape check (stage 3's document-level slice) classifies
+// what kind of top-level node the effective document has; and stage 4
+// decodes an accepted mapping document into a *rawConfig.
+//
+// A stage 1 or stage 2 *LoadError is returned unchanged: this entry point
+// can never bypass parser, source-graph, or bound validation by skipping
+// past their errors.
+//
+// Document-level outcomes, once stage 1 and stage 2 both succeed:
+//
+//   - A nil effective document — parseYAMLDocument's and resolveEffective's
+//     shared "empty or whitespace-only input" result — returns a non-nil,
+//     zero-valued *rawConfig (every page map nil/empty) and no error: it is
+//     a usable no-op overlay, matching the "absent config" semantics
+//     elsewhere in this package. Stage 4's Decode is skipped entirely for
+//     this case.
+//   - A top-level scalar resolving to YAML's null tag ("!!null" — as
+//     produced by an empty document's `null`/`~`/absent value at the
+//     document root) is treated exactly like the nil-document case above:
+//     a non-nil, zero-valued *rawConfig, no error, and no Decode call.
+//   - A top-level scalar that is not null, or a top-level sequence, is
+//     rejected as a KindParseType *LoadError (validatorShapeError) naming
+//     the expected top-level mapping shape and a positive source line
+//     (effectiveNodeLine). Stage 4's Decode is skipped for this case too:
+//     there is no mapping to decode.
+//   - A top-level mapping is accepted structurally; stage 4 then decodes
+//     the effective document into a *rawConfig via yaml.Node.Decode.
+//     Per-entry classification of page/group/action content within an
+//     accepted mapping starts at a later chunk ("c2 on") and is out of
+//     this function's scope.
+//
+// Stage 4 is a defensive final step (interpretation I4): validateSourceGraph
+// and resolveEffective already prove the effective document is a
+// well-formed, alias-free, merge-resolved graph rooted at a mapping by the
+// time Decode runs, so a Decode failure here is not expected to be
+// reachable from ordinary input, but if yaml.v3's own Decode nonetheless
+// reports an error (e.g. a genuine type mismatch decoding into rawConfig's
+// field types), it is classified KindParseType with the yaml error
+// preserved in Err (validatorDecodeError) rather than left unhandled.
+func parseAndValidate(path string, data []byte) (*rawConfig, *LoadError) {
+	doc, err := parseYAMLDocument(path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	effective, err := resolveEffective(path, doc)
+	if err != nil {
+		return nil, err
+	}
+
+	if effective == nil {
+		// Empty or whitespace-only input: a usable no-op overlay.
+		return &rawConfig{}, nil
+	}
+
+	top := effective.Content[0]
+	switch {
+	case top.Kind == yaml.ScalarNode && top.Tag == "!!null":
+		// A top-level null document (`null`, `~`, or an absent scalar
+		// value) is a no-op overlay too, just like the nil-document case.
+		return &rawConfig{}, nil
+	case top.Kind == yaml.MappingNode:
+		var raw rawConfig
+		if err := effective.Decode(&raw); err != nil {
+			return nil, validatorDecodeError(path, err)
+		}
+		return &raw, nil
+	default:
+		return nil, validatorShapeError(path, top)
+	}
+}
+
+// validatorShapeError builds a KindParseType *LoadError reporting that
+// top — the effective document's top-level node — is not a YAML mapping
+// (and, per parseAndValidate's null-scalar no-op case, is not treated as
+// absent either). Detail names the actual node shape found and
+// effectiveNodeLine(top)'s clamped, always-positive source line. There is
+// no underlying yaml.v3 error to preserve here — this is a validator-side
+// shape rejection, not a parser failure — so, like sourceGraphError's
+// other callers, Err is left nil.
+func validatorShapeError(path string, top *yaml.Node) *LoadError {
+	var found string
+	switch top.Kind {
+	case yaml.SequenceNode:
+		found = "a YAML sequence"
+	case yaml.ScalarNode:
+		found = "a YAML scalar"
+	default:
+		found = fmt.Sprintf("a YAML node of kind %d", top.Kind)
+	}
+	return sourceGraphError(path, fmt.Sprintf(
+		"top-level document must be a YAML mapping, found %s (line %d)",
+		found, effectiveNodeLine(top),
+	))
+}
+
+// validatorDecodeError builds the KindParseType *LoadError parseAndValidate
+// returns when yaml.Node.Decode fails to decode an accepted top-level
+// mapping document into a *rawConfig. Unlike validatorShapeError, this
+// wraps a real yaml.v3 error (typically a *yaml.TypeError): Detail is that
+// error's own message and Err preserves it, matching parseFailure's
+// (source.go) treatment of a stage 1 parser error.
+func validatorDecodeError(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindParseType,
+		Detail: err.Error(),
+		Err:    err,
+	}
+}
+
+// effectiveNodeLine returns n's Line, clamped to 1 when non-positive. It
+// mirrors effectiveOutputLimitError's (effective.go) own clamp, applied
+// there to a line looked up from attributeSourceLines: a node's Line can be
+// zero (or, in principle for a synthetic node, negative) when yaml.v3 left
+// it unset, and a reported "line 0" or negative line would be a confusing
+// diagnostic, so the lowest value ever reported here is 1.
+func effectiveNodeLine(n *yaml.Node) int {
+	if n.Line <= 0 {
+		return 1
+	}
+	return n.Line
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -46,10 +47,19 @@ import (
 //     page names is KindSchema (validatorSchemaError) without descending
 //     into its value; a known page's null value is a no-op for that page; a
 //     known page's non-null scalar or sequence value is KindParseType
-//     (validatorPageValueShapeError); and a known page's mapping value is
-//     accepted structurally (its own entries — groups and fields — are
-//     classified starting at a later chunk). Once every entry passes, stage
-//     4 decodes the effective document into a *rawConfig via
+//     (validatorPageValueShapeError); and a known page's mapping value has
+//     its own entries (groups) classified the same way, one level down, by
+//     validateGroupEntries, whose own known groups' mapping values have
+//     their entries (group fields) classified by validateGroupFieldEntries.
+//     A group or field name unknown to SchemaGroups/groupFieldTypes is
+//     KindSchema; a group's non-null scalar/sequence value is KindParseType
+//     (validatorGroupValueShapeError); a known non-"actions" field is
+//     decoded into a fresh value of its declared Go type
+//     (groupFieldTypes), a decode failure being KindParseType with the
+//     yaml.v3 error preserved in Err. "actions" is recognized as known but
+//     its value is left uninspected by this chunk (I5; a later chunk adds
+//     its own structural walk). Once every entry at every level passes,
+//     stage 4 decodes the effective document into a *rawConfig via
 //     yaml.Node.Decode.
 //
 // Stage 4 is a defensive final step (interpretation I4): validateSourceGraph
@@ -143,13 +153,146 @@ func validatePageEntries(path string, top *yaml.Node) *LoadError {
 		case yaml.SequenceNode:
 			return validatorPageValueShapeError(path, name, value)
 		case yaml.MappingNode:
-			continue // accepted structurally; entries classified from c3 on
+			if err := validateGroupEntries(path, name, value); err != nil {
+				return err
+			}
 		default:
 			return validatorPageValueShapeError(path, name, value)
 		}
 	}
 
 	return nil
+}
+
+// validateGroupEntries walks groupsNode's entries (groupsNode is a known
+// page's mapping value, so each entry is a group) exactly like
+// validatePageEntries does for pages, one schema level down: key shape via
+// schemaKeyName, then name membership against SchemaGroups(page)'s
+// canonical group names for this page (never a literal list here), then
+// value shape (null is a no-op; scalar/sequence is KindParseType; a mapping
+// descends into validateGroupFieldEntries). The first failing entry's error
+// is returned; nil means every entry passed. SchemaGroups can only fail for
+// a page name unknown to it, which cannot happen here since page was
+// already validated against SchemaPages(); that branch is still surfaced
+// defensively as KindSchema (validatorSchemaGroupsError).
+func validateGroupEntries(path, page string, groupsNode *yaml.Node) *LoadError {
+	groups, err := SchemaGroups(page)
+	if err != nil {
+		return validatorSchemaGroupsError(path, err)
+	}
+	known := make(map[string]bool, len(groups))
+	for _, group := range groups {
+		known[group] = true
+	}
+
+	for i := 0; i+1 < len(groupsNode.Content); i += 2 {
+		key := groupsNode.Content[i]
+		value := groupsNode.Content[i+1]
+
+		name, ok := schemaKeyName(key)
+		if !ok {
+			return validatorKeyShapeError(path, key)
+		}
+		if !known[name] {
+			return validatorSchemaError(path, key, name)
+		}
+
+		switch value.Kind {
+		case yaml.ScalarNode:
+			if value.Tag == "!!null" {
+				continue // known group with a null value: a no-op for that group
+			}
+			return validatorGroupValueShapeError(path, name, value)
+		case yaml.SequenceNode:
+			return validatorGroupValueShapeError(path, name, value)
+		case yaml.MappingNode:
+			if err := validateGroupFieldEntries(path, name, value); err != nil {
+				return err
+			}
+		default:
+			return validatorGroupValueShapeError(path, name, value)
+		}
+	}
+
+	return nil
+}
+
+// validateGroupFieldEntries walks fieldsNode's entries (fieldsNode is a
+// known group's mapping value, so each entry is a group field): key shape
+// via schemaKeyName, then name membership against groupFieldTypes()'s
+// canonical field names (never a literal list here, aside from the literal
+// "actions" itself). The special-cased "actions" name is recognized as
+// known but its value is deliberately left uninspected by this chunk (I5 —
+// a later chunk adds its own structural walk). Every other known field's
+// effective value node is decoded into a fresh value of its declared Go
+// type (reflect.New(fieldType).Interface(), I4); a decode failure is
+// KindParseType with the real yaml.v3 error preserved in Err
+// (validatorDecodeError, matching stage 4's own decode-failure handling).
+// The first failing entry's error is returned; nil means every entry
+// passed.
+func validateGroupFieldEntries(path, group string, fieldsNode *yaml.Node) *LoadError {
+	fieldTypes, err := groupFieldTypes()
+	if err != nil {
+		return validatorGroupFieldTypesError(path, err)
+	}
+
+	for i := 0; i+1 < len(fieldsNode.Content); i += 2 {
+		key := fieldsNode.Content[i]
+		value := fieldsNode.Content[i+1]
+
+		name, ok := schemaKeyName(key)
+		if !ok {
+			return validatorKeyShapeError(path, key)
+		}
+		fieldType, known := fieldTypes[name]
+		if !known {
+			return validatorSchemaError(path, key, name)
+		}
+		if name == "actions" {
+			continue // I5: actions' value is validated by a later chunk
+		}
+
+		target := reflect.New(fieldType)
+		if err := value.Decode(target.Interface()); err != nil {
+			return validatorDecodeError(path, err)
+		}
+	}
+
+	return nil
+}
+
+// groupFieldTypes reflects over rawGroupConfig's exported fields, returning
+// a freshly allocated map from each field's yaml tag name to its declared
+// Go type. It is the type-carrying counterpart to SchemaGroupFields
+// (schema.go), built by walking the same struct's fields so the two cannot
+// silently drift apart. It errors under the same conditions yamlFieldNames
+// does, which cannot happen for rawGroupConfig's canonical field list.
+func groupFieldTypes() (map[string]reflect.Type, error) {
+	t := reflect.TypeOf(rawGroupConfig{})
+	result := make(map[string]reflect.Type, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+
+		tag, ok := field.Tag.Lookup("yaml")
+		if !ok || tag == "" || tag == "-" {
+			continue
+		}
+
+		name := yamlTagName(tag)
+		if name == "" {
+			return nil, fmt.Errorf("groupFieldTypes: field %s has a yaml tag with an empty name (%q)", field.Name, tag)
+		}
+		if _, dup := result[name]; dup {
+			return nil, fmt.Errorf("groupFieldTypes: duplicate yaml name %q (field %s)", name, field.Name)
+		}
+		result[name] = field.Type
+	}
+
+	return result, nil
 }
 
 // schemaKeyName implements the spec's name rule for a mapping key: key is a
@@ -199,6 +342,31 @@ func validatorSchemaPagesError(path string, err error) *LoadError {
 	}
 }
 
+// validatorSchemaGroupsError builds a KindSchema *LoadError wrapping a
+// SchemaGroups(page) error, matching validatorSchemaPagesError one level
+// down; SchemaGroups can only fail for a page unknown to it, which cannot
+// happen once page has passed SchemaPages() validation.
+func validatorSchemaGroupsError(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindSchema,
+		Detail: fmt.Sprintf("could not determine canonical group names: %v", err),
+		Err:    err,
+	}
+}
+
+// validatorGroupFieldTypesError builds a KindSchema *LoadError wrapping a
+// groupFieldTypes error, matching validatorSchemaPagesError; it cannot
+// happen for rawGroupConfig's canonical, hand-maintained field list.
+func validatorGroupFieldTypesError(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindSchema,
+		Detail: fmt.Sprintf("could not determine canonical group field types: %v", err),
+		Err:    err,
+	}
+}
+
 // validatorKeyShapeError builds a KindParseType *LoadError reporting that
 // key is not a YAML string (schemaKeyName's ("", false) result). Detail
 // names the actual node shape found and a positive source line
@@ -221,6 +389,18 @@ func validatorPageValueShapeError(path, page string, value *yaml.Node) *LoadErro
 	return sourceGraphError(path, fmt.Sprintf(
 		"page %q must be null or a YAML mapping, found %s (line %d)",
 		page, describeNodeShape(value), effectiveNodeLine(value),
+	))
+}
+
+// validatorGroupValueShapeError builds a KindParseType *LoadError reporting
+// that the known group named group has a value that is neither null nor a
+// mapping. Detail names the group, the actual node shape found, and a
+// positive source line, matching validatorPageValueShapeError one level
+// down.
+func validatorGroupValueShapeError(path, group string, value *yaml.Node) *LoadError {
+	return sourceGraphError(path, fmt.Sprintf(
+		"group %q must be null or a YAML mapping, found %s (line %d)",
+		group, describeNodeShape(value), effectiveNodeLine(value),
 	))
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -38,11 +38,19 @@ import (
 //     the expected top-level mapping shape and a positive source line
 //     (effectiveNodeLine). Stage 4's Decode is skipped for this case too:
 //     there is no mapping to decode.
-//   - A top-level mapping is accepted structurally; stage 4 then decodes
-//     the effective document into a *rawConfig via yaml.Node.Decode.
-//     Per-entry classification of page/group/action content within an
-//     accepted mapping starts at a later chunk ("c2 on") and is out of
-//     this function's scope.
+//   - A top-level mapping has each of its entries classified in effective
+//     order by validatePageEntries: a mapping key whose effective node is
+//     not a scalar with ShortTag() == "!!str" is KindParseType
+//     (validatorKeyShapeError) before its value is ever inspected; a
+//     well-formed string key that is not one of SchemaPages()'s canonical
+//     page names is KindSchema (validatorSchemaError) without descending
+//     into its value; a known page's null value is a no-op for that page; a
+//     known page's non-null scalar or sequence value is KindParseType
+//     (validatorPageValueShapeError); and a known page's mapping value is
+//     accepted structurally (its own entries — groups and fields — are
+//     classified starting at a later chunk). Once every entry passes, stage
+//     4 decodes the effective document into a *rawConfig via
+//     yaml.Node.Decode.
 //
 // Stage 4 is a defensive final step (interpretation I4): validateSourceGraph
 // and resolveEffective already prove the effective document is a
@@ -75,6 +83,9 @@ func parseAndValidate(path string, data []byte) (*rawConfig, *LoadError) {
 		// value) is a no-op overlay too, just like the nil-document case.
 		return &rawConfig{}, nil
 	case top.Kind == yaml.MappingNode:
+		if err := validatePageEntries(path, top); err != nil {
+			return nil, err
+		}
 		var raw rawConfig
 		if err := effective.Decode(&raw); err != nil {
 			return nil, validatorDecodeError(path, err)
@@ -82,6 +93,152 @@ func parseAndValidate(path string, data []byte) (*rawConfig, *LoadError) {
 		return &raw, nil
 	default:
 		return nil, validatorShapeError(path, top)
+	}
+}
+
+// validatePageEntries walks top's entries (top is the effective document's
+// top-level mapping node) in effective Content order and classifies each
+// one per interpretation I3's fixed order: (a) key shape — schemaKeyName
+// requires a scalar key whose effective ShortTag() is exactly "!!str", else
+// the entry is KindParseType before its name or value is inspected; (b)
+// name membership — a well-formed string key that is not one of
+// SchemaPages()'s canonical page names is KindSchema without descending
+// into its value; (c) only then is the page's value shape inspected. The
+// first failing entry's error is returned; nil means every entry passed.
+//
+// Page names are sourced only from SchemaPages() (reflected off Config's
+// yaml tags via schema.go) — never a literal list here. SchemaPages() can
+// only fail for a malformed struct tag on Config itself, which cannot
+// happen for that canonical struct; that branch is still surfaced
+// defensively as a KindSchema *LoadError wrapping the reflect error
+// (validatorSchemaPagesError) rather than ignored or panicked on.
+func validatePageEntries(path string, top *yaml.Node) *LoadError {
+	pages, err := SchemaPages()
+	if err != nil {
+		return validatorSchemaPagesError(path, err)
+	}
+	known := make(map[string]bool, len(pages))
+	for _, page := range pages {
+		known[page] = true
+	}
+
+	for i := 0; i+1 < len(top.Content); i += 2 {
+		key := top.Content[i]
+		value := top.Content[i+1]
+
+		name, ok := schemaKeyName(key)
+		if !ok {
+			return validatorKeyShapeError(path, key)
+		}
+		if !known[name] {
+			return validatorSchemaError(path, key, name)
+		}
+
+		switch value.Kind {
+		case yaml.ScalarNode:
+			if value.Tag == "!!null" {
+				continue // known page with a null value: a no-op for that page
+			}
+			return validatorPageValueShapeError(path, name, value)
+		case yaml.SequenceNode:
+			return validatorPageValueShapeError(path, name, value)
+		case yaml.MappingNode:
+			continue // accepted structurally; entries classified from c3 on
+		default:
+			return validatorPageValueShapeError(path, name, value)
+		}
+	}
+
+	return nil
+}
+
+// schemaKeyName implements the spec's name rule for a mapping key: key is a
+// name only when it is a yaml.ScalarNode whose effective ShortTag() is
+// exactly "!!str", in which case its Value is returned with ok == true.
+// Every other key shape — an integer, boolean, or null scalar; a
+// custom-tagged scalar; a sequence; a mapping; or an alias to any of those
+// (aliases are already dereferenced into copies of their targets by
+// resolveEffective, so this rule needs no alias-specific case) — returns
+// ("", false). yaml.v3's own ability to coerce a non-!!str scalar into a Go
+// string (e.g. decoding an integer key into a string field) does not make
+// that key a name here: the rule is the node's own resolved tag, not what
+// yaml.v3 could decode it into.
+func schemaKeyName(key *yaml.Node) (string, bool) {
+	if key.Kind == yaml.ScalarNode && key.ShortTag() == "!!str" {
+		return key.Value, true
+	}
+	return "", false
+}
+
+// validatorSchemaError builds a KindSchema *LoadError reporting that node
+// (a mapping key) names an unrecognized name. Detail names the literal
+// offending name and a positive source line (effectiveNodeLine). There is
+// no underlying yaml.v3 error to preserve — this is a validator-side name
+// rejection — so, like validatorShapeError's other callers, Err is left
+// nil.
+func validatorSchemaError(path string, node *yaml.Node, name string) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindSchema,
+		Detail: fmt.Sprintf("unknown name %q (line %d)", name, effectiveNodeLine(node)),
+	}
+}
+
+// validatorSchemaPagesError builds a KindSchema *LoadError wrapping a
+// SchemaPages() error. SchemaPages() can only fail for a malformed struct
+// tag on Config itself (schema.go's yamlFieldNames), which cannot happen
+// for that canonical, hand-maintained struct; this exists so that
+// theoretical failure is still classified rather than ignored or panicked
+// on.
+func validatorSchemaPagesError(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindSchema,
+		Detail: fmt.Sprintf("could not determine canonical page names: %v", err),
+		Err:    err,
+	}
+}
+
+// validatorKeyShapeError builds a KindParseType *LoadError reporting that
+// key is not a YAML string (schemaKeyName's ("", false) result). Detail
+// names the actual node shape found and a positive source line
+// (effectiveNodeLine). There is no underlying yaml.v3 error to preserve —
+// this is a validator-side shape rejection — so Err is left nil, matching
+// validatorShapeError.
+func validatorKeyShapeError(path string, key *yaml.Node) *LoadError {
+	return sourceGraphError(path, fmt.Sprintf(
+		"mapping key must be a YAML string, found %s (line %d)",
+		describeNodeShape(key), effectiveNodeLine(key),
+	))
+}
+
+// validatorPageValueShapeError builds a KindParseType *LoadError reporting
+// that the known page named page has a value that is neither null nor a
+// mapping (i.e. a non-null scalar or a sequence). Detail names the page,
+// the actual node shape found, and a positive source line
+// (effectiveNodeLine).
+func validatorPageValueShapeError(path, page string, value *yaml.Node) *LoadError {
+	return sourceGraphError(path, fmt.Sprintf(
+		"page %q must be null or a YAML mapping, found %s (line %d)",
+		page, describeNodeShape(value), effectiveNodeLine(value),
+	))
+}
+
+// describeNodeShape returns a short human-readable description of n's kind,
+// used by the validator's shape-rejection error builders. For a scalar it
+// includes the resolved tag (e.g. "a YAML scalar (!!int)") since "found a
+// YAML scalar" alone would not distinguish an unwanted !!int key from an
+// unwanted !!bool key.
+func describeNodeShape(n *yaml.Node) string {
+	switch n.Kind {
+	case yaml.SequenceNode:
+		return "a YAML sequence"
+	case yaml.MappingNode:
+		return "a YAML mapping"
+	case yaml.ScalarNode:
+		return fmt.Sprintf("a YAML scalar (%s)", n.ShortTag())
+	default:
+		return fmt.Sprintf("a YAML node of kind %d", n.Kind)
 	}
 }
 
@@ -94,18 +251,9 @@ func parseAndValidate(path string, data []byte) (*rawConfig, *LoadError) {
 // shape rejection, not a parser failure — so, like sourceGraphError's
 // other callers, Err is left nil.
 func validatorShapeError(path string, top *yaml.Node) *LoadError {
-	var found string
-	switch top.Kind {
-	case yaml.SequenceNode:
-		found = "a YAML sequence"
-	case yaml.ScalarNode:
-		found = "a YAML scalar"
-	default:
-		found = fmt.Sprintf("a YAML node of kind %d", top.Kind)
-	}
 	return sourceGraphError(path, fmt.Sprintf(
 		"top-level document must be a YAML mapping, found %s (line %d)",
-		found, effectiveNodeLine(top),
+		describeNodeShape(top), effectiveNodeLine(top),
 	))
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -54,13 +54,21 @@ import (
 //     A group or field name unknown to SchemaGroups/groupFieldTypes is
 //     KindSchema; a group's non-null scalar/sequence value is KindParseType
 //     (validatorGroupValueShapeError); a known non-"actions" field is
-//     decoded into a fresh value of its declared Go type
-//     (groupFieldTypes), a decode failure being KindParseType with the
-//     yaml.v3 error preserved in Err. "actions" is recognized as known but
-//     its value is left uninspected by this chunk (I5; a later chunk adds
-//     its own structural walk). Once every entry at every level passes,
-//     stage 4 decodes the effective document into a *rawConfig via
-//     yaml.Node.Decode.
+//     decoded into a fresh value of its declared Go type (groupFieldTypes),
+//     a decode failure being KindParseType with the yaml.v3 error preserved
+//     in Err. "actions" is recognized as known but is validated structurally
+//     instead of by a generic decode (I5): its value must be null (a no-op)
+//     or a sequence, else KindParseType (validatorActionsValueShapeError);
+//     every sequence entry must be a YAML mapping — a null entry is
+//     explicitly not a zero action — else KindParseType
+//     (validatorActionEntryShapeError); and each action entry's own fields
+//     are classified exactly like a group's fields, one level down, by
+//     validateActionFieldEntries: key shape and name membership against
+//     SchemaActionFields()/actionFieldTypes (sourced from ActionConfig),
+//     then a known field decoded into a fresh value of its declared Go type,
+//     a decode failure being KindParseType with the yaml.v3 error preserved
+//     in Err. Once every entry at every level passes, stage 4 decodes the
+//     effective document into a *rawConfig via yaml.Node.Decode.
 //
 // Stage 4 is a defensive final step (interpretation I4): validateSourceGraph
 // and resolveEffective already prove the effective document is a
@@ -221,9 +229,9 @@ func validateGroupEntries(path, page string, groupsNode *yaml.Node) *LoadError {
 // known group's mapping value, so each entry is a group field): key shape
 // via schemaKeyName, then name membership against groupFieldTypes()'s
 // canonical field names (never a literal list here, aside from the literal
-// "actions" itself). The special-cased "actions" name is recognized as
-// known but its value is deliberately left uninspected by this chunk (I5 —
-// a later chunk adds its own structural walk). Every other known field's
+// "actions" itself). The special-cased "actions" name is recognized as known
+// but is validated structurally by validateActionsEntries (I5) instead of by
+// a generic decode into its declared Go type. Every other known field's
 // effective value node is decoded into a fresh value of its declared Go
 // type (reflect.New(fieldType).Interface(), I4); a decode failure is
 // KindParseType with the real yaml.v3 error preserved in Err
@@ -249,7 +257,10 @@ func validateGroupFieldEntries(path, group string, fieldsNode *yaml.Node) *LoadE
 			return validatorSchemaError(path, key, name)
 		}
 		if name == "actions" {
-			continue // I5: actions' value is validated by a later chunk
+			if err := validateActionsEntries(path, value); err != nil {
+				return err
+			}
+			continue
 		}
 
 		target := reflect.New(fieldType)
@@ -259,6 +270,104 @@ func validateGroupFieldEntries(path, group string, fieldsNode *yaml.Node) *LoadE
 	}
 
 	return nil
+}
+
+// validateActionsEntries implements the structural walk for a known
+// "actions" field's value (I5): null is a no-op, a sequence has every entry
+// validated by validateActionFieldEntries, and any other shape (non-null
+// scalar or mapping) is KindParseType. This is deliberately not a generic
+// decode into []ActionConfig — yaml.v3 would silently accept a null entry
+// as a zero ActionConfig and silently ignore an unknown action field.
+func validateActionsEntries(path string, actionsNode *yaml.Node) *LoadError {
+	switch actionsNode.Kind {
+	case yaml.ScalarNode:
+		if actionsNode.Tag == "!!null" {
+			return nil // no actions configured: a no-op
+		}
+		return validatorActionsValueShapeError(path, actionsNode)
+	case yaml.SequenceNode:
+		for _, entry := range actionsNode.Content {
+			if entry.Kind != yaml.MappingNode {
+				// A null entry is explicitly not a zero action: it must
+				// be a mapping, like every other non-mapping shape.
+				return validatorActionEntryShapeError(path, entry)
+			}
+			if err := validateActionFieldEntries(path, entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return validatorActionsValueShapeError(path, actionsNode)
+	}
+}
+
+// validateActionFieldEntries walks entryNode's entries (one action-sequence
+// entry, already confirmed to be a mapping): key shape via schemaKeyName,
+// name membership against actionFieldTypes()'s canonical names (from
+// ActionConfig, I7), then a known field's value decoded into
+// reflect.New(fieldType), a decode failure being KindParseType with the
+// real yaml.v3 error preserved (I4) — matching validateGroupFieldEntries'
+// non-"actions" handling one level down. The first failing entry's error is
+// returned; nil means every entry passed.
+func validateActionFieldEntries(path string, entryNode *yaml.Node) *LoadError {
+	fieldTypes, err := actionFieldTypes()
+	if err != nil {
+		return validatorActionFieldTypesError(path, err)
+	}
+
+	for i := 0; i+1 < len(entryNode.Content); i += 2 {
+		key := entryNode.Content[i]
+		value := entryNode.Content[i+1]
+
+		name, ok := schemaKeyName(key)
+		if !ok {
+			return validatorKeyShapeError(path, key)
+		}
+		fieldType, known := fieldTypes[name]
+		if !known {
+			return validatorSchemaError(path, key, name)
+		}
+
+		target := reflect.New(fieldType)
+		if err := value.Decode(target.Interface()); err != nil {
+			return validatorDecodeError(path, err)
+		}
+	}
+
+	return nil
+}
+
+// actionFieldTypes reflects over ActionConfig's exported fields, returning
+// a freshly allocated map from each field's yaml tag name to its declared
+// Go type — the type-carrying counterpart to SchemaActionFields (schema.go),
+// matching groupFieldTypes one schema level down.
+func actionFieldTypes() (map[string]reflect.Type, error) {
+	t := reflect.TypeOf(ActionConfig{})
+	result := make(map[string]reflect.Type, t.NumField())
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+
+		tag, ok := field.Tag.Lookup("yaml")
+		if !ok || tag == "" || tag == "-" {
+			continue
+		}
+
+		name := yamlTagName(tag)
+		if name == "" {
+			return nil, fmt.Errorf("actionFieldTypes: field %s has a yaml tag with an empty name (%q)", field.Name, tag)
+		}
+		if _, dup := result[name]; dup {
+			return nil, fmt.Errorf("actionFieldTypes: duplicate yaml name %q (field %s)", name, field.Name)
+		}
+		result[name] = field.Type
+	}
+
+	return result, nil
 }
 
 // groupFieldTypes reflects over rawGroupConfig's exported fields, returning
@@ -365,6 +474,43 @@ func validatorGroupFieldTypesError(path string, err error) *LoadError {
 		Detail: fmt.Sprintf("could not determine canonical group field types: %v", err),
 		Err:    err,
 	}
+}
+
+// validatorActionFieldTypesError builds a KindSchema *LoadError wrapping an
+// actionFieldTypes error, matching validatorGroupFieldTypesError one schema
+// level down; it cannot happen for ActionConfig's canonical, hand-maintained
+// field list.
+func validatorActionFieldTypesError(path string, err error) *LoadError {
+	return &LoadError{
+		Path:   path,
+		Kind:   KindSchema,
+		Detail: fmt.Sprintf("could not determine canonical action field types: %v", err),
+		Err:    err,
+	}
+}
+
+// validatorActionsValueShapeError builds a KindParseType *LoadError
+// reporting that a known "actions" field's value is neither null nor a
+// sequence (i.e. a non-null scalar or a mapping). Detail names the actual
+// node shape found and a positive source line, matching
+// validatorGroupValueShapeError's pattern one schema level down.
+func validatorActionsValueShapeError(path string, value *yaml.Node) *LoadError {
+	return sourceGraphError(path, fmt.Sprintf(
+		"field %q must be null or a YAML sequence, found %s (line %d)",
+		"actions", describeNodeShape(value), effectiveNodeLine(value),
+	))
+}
+
+// validatorActionEntryShapeError builds a KindParseType *LoadError
+// reporting that an "actions" sequence entry is not a YAML mapping. A null
+// entry is deliberately included here (not treated as a zero action):
+// entry's own actual node shape (including "a YAML scalar (!!null)" for a
+// null entry) and a positive source line are named in Detail.
+func validatorActionEntryShapeError(path string, entry *yaml.Node) *LoadError {
+	return sourceGraphError(path, fmt.Sprintf(
+		"action entry must be a YAML mapping, found %s (line %d)",
+		describeNodeShape(entry), effectiveNodeLine(entry),
+	))
 }
 
 // validatorKeyShapeError builds a KindParseType *LoadError reporting that

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -8,6 +8,21 @@ import (
 	"testing"
 )
 
+// wantSchema fails the test unless err is a non-nil *LoadError with
+// Kind == KindSchema and Path == path.
+func wantSchema(t *testing.T, err *LoadError, path string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("parseAndValidate(%q, ...) = nil, want a KindSchema error", path)
+	}
+	if err.Kind != KindSchema {
+		t.Fatalf("err.Kind = %q, want %q", err.Kind, KindSchema)
+	}
+	if err.Path != path {
+		t.Fatalf("err.Path = %q, want %q", err.Path, path)
+	}
+}
+
 // wantNoopRawConfig fails the test unless parseAndValidate(path, data)
 // returns a non-nil, zero-valued *rawConfig (every page map nil/empty) and
 // a nil error, as required for a document-level no-op overlay.
@@ -185,4 +200,234 @@ func TestParseAndValidateStaysOutOfRuntimeLoad(t *testing.T) {
 			return true
 		})
 	}
+}
+
+// TestParseAndValidateUnknownPageRejected confirms decision-table row 5: an
+// unrecognized top-level page name is KindSchema, with Path copied and
+// Detail containing both the literal offending name and a positive line.
+func TestParseAndValidateUnknownPageRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("not_a_page: 1\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantSchema(t, err, path)
+	if !strings.Contains(err.Detail, "not_a_page") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "not_a_page")
+	}
+	if !strings.Contains(err.Detail, "line 1") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "line 1")
+	}
+}
+
+// TestParseAndValidateKnownPageNull confirms decision-table row 6: a known
+// page with a null value is accepted (a no-op for that page), returning a
+// nil error and a non-nil *rawConfig.
+func TestParseAndValidateKnownPageNull(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("system_page:\n"))
+	if err != nil {
+		t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+	}
+	if raw == nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = nil, want non-nil")
+	}
+}
+
+// TestParseAndValidateKnownPageWrongShape confirms decision-table row 7: a
+// known page whose value is a scalar or a sequence is KindParseType, with
+// Path copied and a positive line named in Detail.
+func TestParseAndValidateKnownPageWrongShape(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"scalar value", "system_page: 3\n"},
+		{"sequence value", "system_page:\n  - a\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateEveryCanonicalPageAccepted iterates every page name
+// SchemaPages() returns and confirms each is accepted with a null value, so
+// no canonical page is accidentally rejected by validatePageEntries's known-
+// page check (docs/agents/skills/regression-tests-must-cover-every-
+// collection-entry.md).
+func TestParseAndValidateEveryCanonicalPageAccepted(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	pages, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages() error = %v, want nil", err)
+	}
+	if len(pages) == 0 {
+		t.Fatalf("SchemaPages() = %v, want at least one page", pages)
+	}
+
+	for _, page := range pages {
+		t.Run(page, func(t *testing.T) {
+			data := page + ":\n"
+			raw, loadErr := parseAndValidate(path, []byte(data))
+			if loadErr != nil {
+				t.Fatalf("parseAndValidate(%q) error = %v, want nil", data, loadErr)
+			}
+			if raw == nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = nil, want non-nil", data)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateNonStringPageKeyRejected confirms every non-!!str
+// mapping-key shape at page level is KindParseType: schemaKeyName's name
+// rule requires a scalar whose effective ShortTag() is exactly "!!str", so
+// an integer, boolean, or null scalar key, a custom-tagged scalar key, a
+// sequence key, and a mapping key are all rejected before any name lookup.
+func TestParseAndValidateNonStringPageKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"integer key", "1: x\n"},
+		{"boolean key", "true: x\n"},
+		{"null key", "~: x\n"},
+		{"custom-tagged scalar key", "!custom foo: x\n"},
+		{"sequence key", "? [a]\n: x\n"},
+		{"mapping key", "? {a: 1}\n: x\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateAliasToNonStringPageKeyRejected confirms that an
+// alias-to-non-string page key is KindParseType, not KindSchema, proving the
+// fixture reaches the alias key rather than failing earlier on an unknown
+// page name. The fixture introduces the anchor through a structurally valid
+// canonical subtree (system_page/system_info_group/enabled, a *bool field,
+// so its own entry is valid) so the alias key really is the first failing
+// entry (interpretation I3/O2).
+//
+// The reported line is 3 — the anchor's own line ("enabled: &n true"), not
+// the alias's line (4, "*n: x") — because resolveEffective dereferences an
+// alias into a copy of its anchor's node, carrying the anchor's Line
+// (interpretation I6).
+func TestParseAndValidateAliasToNonStringPageKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    enabled: &n true\n*n: x\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 3") {
+		t.Fatalf("err.Detail = %q, want it to contain %q (the anchor's line)", err.Detail, "line 3")
+	}
+}
+
+// TestParseAndValidateQuotedMergeKeyIsSchemaError confirms a quoted "<<" key
+// is an ordinary !!str name and therefore KindSchema: the resolver leaves a
+// quoted merge key's effective node tagged "!!str" (a bare merge key would
+// instead carry "!!merge" and be consumed by the resolver before reaching
+// the validator; see the next test).
+func TestParseAndValidateQuotedMergeKeyIsSchemaError(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("\"<<\": x\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantSchema(t, err, path)
+	if !strings.Contains(err.Detail, "<<") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "<<")
+	}
+}
+
+// TestParseAndValidateBareMergeKeyNotSchemaError is a regression test: a
+// document using a bare "<<: *anchor" merge key inside a valid canonical
+// subtree must not produce a KindSchema "<<" error. resolveEffective's
+// merge-key handling consumes the bare merge key entirely before the
+// validator's per-entry walk ever sees it, so this document is simply
+// valid — the merge stays confined to system_page's own (unvalidated at
+// this chunk) group-level mapping, which the merge produces no unknown
+// top-level key from.
+func TestParseAndValidateBareMergeKeyNotSchemaError(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group: &g\n    enabled: true\n  other_group:\n    <<: *g\n"
+
+	_, err := parseAndValidate(path, []byte(data))
+	if err != nil {
+		t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+	}
+}
+
+// TestParseAndValidateUnknownPagePrecedesValueInspection confirms that
+// unknown-name classification precedes value inspection at page level: all
+// four value shapes (null, scalar, sequence, mapping) for an unrecognized
+// page name return KindSchema, never KindParseType.
+func TestParseAndValidateUnknownPagePrecedesValueInspection(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"null value", "nope:\n"},
+		{"scalar value", "nope: 3\n"},
+		{"sequence value", "nope:\n  - a\n"},
+		{"mapping value", "nope:\n  k: 1\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantSchema(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateEntryOrderConsequence confirms interpretation I3's
+// per-entry ordering consequence: entries are classified in effective
+// Content order, so which error surfaces depends on which failing entry
+// comes first. "nope: x\nsystem_page: 3\n" fails on "nope" (KindSchema)
+// before "system_page: 3\n"'s shape is ever inspected; reversing the entries
+// makes "system_page: 3\n" the first failing entry (KindParseType) before
+// "nope" is ever looked up.
+func TestParseAndValidateEntryOrderConsequence(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	t.Run("unknown page first", func(t *testing.T) {
+		_, err := parseAndValidate(path, []byte("nope: x\nsystem_page: 3\n"))
+		wantSchema(t, err, path)
+	})
+	t.Run("known page with wrong shape first", func(t *testing.T) {
+		_, err := parseAndValidate(path, []byte("system_page: 3\nnope: x\n"))
+		wantParseType(t, err, path)
+	})
 }

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"errors"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"reflect"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // wantSchema fails the test unless err is a non-nil *LoadError with
@@ -782,6 +785,412 @@ func TestParseAndValidateEveryGroupFieldAccepted(t *testing.T) {
 			}
 			if raw == nil {
 				t.Fatalf("parseAndValidate(%q) rawConfig = nil, want non-nil", data)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateActionsValueWrongShape confirms row 12: a known
+// "actions" field's value that is neither null nor a sequence (a scalar or
+// a mapping) is KindParseType, with Path copied and a positive line named
+// in Detail. A null "actions" value is confirmed separately as a no-op.
+func TestParseAndValidateActionsValueWrongShape(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"scalar value", "system_page:\n  system_info_group:\n    actions: 5\n"},
+		{"mapping value", "system_page:\n  system_info_group:\n    actions:\n      k: 1\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+			}
+		})
+	}
+
+	t.Run("null value", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    actions:\n"
+		raw, err := parseAndValidate(path, []byte(data))
+		if err != nil {
+			t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+		}
+		if raw == nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = nil, want non-nil")
+		}
+	})
+}
+
+// TestParseAndValidateActionEntryWrongShape confirms row 13: every
+// "actions" sequence entry must be a YAML mapping. A null entry is
+// explicitly not accepted as a zero action — a separate assertion confirms
+// the returned *rawConfig is nil for it, not merely that an error is
+// returned — and a scalar entry and a sequence entry are likewise rejected.
+// All three are KindParseType.
+func TestParseAndValidateActionEntryWrongShape(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	t.Run("null entry", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    actions:\n      - ~\n"
+		raw, err := parseAndValidate(path, []byte(data))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil (a null action entry is not a zero action)", raw)
+		}
+		wantParseType(t, err, path)
+	})
+	t.Run("scalar entry", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    actions:\n      - 5\n"
+		raw, err := parseAndValidate(path, []byte(data))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+	})
+	t.Run("sequence entry", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    actions:\n      - [a]\n"
+		raw, err := parseAndValidate(path, []byte(data))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+	})
+}
+
+// TestParseAndValidateUnknownActionFieldRejected confirms row 14: an
+// unrecognized action field name is KindSchema with Detail containing the
+// offending name and a positive line — proving the structural actions walk
+// catches what yaml.v3's Node.Decode silently ignores (I5).
+func TestParseAndValidateUnknownActionFieldRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    actions:\n      - bogus: 1\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantSchema(t, err, path)
+	if !strings.Contains(err.Detail, "bogus") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "bogus")
+	}
+	if !strings.Contains(err.Detail, "line ") {
+		t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+	}
+}
+
+// TestParseAndValidateUnknownActionFieldPrecedesValueInspection confirms
+// unknown-action-field classification precedes value inspection: all four
+// value shapes (null, scalar, sequence, mapping) under key "bogus" return
+// KindSchema, never KindParseType.
+func TestParseAndValidateUnknownActionFieldPrecedesValueInspection(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"null value", "system_page:\n  system_info_group:\n    actions:\n      - bogus:\n"},
+		{"scalar value", "system_page:\n  system_info_group:\n    actions:\n      - bogus: 3\n"},
+		{"sequence value", "system_page:\n  system_info_group:\n    actions:\n      - bogus: [a]\n"},
+		{"mapping value", "system_page:\n  system_info_group:\n    actions:\n      - bogus: {k: 1}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantSchema(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateActionFieldTypeMismatchRejected confirms row 15 for
+// action fields: a value that cannot decode into the declared Go type is
+// KindParseType with a non-nil Err.
+func TestParseAndValidateActionFieldTypeMismatchRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    actions:\n      - sudo: {a: 1}\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if err.Err == nil {
+		t.Fatalf("err.Err = nil, want yaml.v3's own type error")
+	}
+}
+
+// TestParseAndValidateNonStringActionFieldKeyRejected confirms every
+// non-!!str key shape at action-field level is KindParseType, matching the
+// page/group/group-field cases one schema level down.
+func TestParseAndValidateNonStringActionFieldKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"integer key", "system_page:\n  system_info_group:\n    actions:\n      - 1: x\n"},
+		{"boolean key", "system_page:\n  system_info_group:\n    actions:\n      - true: x\n"},
+		{"null key", "system_page:\n  system_info_group:\n    actions:\n      - ~: x\n"},
+		{"custom-tagged scalar key", "system_page:\n  system_info_group:\n    actions:\n      - !custom foo: x\n"},
+		{"sequence key", "system_page:\n  system_info_group:\n    actions:\n      - ? [a]\n        : x\n"},
+		{"mapping key", "system_page:\n  system_info_group:\n    actions:\n      - ? {a: 1}\n        : x\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateAliasToNonStringActionFieldKeyRejected confirms an
+// alias-to-non-string key inside an action entry is KindParseType, one
+// schema level down from the group-field case (O2). The anchor is
+// introduced on a structurally valid action field ("sudo") in that same
+// entry so the entry's own valid field does not pre-empt the alias-key
+// failure (I3); the reported line is the anchor's own line (4), not the
+// alias's.
+func TestParseAndValidateAliasToNonStringActionFieldKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    actions:\n      - sudo: &n true\n        *n: x\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 4") {
+		t.Fatalf("err.Detail = %q, want it to contain %q (the anchor's line)", err.Detail, "line 4")
+	}
+}
+
+// TestParseAndValidateEveryActionFieldAccepted iterates every name
+// SchemaActionFields() returns and confirms each is accepted with a
+// type-correct value (no canonical action field is accidentally unknown).
+func TestParseAndValidateEveryActionFieldAccepted(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	fields, err := SchemaActionFields()
+	if err != nil {
+		t.Fatalf("SchemaActionFields() error = %v, want nil", err)
+	}
+	if len(fields) == 0 {
+		t.Fatalf("SchemaActionFields() = %v, want at least one field", fields)
+	}
+
+	at := reflect.TypeOf(ActionConfig{})
+	fieldTypes := make(map[string]reflect.Type, at.NumField())
+	for i := 0; i < at.NumField(); i++ {
+		f := at.Field(i)
+		tag, ok := f.Tag.Lookup("yaml")
+		if !ok {
+			continue
+		}
+		if idx := strings.Index(tag, ","); idx >= 0 {
+			tag = tag[:idx]
+		}
+		fieldTypes[tag] = f.Type
+	}
+
+	for _, field := range fields {
+		fieldType, ok := fieldTypes[field]
+		if !ok {
+			t.Fatalf("no reflect.Type found for action field %q", field)
+		}
+		t.Run(field, func(t *testing.T) {
+			data := "system_page:\n  system_info_group:\n    actions:\n      - " + field + ": " + sampleYAMLValueForType(fieldType) + "\n"
+			raw, loadErr := parseAndValidate(path, []byte(data))
+			if loadErr != nil {
+				t.Fatalf("parseAndValidate(%q) error = %v, want nil", data, loadErr)
+			}
+			if raw == nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = nil, want non-nil", data)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateTypeErrorRegression is the errors.As(..., *yaml.TypeError)
+// regression: a group-field type failure and an action-field type failure
+// must both surface yaml.v3's own *yaml.TypeError, reachable through
+// *LoadError.Unwrap.
+func TestParseAndValidateTypeErrorRegression(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	t.Run("group field", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    enabled: [1, 2]\n"
+		_, loadErr := parseAndValidate(path, []byte(data))
+		wantParseType(t, loadErr, path)
+
+		var typeErr *yaml.TypeError
+		if !errors.As(error(loadErr), &typeErr) {
+			t.Fatalf("errors.As(loadErr, &typeErr) = false, want true (loadErr = %v)", loadErr)
+		}
+	})
+
+	t.Run("action field", func(t *testing.T) {
+		const data = "system_page:\n  system_info_group:\n    actions:\n      - sudo: [1, 2]\n"
+		_, loadErr := parseAndValidate(path, []byte(data))
+		wantParseType(t, loadErr, path)
+
+		var typeErr *yaml.TypeError
+		if !errors.As(error(loadErr), &typeErr) {
+			t.Fatalf("errors.As(loadErr, &typeErr) = false, want true (loadErr = %v)", loadErr)
+		}
+	})
+}
+
+// TestParseAndValidateExplicitZeroPreserved confirms row 16's explicit-zero
+// preservation: a valid document setting enabled: false, app_id: "" and
+// bundles_paths: [] decodes to a *rawConfig whose Enabled, AppID and
+// BundlesPaths pointers are all non-nil, carrying false, "" and an empty
+// non-nil slice respectively — proving these are preserved as explicitly
+// set values, not converted to omission.
+func TestParseAndValidateExplicitZeroPreserved(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    enabled: false\n    app_id: \"\"\n    bundles_paths: []\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if err != nil {
+		t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+	}
+	if raw == nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = nil, want non-nil")
+	}
+	group, ok := raw.SystemPage["system_info_group"]
+	if !ok {
+		t.Fatalf("raw.SystemPage[%q] missing", "system_info_group")
+	}
+
+	if group.Enabled == nil {
+		t.Fatalf("group.Enabled = nil, want a non-nil *bool")
+	}
+	if *group.Enabled != false {
+		t.Fatalf("*group.Enabled = %v, want false", *group.Enabled)
+	}
+
+	if group.AppID == nil {
+		t.Fatalf("group.AppID = nil, want a non-nil *string")
+	}
+	if *group.AppID != "" {
+		t.Fatalf("*group.AppID = %q, want %q", *group.AppID, "")
+	}
+
+	if group.BundlesPaths == nil {
+		t.Fatalf("group.BundlesPaths = nil, want a non-nil *[]string")
+	}
+	if *group.BundlesPaths == nil {
+		t.Fatalf("*group.BundlesPaths = nil, want a non-nil empty slice")
+	}
+	if len(*group.BundlesPaths) != 0 {
+		t.Fatalf("*group.BundlesPaths = %v, want empty", *group.BundlesPaths)
+	}
+}
+
+// TestParseAndValidatePathSchemaName covers the O1 matrix's schema-name
+// category: err.Path equals the path argument for every level where an
+// unknown name can arise — page, group, group field, action field. There is
+// no schema-name subtest at document level (a document has no name) or at
+// action-entry level (a sequence entry has no name either), matching the
+// plan.md matrix.
+func TestParseAndValidatePathSchemaName(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"unknown page", "not_a_page: 1\n"},
+		{"unknown group", "system_page:\n  nope_group:\n    enabled: true\n"},
+		{"unknown group field", "system_page:\n  system_info_group:\n    nope_field: 1\n"},
+		{"unknown action field", "system_page:\n  system_info_group:\n    actions:\n      - bogus: 1\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAndValidate(path, []byte(tt.data))
+			if err == nil {
+				t.Fatalf("parseAndValidate(%q) error = nil, want non-nil", tt.data)
+			}
+			if err.Path != path {
+				t.Fatalf("err.Path = %q, want %q", err.Path, path)
+			}
+		})
+	}
+}
+
+// TestParseAndValidatePathValidatorShape covers the O1 matrix's
+// validator-created-shape category: err.Path equals the path argument, and
+// Detail contains a positive line, for every level a shape failure can
+// arise at — document (a top-level sequence), page value, group value,
+// actions value, and a null action entry.
+func TestParseAndValidatePathValidatorShape(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"document (top-level sequence)", "- a\n- b\n"},
+		{"page value (scalar)", "system_page: 3\n"},
+		{"group value (scalar)", "system_page:\n  system_info_group: 3\n"},
+		{"actions value (scalar)", "system_page:\n  system_info_group:\n    actions: 5\n"},
+		{"null action entry", "system_page:\n  system_info_group:\n    actions:\n      - ~\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAndValidate(path, []byte(tt.data))
+			if err == nil {
+				t.Fatalf("parseAndValidate(%q) error = nil, want non-nil", tt.data)
+			}
+			if err.Path != path {
+				t.Fatalf("err.Path = %q, want %q", err.Path, path)
+			}
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+			}
+		})
+	}
+}
+
+// TestParseAndValidatePathDeclaredType covers the O1 matrix's
+// declared-Go-type category: err.Path equals the path argument for a
+// group-field type failure and an action-field type failure. There is no
+// declared-type subtest at page, group, or action-entry level — none of
+// those has a single declared Go field type to decode into (a page/group is
+// validated field by field, and a sequence entry has no declared type of
+// its own) — matching the plan.md matrix.
+func TestParseAndValidatePathDeclaredType(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"group field", "system_page:\n  system_info_group:\n    enabled: [1, 2]\n"},
+		{"action field", "system_page:\n  system_info_group:\n    actions:\n      - sudo: {a: 1}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseAndValidate(path, []byte(tt.data))
+			if err == nil {
+				t.Fatalf("parseAndValidate(%q) error = nil, want non-nil", tt.data)
+			}
+			if err.Path != path {
+				t.Fatalf("err.Path = %q, want %q", err.Path, path)
 			}
 		})
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// wantNoopRawConfig fails the test unless parseAndValidate(path, data)
+// returns a non-nil, zero-valued *rawConfig (every page map nil/empty) and
+// a nil error, as required for a document-level no-op overlay.
+func wantNoopRawConfig(t *testing.T, path string, data []byte) {
+	t.Helper()
+	raw, err := parseAndValidate(path, data)
+	if err != nil {
+		t.Fatalf("parseAndValidate(%q, %q) error = %v, want nil", path, data, err)
+	}
+	if raw == nil {
+		t.Fatalf("parseAndValidate(%q, %q) rawConfig = nil, want non-nil", path, data)
+	}
+	pages := map[string]rawPageConfig{
+		"system_page":       raw.SystemPage,
+		"updates_page":      raw.UpdatesPage,
+		"applications_page": raw.ApplicationsPage,
+		"maintenance_page":  raw.MaintenancePage,
+		"features_page":     raw.FeaturesPage,
+		"help_page":         raw.HelpPage,
+	}
+	for name, page := range pages {
+		if len(page) != 0 {
+			t.Fatalf("parseAndValidate(%q, %q) rawConfig.%s = %+v, want nil/empty", path, data, name, page)
+		}
+	}
+}
+
+// TestParseAndValidateNoopOverlay confirms that empty input, whitespace-only
+// input, and a top-level null document (`null` or `~`) all succeed with a
+// non-nil, zero-valued *rawConfig and no error: each is usable as a no-op
+// overlay.
+func TestParseAndValidateNoopOverlay(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	t.Run("empty input", func(t *testing.T) {
+		wantNoopRawConfig(t, path, []byte(""))
+	})
+	t.Run("whitespace-only input", func(t *testing.T) {
+		wantNoopRawConfig(t, path, []byte("   \n   \n"))
+	})
+	t.Run("top-level null scalar", func(t *testing.T) {
+		wantNoopRawConfig(t, path, []byte("null\n"))
+	})
+	t.Run("top-level tilde null scalar", func(t *testing.T) {
+		wantNoopRawConfig(t, path, []byte("~\n"))
+	})
+}
+
+// TestParseAndValidateTopLevelScalarRejected confirms a non-null top-level
+// scalar document is rejected as KindParseType, with Path copied and a
+// positive line named in Detail.
+func TestParseAndValidateTopLevelScalarRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("just a scalar\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 1") {
+		t.Fatalf("err.Detail = %q, want it to contain a positive %q", err.Detail, "line 1")
+	}
+}
+
+// TestParseAndValidateTopLevelSequenceRejected confirms a top-level
+// sequence document is rejected as KindParseType, with Path copied and a
+// positive line named in Detail.
+func TestParseAndValidateTopLevelSequenceRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("- a\n- b\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 1") {
+		t.Fatalf("err.Detail = %q, want it to contain a positive %q", err.Detail, "line 1")
+	}
+}
+
+// TestParseAndValidateMalformedYAML confirms a stage 1 (parseYAMLDocument)
+// parser error is surfaced unchanged: KindParseType with a non-nil Err
+// wrapping yaml.v3's own parser error.
+func TestParseAndValidateMalformedYAML(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("a: [\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if err.Err == nil {
+		t.Fatalf("err.Err = nil, want yaml.v3's own parser error")
+	}
+}
+
+// TestParseAndValidateExtraDocumentRejected confirms a stage 1
+// (parseYAMLDocument) "only one document supported" error is surfaced
+// unchanged as KindParseType.
+func TestParseAndValidateExtraDocumentRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("a: 1\n---\nb: 2\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+}
+
+// TestParseAndValidateMalformedSourceGraphRejected confirms a stage 2
+// (resolveEffective -> validateSourceGraph) source-graph rejection is
+// surfaced unchanged as KindParseType. The input is syntactically valid
+// YAML (stage 1 succeeds) whose merge key ("<<") value is a plain scalar,
+// which validateMergeOperand (sourcegraph.go) rejects as a malformed
+// source graph.
+func TestParseAndValidateMalformedSourceGraphRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("a:\n  <<: 5\n"))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+}
+
+// TestParseAndValidateMinimalMapping confirms a minimal valid document
+// decodes into a *rawConfig with the expected field set, and returns no
+// error.
+func TestParseAndValidateMinimalMapping(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	raw, err := parseAndValidate(path, []byte("system_page:\n  system_info_group:\n    enabled: false\n"))
+	if err != nil {
+		t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+	}
+	if raw == nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = nil, want non-nil")
+	}
+	group, ok := raw.SystemPage["system_info_group"]
+	if !ok {
+		t.Fatalf("raw.SystemPage[%q] missing", "system_info_group")
+	}
+	if group.Enabled == nil {
+		t.Fatalf("raw.SystemPage[%q].Enabled = nil, want a non-nil *bool", "system_info_group")
+	}
+	if *group.Enabled != false {
+		t.Fatalf("*raw.SystemPage[%q].Enabled = %v, want false", "system_info_group", *group.Enabled)
+	}
+}
+
+// TestParseAndValidateStaysOutOfRuntimeLoad proves, via go/ast over
+// internal/config/config.go, that neither Load nor loadFromPath's function
+// body references parseAndValidate: this chunk adds parseAndValidate as a
+// standalone capability without wiring it into the runtime config-loading
+// path.
+func TestParseAndValidateStaysOutOfRuntimeLoad(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "config.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing config.go: %v", err)
+	}
+
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		if fn.Name.Name != "Load" && fn.Name.Name != "loadFromPath" {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			if id, ok := n.(*ast.Ident); ok && id.Name == "parseAndValidate" {
+				t.Fatalf("%s references parseAndValidate, want it left unwired in this chunk", fn.Name.Name)
+			}
+			return true
+		})
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -372,12 +373,14 @@ func TestParseAndValidateQuotedMergeKeyIsSchemaError(t *testing.T) {
 // subtree must not produce a KindSchema "<<" error. resolveEffective's
 // merge-key handling consumes the bare merge key entirely before the
 // validator's per-entry walk ever sees it, so this document is simply
-// valid — the merge stays confined to system_page's own (unvalidated at
-// this chunk) group-level mapping, which the merge produces no unknown
-// top-level key from.
+// valid — the merge stays confined to system_page's own canonical group
+// map, which the merge produces no unknown key from. ("health_group" is
+// used, rather than an arbitrary name, because c3 now validates group
+// names too: an unrecognized group name would itself be a KindSchema
+// error, which is not what this test is proving.)
 func TestParseAndValidateBareMergeKeyNotSchemaError(t *testing.T) {
 	const path = "/etc/chairlift/config.yml"
-	const data = "system_page:\n  system_info_group: &g\n    enabled: true\n  other_group:\n    <<: *g\n"
+	const data = "system_page:\n  system_info_group: &g\n    enabled: true\n  health_group:\n    <<: *g\n"
 
 	_, err := parseAndValidate(path, []byte(data))
 	if err != nil {
@@ -430,4 +433,356 @@ func TestParseAndValidateEntryOrderConsequence(t *testing.T) {
 		_, err := parseAndValidate(path, []byte("system_page: 3\nnope: x\n"))
 		wantParseType(t, err, path)
 	})
+}
+
+// TestParseAndValidateUnknownGroupRejected confirms row 8: an unrecognized
+// group name is KindSchema, naming the offending name and its line.
+func TestParseAndValidateUnknownGroupRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  nope_group:\n    enabled: true\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantSchema(t, err, path)
+	if !strings.Contains(err.Detail, "nope_group") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "nope_group")
+	}
+	if !strings.Contains(err.Detail, "line 2") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "line 2")
+	}
+}
+
+// TestParseAndValidateKnownGroupNull confirms row 9: a known group with a
+// null value is a no-op, returning a nil error and a non-nil *rawConfig.
+func TestParseAndValidateKnownGroupNull(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if err != nil {
+		t.Fatalf("parseAndValidate(...) error = %v, want nil", err)
+	}
+	if raw == nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = nil, want non-nil")
+	}
+}
+
+// TestParseAndValidateKnownGroupWrongShape confirms row 10: a known group
+// with a scalar/sequence value is KindParseType with a positive line.
+func TestParseAndValidateKnownGroupWrongShape(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"scalar value", "system_page:\n  system_info_group: 3\n"},
+		{"sequence value", "system_page:\n  system_info_group:\n    - a\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateUnknownGroupFieldRejected confirms row 11: an
+// unrecognized field name is KindSchema, naming it and its line.
+func TestParseAndValidateUnknownGroupFieldRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    nope_field: 1\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantSchema(t, err, path)
+	if !strings.Contains(err.Detail, "nope_field") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "nope_field")
+	}
+	if !strings.Contains(err.Detail, "line 3") {
+		t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "line 3")
+	}
+}
+
+// TestParseAndValidateGroupFieldTypeMismatchRejected confirms row 15 for
+// non-"actions" fields: a value that cannot decode into the declared Go
+// type is KindParseType with a non-nil Err and a positive line (I4).
+func TestParseAndValidateGroupFieldTypeMismatchRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"bool field given a sequence", "system_page:\n  system_info_group:\n    enabled: [1, 2]\n"},
+		{"string field given a mapping", "system_page:\n  system_info_group:\n    app_id: {a: 1}\n"},
+		{"string slice field given a scalar", "system_page:\n  system_info_group:\n    bundles_paths: 5\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+			if err.Err == nil {
+				t.Fatalf("err.Err = nil, want yaml.v3's own type error")
+			}
+			if !strings.Contains(err.Detail, "line ") {
+				t.Fatalf("err.Detail = %q, want it to contain a positive line", err.Detail)
+			}
+		})
+	}
+}
+
+// TestParseAndValidateUnknownGroupPrecedesValueInspection confirms name
+// classification precedes value inspection at group level: all four value
+// shapes for an unrecognized group name return KindSchema.
+func TestParseAndValidateUnknownGroupPrecedesValueInspection(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"null value", "system_page:\n  nope_group:\n"},
+		{"scalar value", "system_page:\n  nope_group: 3\n"},
+		{"sequence value", "system_page:\n  nope_group: [a]\n"},
+		{"mapping value", "system_page:\n  nope_group: {k: 1}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantSchema(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateUnknownGroupFieldPrecedesValueInspection confirms the
+// same precedence rule one level down, for an unrecognized field name.
+func TestParseAndValidateUnknownGroupFieldPrecedesValueInspection(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"null value", "system_page:\n  system_info_group:\n    nope_field:\n"},
+		{"scalar value", "system_page:\n  system_info_group:\n    nope_field: 3\n"},
+		{"sequence value", "system_page:\n  system_info_group:\n    nope_field: [a]\n"},
+		{"mapping value", "system_page:\n  system_info_group:\n    nope_field: {k: 1}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantSchema(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateNonStringGroupKeyRejected confirms every non-!!str
+// key shape at group level is KindParseType, one level down from the page
+// case.
+func TestParseAndValidateNonStringGroupKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"integer key", "system_page:\n  1: x\n"},
+		{"boolean key", "system_page:\n  true: x\n"},
+		{"null key", "system_page:\n  ~: x\n"},
+		{"custom-tagged scalar key", "system_page:\n  !custom foo: x\n"},
+		{"sequence key", "system_page:\n  ? [a]\n  : x\n"},
+		{"mapping key", "system_page:\n  ? {a: 1}\n  : x\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateNonStringGroupFieldKeyRejected confirms every
+// non-!!str key shape at group-field level is KindParseType.
+func TestParseAndValidateNonStringGroupFieldKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"integer key", "system_page:\n  system_info_group:\n    1: x\n"},
+		{"boolean key", "system_page:\n  system_info_group:\n    true: x\n"},
+		{"null key", "system_page:\n  system_info_group:\n    ~: x\n"},
+		{"custom-tagged scalar key", "system_page:\n  system_info_group:\n    !custom foo: x\n"},
+		{"sequence key", "system_page:\n  system_info_group:\n    ? [a]\n    : x\n"},
+		{"mapping key", "system_page:\n  system_info_group:\n    ? {a: 1}\n    : x\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := parseAndValidate(path, []byte(tt.data))
+			if raw != nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = %+v, want nil", tt.data, raw)
+			}
+			wantParseType(t, err, path)
+		})
+	}
+}
+
+// TestParseAndValidateAliasToNonStringGroupKeyRejected confirms an
+// alias-to-non-string group key is KindParseType, one level down from the
+// page case (O2), reporting the anchor's line (3), not the alias's (I6).
+func TestParseAndValidateAliasToNonStringGroupKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    enabled: &n true\n  *n: x\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 3") {
+		t.Fatalf("err.Detail = %q, want it to contain %q (the anchor's line)", err.Detail, "line 3")
+	}
+}
+
+// TestParseAndValidateAliasToNonStringGroupFieldKeyRejected is the
+// group-field-level counterpart, with the alias key a sibling field name
+// within system_info_group's own mapping; the reported line is again 3.
+func TestParseAndValidateAliasToNonStringGroupFieldKeyRejected(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+	const data = "system_page:\n  system_info_group:\n    enabled: &n true\n    *n: x\n"
+
+	raw, err := parseAndValidate(path, []byte(data))
+	if raw != nil {
+		t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+	}
+	wantParseType(t, err, path)
+	if !strings.Contains(err.Detail, "line 3") {
+		t.Fatalf("err.Detail = %q, want it to contain %q (the anchor's line)", err.Detail, "line 3")
+	}
+}
+
+// TestParseAndValidateEveryCanonicalGroupAccepted iterates every group
+// SchemaGroups(page) returns, for every SchemaPages() page, and confirms
+// each is accepted with a null value (no canonical group is accidentally
+// rejected as unknown).
+func TestParseAndValidateEveryCanonicalGroupAccepted(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	pages, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages() error = %v, want nil", err)
+	}
+
+	for _, page := range pages {
+		groups, err := SchemaGroups(page)
+		if err != nil {
+			t.Fatalf("SchemaGroups(%q) error = %v, want nil", page, err)
+		}
+		for _, group := range groups {
+			t.Run(page+"/"+group, func(t *testing.T) {
+				data := page + ":\n  " + group + ":\n"
+				raw, loadErr := parseAndValidate(path, []byte(data))
+				if loadErr != nil {
+					t.Fatalf("parseAndValidate(%q) error = %v, want nil", data, loadErr)
+				}
+				if raw == nil {
+					t.Fatalf("parseAndValidate(%q) rawConfig = nil, want non-nil", data)
+				}
+			})
+		}
+	}
+}
+
+// sampleYAMLValueForType returns a flow-style YAML literal decoding cleanly
+// into t (a rawGroupConfig field's declared, always-pointer Go type),
+// derived purely from t's reflect.Kind, never a field name.
+func sampleYAMLValueForType(t reflect.Type) string {
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		return "true"
+	case reflect.String:
+		return `"x"`
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Struct {
+			// e.g. []ActionConfig: an empty sequence decodes cleanly and
+			// this chunk does not yet inspect actions' value (I5) anyway.
+			return "[]"
+		}
+		return `["x"]`
+	default:
+		return "null"
+	}
+}
+
+// TestParseAndValidateEveryGroupFieldAccepted iterates every name
+// SchemaGroupFields() returns and confirms each is accepted with a
+// type-correct value (no canonical field is accidentally unknown).
+func TestParseAndValidateEveryGroupFieldAccepted(t *testing.T) {
+	const path = "/etc/chairlift/config.yml"
+
+	fields, err := SchemaGroupFields()
+	if err != nil {
+		t.Fatalf("SchemaGroupFields() error = %v, want nil", err)
+	}
+	if len(fields) == 0 {
+		t.Fatalf("SchemaGroupFields() = %v, want at least one field", fields)
+	}
+
+	rt := reflect.TypeOf(rawGroupConfig{})
+	fieldTypes := make(map[string]reflect.Type, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		tag, ok := f.Tag.Lookup("yaml")
+		if !ok {
+			continue
+		}
+		if idx := strings.Index(tag, ","); idx >= 0 {
+			tag = tag[:idx]
+		}
+		fieldTypes[tag] = f.Type
+	}
+
+	for _, field := range fields {
+		fieldType, ok := fieldTypes[field]
+		if !ok {
+			t.Fatalf("no reflect.Type found for group field %q", field)
+		}
+		t.Run(field, func(t *testing.T) {
+			data := "system_page:\n  system_info_group:\n    " + field + ": " + sampleYAMLValueForType(fieldType) + "\n"
+			raw, loadErr := parseAndValidate(path, []byte(data))
+			if loadErr != nil {
+				t.Fatalf("parseAndValidate(%q) error = %v, want nil", data, loadErr)
+			}
+			if raw == nil {
+				t.Fatalf("parseAndValidate(%q) rawConfig = nil, want non-nil", data)
+			}
+		})
+	}
 }

--- a/internal/config/validatebounds_test.go
+++ b/internal/config/validatebounds_test.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// buildSourcePathDepthDocument returns the YAML source text
+// "nope: " followed by d nested flow sequences ("[" * d + "x" + "]" * d),
+// all on a single line. Counting rule (measured against the merged
+// parseYAMLDocument + resolveEffective resolver, not estimated):
+// pathVisitCount (sourcebounds.go) charges one visit per node along a
+// root-to-leaf path, and a mapping key is a sibling of its value rather
+// than an extra hop, so this document's deepest path costs
+// 1 (document) + 1 (top mapping) + d (nested flow sequences) + 1 (leaf
+// scalar "x") = d + 3 visits against maxSourcePathVisits = 128. "nope" is
+// deliberately not a canonical page name, so a document at or below the
+// bound still reaches stage 3's page-name check and returns KindSchema —
+// proving the source-path bounds pass was cleared, not merely unreached.
+func buildSourcePathDepthDocument(d int) string {
+	return "nope: " + strings.Repeat("[", d) + "x" + strings.Repeat("]", d) + "\n"
+}
+
+// buildDoublingAliasChainDocument returns the YAML source text for the
+// doubling alias chain l0: &l0 [x]; lN: &lN [*l(N-1), *l(N-1)] through
+// level n. Each level's sequence aliases the previous level's anchor
+// twice, so resolveEffective's alias-free emission of level n contains two
+// full copies of level n-1's emission, doubling the emitted node count per
+// level while charging only one alias hop per node (nowhere near
+// maxAliasHops = 64) and keeping the source graph's own path-visit count
+// at roughly 33 (nowhere near maxSourcePathVisits = 128) — so this fixture
+// exercises maxEffectiveOutputNodes = 100000 in isolation. Every level
+// name (l0, l1, ...) is deliberately not a canonical page name, so a chain
+// at or below the bound still reaches stage 3's page-name check on its
+// first entry, l0, and returns KindSchema.
+func buildDoublingAliasChainDocument(n int) string {
+	var b strings.Builder
+	b.WriteString("l0: &l0 [x]\n")
+	for i := 1; i <= n; i++ {
+		prev := "l" + strconv.Itoa(i-1)
+		cur := "l" + strconv.Itoa(i)
+		b.WriteString(cur + ": &" + cur + " [*" + prev + ", *" + prev + "]\n")
+	}
+	return b.String()
+}
+
+// TestParseAndValidateSourcePathVisitBoundary drives maxSourcePathVisits
+// (128) through parseAndValidate using buildSourcePathDepthDocument,
+// measured exactly against the merged resolver: d = 125 (128 visits)
+// passes the source-path bounds pass and is rejected only afterward, by
+// stage 3, as KindSchema for the unknown page "nope" — proving the bounds
+// pass ran and cleared. d = 126 (129 visits) fails the bounds pass itself,
+// before stage 3 ever runs, as KindParseType naming the "128" bound.
+//
+// maxAliasHops (64) is deliberately not exercised by any fixture in this
+// file: it is unreachable from parser-produced text without an alias, and
+// sourcebounds_test.go's existing direct checkAliasHopLimit/synthetic-graph
+// tests already cover that boundary exactly as the spec directs.
+func TestParseAndValidateSourcePathVisitBoundary(t *testing.T) {
+	const path = "/etc/chairlift/source-path-boundary.yml"
+
+	t.Run("d=125 clears the bounds pass", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte(buildSourcePathDepthDocument(125)))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(d=125) rawConfig = %+v, want nil", raw)
+		}
+		wantSchema(t, err, path)
+		if !strings.Contains(err.Detail, "nope") {
+			t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "nope")
+		}
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want exactly 1", got)
+		}
+	})
+
+	t.Run("d=126 fails the bounds pass", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte(buildSourcePathDepthDocument(126)))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(d=126) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+		if err.Err != nil {
+			t.Fatalf("err.Err = %v, want nil (a validator-side bounds rejection, not a wrapped yaml.v3 error)", err.Err)
+		}
+		wantDetail := "maximum of 128 source-node path visits"
+		if !strings.Contains(err.Detail, wantDetail) {
+			t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, wantDetail)
+		}
+		if got := sourceDetailLine(t, err); got != 1 {
+			t.Fatalf("attributed line = %d, want exactly 1", got)
+		}
+	})
+}
+
+// TestParseAndValidateEffectiveOutputNodeBoundary drives
+// maxEffectiveOutputNodes (100000) through parseAndValidate using
+// buildDoublingAliasChainDocument, measured exactly against the merged
+// resolver: n = 14 passes both source-graph bounds passes and
+// resolveEffective's own emission budget, then is rejected only
+// afterward, by stage 3, as KindSchema for the unknown page "l0" —
+// proving the effective-output bound was cleared. n = 15 fails
+// resolveEffective's emission budget itself, before stage 3 ever runs, as
+// KindParseType naming the "100000" bound.
+func TestParseAndValidateEffectiveOutputNodeBoundary(t *testing.T) {
+	const path = "/etc/chairlift/effective-output-boundary.yml"
+
+	t.Run("n=14 clears the bounds pass", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte(buildDoublingAliasChainDocument(14)))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(n=14) rawConfig = %+v, want nil", raw)
+		}
+		wantSchema(t, err, path)
+		if !strings.Contains(err.Detail, "l0") {
+			t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "l0")
+		}
+	})
+
+	t.Run("n=15 fails the bounds pass", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte(buildDoublingAliasChainDocument(15)))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(n=15) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+		if err.Err != nil {
+			t.Fatalf("err.Err = %v, want nil (a validator-side bounds rejection, not a wrapped yaml.v3 error)", err.Err)
+		}
+		wantDetail := "maximum of 100000 emitted nodes"
+		if !strings.Contains(err.Detail, wantDetail) {
+			t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, wantDetail)
+		}
+		if got := sourceDetailLine(t, err); got != 2 {
+			t.Fatalf("attributed line = %d, want exactly 2", got)
+		}
+	})
+}
+
+// TestParseAndValidatePrecedenceOverKindSchema confirms that a document
+// simultaneously containing an unknown top-level page name and a stage
+// 1/stage 2 failure is always classified KindParseType, never KindSchema:
+// stage 3's page-name check (which would otherwise report "nope" as an
+// unknown page, KindSchema) is never reached once an earlier stage fails.
+func TestParseAndValidatePrecedenceOverKindSchema(t *testing.T) {
+	const path = "/etc/chairlift/precedence.yml"
+
+	t.Run("unknown page plus a second YAML document", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte("nope: 1\n---\nb: 2\n"))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+		if strings.Contains(err.Detail, "unknown name") {
+			t.Fatalf("err.Detail = %q, want the parser's second-document rejection, not the schema-name rejection", err.Detail)
+		}
+	})
+
+	t.Run("unknown page plus an over-budget nested value", func(t *testing.T) {
+		// The unknown top-level page name itself ("nope") carries the
+		// over-budget nested flow sequence as its own value, so this is
+		// the same document buildSourcePathDepthDocument(126) builds:
+		// both conditions (unknown page, over-budget path) hold at once,
+		// and only KindParseType is observed.
+		raw, err := parseAndValidate(path, []byte(buildSourcePathDepthDocument(126)))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+		if strings.Contains(err.Detail, "unknown name") {
+			t.Fatalf("err.Detail = %q, want the bounds rejection, not the schema-name rejection", err.Detail)
+		}
+	})
+
+	t.Run("unknown page plus a source-duplicate key", func(t *testing.T) {
+		raw, err := parseAndValidate(path, []byte("nope:\n  a: 1\n  a: 2\n"))
+		if raw != nil {
+			t.Fatalf("parseAndValidate(...) rawConfig = %+v, want nil", raw)
+		}
+		wantParseType(t, err, path)
+		if strings.Contains(err.Detail, "unknown name") {
+			t.Fatalf("err.Detail = %q, want the duplicate-key rejection, not the schema-name rejection", err.Detail)
+		}
+		if !strings.Contains(err.Detail, "duplicated") {
+			t.Fatalf("err.Detail = %q, want it to contain %q", err.Detail, "duplicated")
+		}
+	})
+}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -782,19 +782,37 @@ its top-level node shape into exactly one of these outcomes:
       - A non-`!!str` mapping key is rejected as `KindParseType`, exactly as
         at page and group level; an unrecognized field name is rejected as
         `KindSchema`, exactly as an unrecognized group name is.
-      - The special-cased `actions` field is recognized as a known name, but
-        **as of this commit its value is left uninspected by stage 3** — no
-        shape or type check runs on it here at all (interpretation I5: a
-        later slice adds `actions`'s own structural walk, because a generic
-        decode into `*[]ActionConfig` cannot produce the right errors —
-        yaml.v3 silently ignores an unknown struct field on decode and
-        silently decodes a null sequence entry into a zero `ActionConfig`).
-        Stage 4's whole-document decode (below) still incidentally rejects a
-        non-decodable `actions` value (e.g. a scalar or mapping) as
-        `KindParseType`, but it silently accepts a null action entry as a
-        zero `ActionConfig` and silently ignores an unknown action field —
-        those two gaps are exactly what the later slice's dedicated
-        `actions` walk closes.
+      - The special-cased `actions` field is recognized as a known name and
+        validated structurally by the unexported `validateActionsEntries`,
+        instead of by a generic decode into `*[]ActionConfig` (interpretation
+        I5, because yaml.v3 silently ignores an unknown struct field on
+        decode and silently decodes a null sequence entry into a zero
+        `ActionConfig`):
+        - Its value must be **null** (a no-op — no actions configured) or a
+          **sequence**; any other shape (a non-null scalar or a mapping) is
+          rejected as `KindParseType` via the unexported
+          `validatorActionsValueShapeError`, naming the actual shape found
+          and a positive line.
+        - Every sequence entry must be a YAML **mapping**; a **null** entry
+          is explicitly not accepted as a zero action, and a scalar or
+          sequence entry is likewise rejected — all as `KindParseType` via
+          the unexported `validatorActionEntryShapeError`.
+        - Each mapping entry's own fields are classified by the unexported
+          `validateActionFieldEntries`, one schema level down from a group's
+          fields and sourced from the unexported `actionFieldTypes()`
+          (reflection over `ActionConfig`'s yaml tags and declared Go field
+          types — never a literal list in validate.go): a non-`!!str`
+          mapping key is `KindParseType`, exactly as at page/group/group-field
+          level; an unrecognized action-field name (e.g. `SchemaActionFields()`
+          not listing it) is `KindSchema` via `validatorSchemaError`, naming
+          the offending key and a positive line, without descending into its
+          value; and a known field's effective value node is decoded into a
+          fresh value of its declared Go type
+          (`reflect.New(fieldType).Interface()`), a decode failure
+          (yaml.v3's own `*yaml.TypeError`, e.g. `sudo: {a: 1}` into `bool`)
+          classified `KindParseType` via `validatorDecodeError`, with the
+          yaml.v3 error's message in `Detail` and the error itself preserved
+          in `Err`.
       - Every other known field's effective value node is decoded into a
         fresh value of that field's declared Go type,
         `reflect.New(fieldType).Interface()` (interpretation I4) — e.g.
@@ -813,7 +831,13 @@ its top-level node shape into exactly one of these outcomes:
   `validateSourceGraph`/`resolveEffective` and the page-entry walk above
   already prove the effective document is well-formed by the time `Decode`
   runs, but any residual decode failure is still classified rather than
-  left unhandled.
+  left unhandled. Once every level's fields pass, an explicitly set zero
+  value survives the decode as set, not as omission: `enabled: false`,
+  `app_id: ""`, and `bundles_paths: []` all decode to non-nil pointers
+  (`*bool`, `*string`, `*[]string`) carrying `false`, `""`, and an empty
+  non-nil slice respectively — `rawGroupConfig`'s pointer fields exist
+  precisely so a merge onto `defaultConfig()` can tell "explicitly set to
+  the zero value" apart from "key absent."
 
 Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
 `parseAndValidate` is the only addition this slice's authorization spends;
@@ -823,7 +847,10 @@ Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
 `validatorPageValueShapeError`, `describeNodeShape`,
 `validateGroupEntries`, `validatorSchemaGroupsError`,
 `validatorGroupValueShapeError`, `validateGroupFieldEntries`,
-`groupFieldTypes`, and `validatorGroupFieldTypesError` are all exercised
+`groupFieldTypes`, `validatorGroupFieldTypesError`,
+`validateActionsEntries`, `validatorActionsValueShapeError`,
+`validatorActionEntryShapeError`, `validateActionFieldEntries`,
+`actionFieldTypes`, and `validatorActionFieldTypesError` are all exercised
 only indirectly, through `parseAndValidate`, in `validate_test.go`.
 `parseAndValidate` itself is, like `parseYAMLDocument`, `validateSourceGraph`,
 and `resolveEffective` before it, still not wired into `Load()` or

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -781,12 +781,16 @@ steps never run once an earlier one has already classified the entry:
    decode failure) preserved in `Err` and classified `KindParseType`.
 
 Page, group, group-field, and action-field name inventories are never a
-hand-maintained list in `validate.go`. They come entirely from the
-canonical `Config`/`rawConfig`/`rawGroupConfig`/`ActionConfig` structs,
-reflected via `SchemaPages()`, `SchemaGroups(page)`, `SchemaGroupFields()`,
-and `SchemaActionFields()` respectively (schema.go) — adding, renaming, or
-removing a field on one of those structs changes the accepted schema
-automatically, with no parallel edit required in the validator.
+hand-maintained list in `validate.go`. `SchemaPages()`, `SchemaGroupFields()`,
+and `SchemaActionFields()` (schema.go) reflect directly on the canonical
+`Config`, `rawGroupConfig`, and `ActionConfig` structs, so adding, renaming,
+or removing a field on one of those structs changes the accepted schema
+automatically, with no parallel edit required in the validator. `SchemaGroups(page)`
+is derived differently: it reads the group names present as map keys in that
+page's entry in `defaultConfig()`, not struct fields of `Config` — a group
+added only to `defaultConfig()`'s map (with no corresponding struct field)
+still changes the accepted schema, and a parity test keeps that map's keys
+from drifting out of sync with the fields the validator otherwise expects.
 
 **Interpretation I8: the validator is deliberately stricter than
 `mergePage`'s unknown-group tolerance.** `mergePage` (config.go) already

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -202,9 +202,13 @@ alias/anchor-resolving, merge-precedence-resolving, bounded-output emitter
 with its own post-alias key-identity-collision rule) meant to
 eventually replace `loadFromPath()`'s current `yaml.Unmarshal` call with
 fail-closed, single-document, structurally validated loading — but none of
-that wiring exists yet, so `KindRead` and `KindSchema` still describe
-capabilities the package's vocabulary anticipates rather than ones any code
-path currently exercises.
+that wiring exists yet, so `KindRead` still describes a capability the
+package's vocabulary anticipates but no code path yet reaches. `KindSchema`
+no longer belongs in that list:
+`parseAndValidate`'s page-level walk (described below) is the package's
+first code path that actually produces a `KindSchema` error — an unknown
+top-level page name — even though `Load()`/`loadFromPath()` still never call
+`parseAndValidate` and so never see it.
 
 **Exact merge-key recognition and tag normalization
 (`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
@@ -724,23 +728,55 @@ its top-level node shape into exactly one of these outcomes:
   non-positive, mirroring `effectiveOutputLimitError`'s own clamp). No
   `Decode` call runs for this outcome either, since there is no mapping to
   decode.
-- **Top-level mapping** — accepted structurally; stage 4 then calls the
-  effective document's `yaml.Node.Decode` into a `*rawConfig`. A `Decode`
-  failure here is classified `KindParseType` via the unexported
-  `validatorDecodeError`, with the yaml.v3 error's message in `Detail` and
-  the error itself preserved in `Err` — a defensive final step, since
-  `validateSourceGraph`/`resolveEffective` already prove the effective
-  document is well-formed by the time `Decode` runs, but any residual
-  decode failure is still classified rather than left unhandled.
-  Per-entry classification of page/group/action content within an accepted
-  mapping (unknown keys, wrong-shaped values, and so on) is out of
-  `parseAndValidate`'s scope as of this writing and starts at a later
-  chunk.
+- **Top-level mapping** — accepted structurally, and its entries are
+  classified one at a time, in effective `Content` order, by
+  `validatePageEntries` (interpretation I3's per-entry order: key shape,
+  then name membership, then value shape):
+  - A mapping key whose effective node is not a scalar with `ShortTag() ==
+    "!!str"` — an integer, boolean, or null scalar; a custom-tagged scalar;
+    a sequence; a mapping; or an alias to any of those (already
+    dereferenced into a copy of its target by `resolveEffective`) — is
+    rejected as `KindParseType` via the unexported `validatorKeyShapeError`
+    before its name or value is ever inspected. The unexported
+    `schemaKeyName(key *yaml.Node) (string, bool)` implements this rule; a
+    quoted `"<<"` key resolves to tag `!!str` (an ordinary name), while a
+    bare `<<` merge key carries `!!merge` and is consumed by
+    `resolveEffective` long before this walk runs, so it never reaches
+    `schemaKeyName` at all.
+  - A well-formed string key that is not one of `SchemaPages()`'s canonical
+    page names (schema.go, reflected off `Config`'s yaml tags — never a
+    literal list in validate.go) is rejected as `KindSchema` via the
+    unexported `validatorSchemaError`, naming the literal offending key and
+    a positive line, without descending into that entry's value at all.
+    (`SchemaPages()` returning an error — only possible for a malformed
+    struct tag on `Config` itself, which cannot happen for that canonical
+    struct — is still surfaced defensively as a `KindSchema` `*LoadError`
+    via the unexported `validatorSchemaPagesError`, wrapping the reflect
+    error, rather than ignored or panicked on.)
+  - A known page's **null** value is accepted as a no-op for that page.
+  - A known page's **non-null scalar or sequence** value is rejected as
+    `KindParseType` via the unexported `validatorPageValueShapeError`,
+    naming the page, the actual shape found, and a positive line.
+  - A known page's **mapping** value is accepted structurally; its own
+    entries (groups and fields) are classified starting at a later chunk.
+
+  Once every entry passes, stage 4 calls the effective document's
+  `yaml.Node.Decode` into a `*rawConfig`. A `Decode` failure here is
+  classified `KindParseType` via the unexported `validatorDecodeError`,
+  with the yaml.v3 error's message in `Detail` and the error itself
+  preserved in `Err` — a defensive final step, since
+  `validateSourceGraph`/`resolveEffective` and the page-entry walk above
+  already prove the effective document is well-formed by the time `Decode`
+  runs, but any residual decode failure is still classified rather than
+  left unhandled.
 
 Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
-`parseAndValidate` is the only addition this chunk's authorization spends;
-`validatorShapeError`, `validatorDecodeError`, and `effectiveNodeLine` are
-exercised only indirectly, through `parseAndValidate`, in `validate_test.go`.
+`parseAndValidate` is the only addition this slice's authorization spends;
+`validatorShapeError`, `validatorDecodeError`, `effectiveNodeLine`,
+`validatePageEntries`, `schemaKeyName`, `validatorSchemaError`,
+`validatorSchemaPagesError`, `validatorKeyShapeError`,
+`validatorPageValueShapeError`, and `describeNodeShape` are all exercised
+only indirectly, through `parseAndValidate`, in `validate_test.go`.
 `parseAndValidate` itself is, like `parseYAMLDocument`, `validateSourceGraph`,
 and `resolveEffective` before it, still not wired into `Load()` or
 `loadFromPath()` — a `go/ast`-based test

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -708,6 +708,102 @@ stage 1 or stage 2 `*LoadError` is returned unchanged — `parseAndValidate`
 can never bypass parser, source-graph, or bounds validation by continuing
 past their errors.
 
+The full pipeline, in order, is: `parseAndValidate` calls `parseYAMLDocument`
+(stage 1) to parse `data` into a single `*yaml.Node` document, rejecting a
+malformed document or a second document; then `resolveEffective` (stage 2),
+which validates the reachable source-branch graph via `validateSourceGraph`
+(including its node/path/alias-hop bounds) before resolving `<<` merges and
+aliases into one alias-free effective tree; then this file's own ChairLift
+schema/shape/declared-type validation (stage 3) walks that effective tree
+page by page, group by group, group-field by group-field, and (for
+`actions`) action-entry by action-field; and finally, only once every prior
+stage and every entry at every level has passed, stage 4 decodes the
+already-validated effective document into a `*rawConfig` via
+`yaml.Node.Decode`. A failure at any earlier stage returns immediately
+without running any later stage.
+
+Every reachable outcome of that pipeline classifies to exactly one of three
+results — `KindParseType`, `KindSchema`, or a valid decoded/no-op result —
+per this decision table:
+
+| Effective input | Result |
+|---|---|
+| malformed YAML, second document, or source duplicate | `KindParseType` |
+| cyclic, malformed, source-path-over-budget, or effective-output-over-budget graph | `KindParseType` |
+| empty document or top-level null | valid no-op overlay |
+| top-level scalar or sequence | `KindParseType` |
+| unknown top-level page | `KindSchema` |
+| known page with null | valid no-op for that page |
+| known page with scalar or sequence | `KindParseType` |
+| unknown group under a known page | `KindSchema` |
+| known group with null | valid no-op for that group |
+| known group with scalar or sequence | `KindParseType` |
+| unknown group field | `KindSchema` |
+| `actions` value that is not null or a sequence | `KindParseType` |
+| action entry that is null or otherwise not a mapping | `KindParseType` |
+| unknown action field | `KindSchema` |
+| known field that cannot decode into its declared Go type | `KindParseType` |
+| valid effective document | decoded `*rawConfig` |
+
+The first four rows are produced by stages 1-2 (`parseYAMLDocument`,
+`validateSourceGraph`, `resolveEffective`) and always take precedence: a
+parser, graph, source-duplicate, or resolver-bound failure is returned
+before stage 3 ever inspects a single mapping entry. Every remaining row is
+produced by stage 3's per-level entry walk or stage 4's final `Decode`.
+
+At every one of the four name levels (page, group, group field, action
+field), each mapping entry is classified in this fixed order, and later
+steps never run once an earlier one has already classified the entry:
+
+1. **Key shape.** A mapping key counts as a name only when its effective
+   node is a scalar whose `ShortTag()` is exactly `!!str`. An integer,
+   boolean, or null scalar key; a custom-tagged scalar; a sequence or
+   mapping key; or an alias to any of those, is rejected as `KindParseType`
+   via `validatorKeyShapeError` before its name or value is inspected at
+   all. `schemaKeyName` implements this rule; the quoted string key `"<<"`
+   resolves to tag `!!str` and is therefore an ordinary name (rejected as
+   `KindSchema` if absent from the canonical inventory, like any other
+   unrecognized name) — it is only the bare, unquoted `<<` merge key that
+   carries yaml.v3's own `!!merge` tag, and that key is consumed by
+   `resolveEffective` during stage 2, long before `schemaKeyName` ever runs,
+   so it never reaches this classification at all.
+2. **Name membership**, checked without descending into that entry's value.
+   A well-formed string key that is not present in the canonical inventory
+   for that level is rejected as `KindSchema`, naming the literal offending
+   key and a positive line — regardless of whether the associated value is
+   null, a scalar, a sequence, or a mapping. An unknown name's value is
+   never inspected, decoded, or recursed into.
+3. **Value inspection**, only for a name that passed step 2. A known page's
+   or group's non-null scalar/sequence value is `KindParseType`; a null
+   value is a no-op; a mapping value recurses one schema level down. A known
+   group field's or action field's value is decoded into a fresh instance of
+   that field's declared Go type, with any `*yaml.TypeError` (or other
+   decode failure) preserved in `Err` and classified `KindParseType`.
+
+Page, group, group-field, and action-field name inventories are never a
+hand-maintained list in `validate.go`. They come entirely from the
+canonical `Config`/`rawConfig`/`rawGroupConfig`/`ActionConfig` structs,
+reflected via `SchemaPages()`, `SchemaGroups(page)`, `SchemaGroupFields()`,
+and `SchemaActionFields()` respectively (schema.go) — adding, renaming, or
+removing a field on one of those structs changes the accepted schema
+automatically, with no parallel edit required in the validator.
+
+**Interpretation I8: the validator is deliberately stricter than
+`mergePage`'s unknown-group tolerance.** `mergePage` (config.go) already
+tolerates a group name absent from `defaultConfig()` for a page: it
+synthesizes a zero `GroupConfig{Enabled: true}` as the merge base and
+proceeds, matching `IsGroupEnabled`'s "missing group -> enabled" fallback.
+`parseAndValidate`'s `validateGroupEntries`, by contrast, rejects that same
+unknown group name outright as `KindSchema` — it never reaches `mergePage`
+at all. These two behaviors diverge on the same input class, and that
+divergence is intentional and currently safe: `parseAndValidate` is not
+wired into `Load()`/`loadFromPath()` (see below), so `mergePage` is the only
+one of the two that any runtime config load actually exercises today. A
+future slice that wires `parseAndValidate` into runtime loading must resolve
+this divergence explicitly — either by loosening the validator to match
+`mergePage`'s tolerance or by tightening `mergePage`/`defaultConfig()` to
+match the validator — rather than leaving both behaviors live at once.
+
 Once both prior stages succeed, stage 3 classifies the effective document by
 its top-level node shape into exactly one of these outcomes:
 
@@ -857,7 +953,13 @@ and `resolveEffective` before it, still not wired into `Load()` or
 `loadFromPath()` — a `go/ast`-based test
 (`TestParseAndValidateStaysOutOfRuntimeLoad`) proves neither function's body
 references it, so this remains a standalone capability rather than a change
-in runtime behavior.
+in runtime behavior. Concretely: `Load()` and `loadFromPath()` are unchanged
+from before this slice; there is no strict runtime config validation and no
+fail-closed config loading — a malformed or schema-invalid config file still
+falls back silently to `defaultConfig()`, exactly as before; and there is no
+startup config-error log line and no config-error toast/notification
+surfaced anywhere in the UI. `parseAndValidate` is reachable only from tests
+in `internal/config` until a later issue-69 slice wires it in.
 
 ### Package manager wrapper pattern
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -186,12 +186,14 @@ YAML document, with a fixed cardinality outcome per input shape:
   error and line in `Err`/`Detail`, just like a malformed first document
   would.
 
-As of this writing `parseYAMLDocument`, `validateSourceGraph`, and
-`resolveEffective` are not wired into `Load()` or `loadFromPath()` — both
-are unchanged and still fall back to `defaultConfig()` on any read or parse
-failure, so there is no strict parsing and no fail-closed runtime behavior
-yet, and `resolveEffective`'s output does not feed ChairLift's strict
-schema validation either. This is the first of several package-private
+As of this writing `parseYAMLDocument`, `validateSourceGraph`,
+`resolveEffective`, and `parseAndValidate` (the four-stage entry point tying
+them together, described below alongside the schema inventory) are not
+wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
+back to `defaultConfig()` on any read or parse failure, so there is no
+strict parsing and no fail-closed runtime behavior yet, and neither
+`resolveEffective`'s nor `parseAndValidate`'s output feeds ChairLift's
+strict schema validation either. This is the first of several package-private
 capabilities (document parsing, reachable source-graph shape validation,
 merge-operand shape validation, duplicate-explicit-key detection, the
 memoized alias-hop bound and the memoized source-node path-visit bound
@@ -688,6 +690,63 @@ code path — neither `Load()`/`loadFromPath()` nor any runtime diagnostic —
 consumes this inventory yet, and this slice adds no strict parsing and no
 unknown-key rejection; `Load()` still falls back to `defaultConfig()` on any
 read or parse failure. The inventory exists for a later change to build on.
+
+**The four-stage validator entry point (`internal/config/validate.go`).**
+`parseAndValidate(path string, data []byte) (*rawConfig, *LoadError)` is the
+unexported entry point that ties together every validation capability
+described above into a single call: stage 1 is `parseYAMLDocument`
+(source.go); stage 2 is `resolveEffective` (effective.go), which itself runs
+`validateSourceGraph` (sourcegraph.go, including its `checkSourceGraphBounds`
+bounds pass, sourcebounds.go) before emitting an alias-free, merge-resolved
+effective document; stage 3 is this file's own document-level shape check;
+and stage 4 decodes an accepted mapping document into a `*rawConfig`. A
+stage 1 or stage 2 `*LoadError` is returned unchanged — `parseAndValidate`
+can never bypass parser, source-graph, or bounds validation by continuing
+past their errors.
+
+Once both prior stages succeed, stage 3 classifies the effective document by
+its top-level node shape into exactly one of these outcomes:
+
+- **Nil effective document** (the shared "empty or whitespace-only input"
+  result `parseYAMLDocument`/`resolveEffective` already return for that
+  case) — a non-nil, zero-valued `*rawConfig` (every page map nil/empty) and
+  no error. This is a usable no-op overlay, matching the "absent config"
+  semantics elsewhere in this package. Stage 4's `Decode` call never runs
+  for this outcome.
+- **Top-level null scalar** (YAML's `null`/`~`, or an absent value, which
+  yaml.v3 resolves to tag `!!null`) — treated identically to the nil-document
+  outcome above: a non-nil, zero-valued `*rawConfig`, no error, and no
+  `Decode` call.
+- **Top-level scalar that is not null, or a top-level sequence** — rejected
+  as `KindParseType` via the unexported `validatorShapeError`, which names
+  the actual shape found and a positive source line from the unexported
+  `effectiveNodeLine` (`n.Line`, clamped to `1` when yaml.v3 left it
+  non-positive, mirroring `effectiveOutputLimitError`'s own clamp). No
+  `Decode` call runs for this outcome either, since there is no mapping to
+  decode.
+- **Top-level mapping** — accepted structurally; stage 4 then calls the
+  effective document's `yaml.Node.Decode` into a `*rawConfig`. A `Decode`
+  failure here is classified `KindParseType` via the unexported
+  `validatorDecodeError`, with the yaml.v3 error's message in `Detail` and
+  the error itself preserved in `Err` — a defensive final step, since
+  `validateSourceGraph`/`resolveEffective` already prove the effective
+  document is well-formed by the time `Decode` runs, but any residual
+  decode failure is still classified rather than left unhandled.
+  Per-entry classification of page/group/action content within an accepted
+  mapping (unknown keys, wrong-shaped values, and so on) is out of
+  `parseAndValidate`'s scope as of this writing and starts at a later
+  chunk.
+
+Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
+`parseAndValidate` is the only addition this chunk's authorization spends;
+`validatorShapeError`, `validatorDecodeError`, and `effectiveNodeLine` are
+exercised only indirectly, through `parseAndValidate`, in `validate_test.go`.
+`parseAndValidate` itself is, like `parseYAMLDocument`, `validateSourceGraph`,
+and `resolveEffective` before it, still not wired into `Load()` or
+`loadFromPath()` — a `go/ast`-based test
+(`TestParseAndValidateStaysOutOfRuntimeLoad`) proves neither function's body
+references it, so this remains a standalone capability rather than a change
+in runtime behavior.
 
 ### Package manager wrapper pattern
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -757,8 +757,53 @@ its top-level node shape into exactly one of these outcomes:
   - A known page's **non-null scalar or sequence** value is rejected as
     `KindParseType` via the unexported `validatorPageValueShapeError`,
     naming the page, the actual shape found, and a positive line.
-  - A known page's **mapping** value is accepted structurally; its own
-    entries (groups and fields) are classified starting at a later chunk.
+  - A known page's **mapping** value has its own entries — groups — classified
+    the same way, one schema level down, by `validateGroupEntries`:
+    - A non-`!!str` mapping key is rejected as `KindParseType` via
+      `validatorKeyShapeError`, exactly as at page level.
+    - A well-formed string key that is not one of `SchemaGroups(page)`'s
+      canonical group names for that page (schema.go, reflected off
+      `defaultConfig()` — never a literal list in validate.go) is rejected as
+      `KindSchema` via `validatorSchemaError`, naming the offending key and a
+      positive line, without descending into its value. (`SchemaGroups`
+      erroring — only possible for a page unknown to it, which cannot happen
+      once `page` has passed `SchemaPages()` — is still surfaced defensively
+      as `KindSchema` via the unexported `validatorSchemaGroupsError`.)
+    - A known group's **null** value is a no-op for that group; its
+      **non-null scalar or sequence** value is `KindParseType` via the
+      unexported `validatorGroupValueShapeError`, naming the group, shape,
+      and line.
+    - A known group's **mapping** value has its own entries — group fields —
+      classified by `validateGroupFieldEntries`, sourced from the unexported
+      `groupFieldTypes()` (reflection over `rawGroupConfig`'s yaml tags and
+      declared Go field types — never a literal list in validate.go, aside
+      from the literal name `"actions"` itself, needed for the special case
+      below):
+      - A non-`!!str` mapping key is rejected as `KindParseType`, exactly as
+        at page and group level; an unrecognized field name is rejected as
+        `KindSchema`, exactly as an unrecognized group name is.
+      - The special-cased `actions` field is recognized as a known name, but
+        **as of this commit its value is left uninspected by stage 3** — no
+        shape or type check runs on it here at all (interpretation I5: a
+        later slice adds `actions`'s own structural walk, because a generic
+        decode into `*[]ActionConfig` cannot produce the right errors —
+        yaml.v3 silently ignores an unknown struct field on decode and
+        silently decodes a null sequence entry into a zero `ActionConfig`).
+        Stage 4's whole-document decode (below) still incidentally rejects a
+        non-decodable `actions` value (e.g. a scalar or mapping) as
+        `KindParseType`, but it silently accepts a null action entry as a
+        zero `ActionConfig` and silently ignores an unknown action field —
+        those two gaps are exactly what the later slice's dedicated
+        `actions` walk closes.
+      - Every other known field's effective value node is decoded into a
+        fresh value of that field's declared Go type,
+        `reflect.New(fieldType).Interface()` (interpretation I4) — e.g.
+        `enabled`'s `*bool`, `bundles_paths`'s `*[]string`. A decode failure
+        (yaml.v3's own `*yaml.TypeError`, e.g. `enabled: [1, 2]` into
+        `*bool`) is classified `KindParseType` via the unexported
+        `validatorDecodeError`, with the yaml.v3 error's message in `Detail`
+        and the error itself preserved in `Err` — the same builder stage 4's
+        final `Decode` call uses.
 
   Once every entry passes, stage 4 calls the effective document's
   `yaml.Node.Decode` into a `*rawConfig`. A `Decode` failure here is
@@ -775,7 +820,10 @@ Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
 `validatorShapeError`, `validatorDecodeError`, `effectiveNodeLine`,
 `validatePageEntries`, `schemaKeyName`, `validatorSchemaError`,
 `validatorSchemaPagesError`, `validatorKeyShapeError`,
-`validatorPageValueShapeError`, and `describeNodeShape` are all exercised
+`validatorPageValueShapeError`, `describeNodeShape`,
+`validateGroupEntries`, `validatorSchemaGroupsError`,
+`validatorGroupValueShapeError`, `validateGroupFieldEntries`,
+`groupFieldTypes`, and `validatorGroupFieldTypesError` are all exercised
 only indirectly, through `parseAndValidate`, in `validate_test.go`.
 `parseAndValidate` itself is, like `parseYAMLDocument`, `validateSourceGraph`,
 and `resolveEffective` before it, still not wired into `Load()` or


### PR DESCRIPTION
Implements /home/bjk/projects/frostyard/chairlift/.mill-prep/issue-69-phase1c1-core-validator.md via the mill workflow.

# Plan — feat(config): validate configuration schema and types (issue #69, phase 1c1)

**Revision 2.** Every objection in `.mill/objections.json` (round 1) is
addressed below; see "Objection responses" for the point-by-point record.

## Goal

Add the package-private, pure-Go validation entry point

```go
func parseAndValidate(path string, data []byte) (*rawConfig, *LoadError)
```

to `internal/config`, running the complete four-stage pipeline
(`parseYAMLDocument` → `resolveEffective` → ChairLift schema/shape/declared-type
validation → decode into `rawConfig`). It stays **unwired** from `Load` and
`loadFromPath`; a later issue-69 slice does the runtime wiring.

Stages 1 and 2 already exist (`source.go`, `sourcegraph.go`, `sourcebounds.go`,
`effective.go`, `effectivemerge.go`, `effectivekeys.go`, `schema.go`). This
slice adds stage 3 (the schema validator) and stage 4 (the decode), one schema
level per chunk.

## Fixed decision table (pinned before any chunk)

Per `docs/agents/skills/multi-tier-error-classification-needs-a-decision-table.md`
the Kind boundary is fixed here once and every chunk's tests inherit it. Row →
owning chunk (the chunk whose tests assert that row's `ErrorKind` through
`parseAndValidate`):

| # | Effective input | Result | Owner |
|---|---|---|---|
| 1 | malformed YAML, second document, or source duplicate | `KindParseType` | c5 (smoke in c1) |
| 2 | cyclic, malformed, source-path-over-budget, or effective-output-over-budget graph | `KindParseType` | c5 (smoke in c1) |
| 3 | empty document or top-level null | valid no-op overlay | c1 |
| 4 | top-level scalar or sequence | `KindParseType` | c1 |
| 5 | unknown top-level page | `KindSchema` | c2 |
| 6 | known page with null | valid no-op for that page | c2 |
| 7 | known page with scalar or sequence | `KindParseType` | c2 |
| 8 | unknown group under a known page | `KindSchema` | c3 |
| 9 | known group with null | valid no-op for that group | c3 |
| 10 | known group with scalar or sequence | `KindParseType` | c3 |
| 11 | unknown group field | `KindSchema` | c3 |
| 12 | `actions` value that is not null or a sequence | `KindParseType` | c4 |
| 13 | action entry that is null or otherwise not a mapping | `KindParseType` | c4 |
| 14 | unknown action field | `KindSchema` | c4 |
| 15 | known field that cannot decode into its declared Go type | `KindParseType` | c3 (non-`actions` fields), c4 (action fields) |
| 16 | valid effective document | decoded `*rawConfig` | c1 (document level), c4 (full, incl. explicit-zero preservation) |

## Objection responses (round 1)

**O1 — "c4 acceptance criterion 98: the required Path test matrix is
impossible as written" (high).** Accepted; the criterion is replaced. The four
ChairLift schema levels do not each support all three error categories:

| Level | schema-name failure | shape failure | declared-Go-type failure |
|---|---|---|---|
| document | — (no name) | yes (top-level scalar/sequence) | — |
| page | yes (unknown page) | yes (page value scalar/sequence) | — (a page has no declared field type; `rawPageConfig` is a map) |
| group | yes (unknown group) | yes (group value scalar/sequence) | — (a group has no single declared field type; `rawGroupConfig` is validated field by field) |
| group field | yes (unknown field) | yes (`actions` value not null/sequence) | yes (e.g. `enabled: [1, 2]` into `*bool`) |
| action entry | — (a sequence entry has no name) | yes (null / non-mapping entry) | — |
| action field | yes (unknown action field) | — (subsumed by the declared-type check) | yes (e.g. `sudo: {}` into `bool`) |

c4's `Path` criterion now requires exactly the cells marked "yes": four
schema-name `Path` assertions, five shape `Path` assertions, two
declared-type `Path` assertions. This is the reading an experienced maintainer
takes of the spec's "at every schema level": *each applicable category at each
level where that category can arise*, not a dense 4×3 product that cannot
exist.

**O2 — "c2 acceptance criterion 44: the alias-key fixture `a: &n 1` / `*n: x`
is unreachable" (high).** Accepted. The anchor is now introduced inside a
structurally valid canonical subtree so the alias key really is the first
failing entry. Verified empirically against the merged resolver
(`gopkg.in/yaml.v3` v3.0.1) — the fixtures and the exact effective key nodes
they produce are:

- page level:
  `"system_page:\n  system_info_group:\n    enabled: &n true\n*n: x\n"` →
  top-level mapping entries are (`system_page` `!!str`, valid mapping) then
  (`!!bool` `true`, `x`). The second key node is a **`!!bool` scalar at line
  3** (the anchor's line, not the alias's line 4), so it is `KindParseType`
  and its reported line is 3.
- group level:
  `"system_page:\n  system_info_group:\n    enabled: &n true\n  *n: x\n"` →
  the page mapping's second key is the same `!!bool` node at line 3.
- action-field level: same construction with the anchor on a valid action
  field (`- {title: t, script: s, sudo: &n true}`) and the alias used as a key
  in a following action entry.

The anchor value is `true`, not `1`, precisely so the entry carrying the
anchor is itself valid (`enabled` is `*bool`) and cannot pre-empt the alias-key
failure under I3's per-entry ordering.

**O3 — "c5 source-path bound fixture: ~70 nested levels does not exceed
maxSourcePathVisits=128" (high).** Accepted; the reviewer's counting is
correct. `pathVisitCount` charges one visit per node along a root-to-leaf
path, and a mapping key is a *sibling* of its value, so a nested mapping of
depth *d* under one top-level key costs `1 (document) + 1 (top mapping) + d
(nested mappings) + 1 (leaf scalar) = d + 3`. The exact boundary was measured
by running the merged `parseYAMLDocument` + `resolveEffective` over generated
text:

| fixture | depth | result (measured) |
|---|---|---|
| `nope:` + nested block mappings | 125 | passes bounds |
| `nope:` + nested block mappings | 126 | `KindParseType`, "maximum of 128 source-node path visits (line 1)" |
| `nope: [[[…x…]]]` (flow sequences) | 125 | passes bounds |
| `nope: [[[…x…]]]` (flow sequences) | 126 | `KindParseType`, "maximum of 128 source-node path visits (line 1)" |

c5 therefore uses the **flow-sequence** form (one short generated line, no
indentation blow-up) with the exact below/above pair **125 / 126**, generated
by a table-driven helper so the counting rule is visible in the test. The
below-bound document returns `KindSchema` (unknown page `nope`), which is what
proves the bounds pass was cleared rather than merely not reached.

The effective-output bound was measured the same way. The doubling alias chain
`l0: &l0 [x]`, `lN: &lN [*l(N-1), *l(N-1)]` trips
`maxEffectiveOutputNodes = 100000` at **n = 15** and passes at **n = 14**
(error: "effective output exceeds the maximum of 100000 emitted nodes (line
2)"). Its alias-hop count is 1 per node and its path-visit count is ~33, so
neither source-graph bound fires first. c5 uses the 14 / 15 pair; the
below-bound document again returns `KindSchema` (unknown page `l0`).

**O4 — "c3 documentation contract: 'the `actions` value is accepted without
inspection' is false for the complete call" (medium).** Accepted. Measured
behavior of stage 4's whole-document `Decode` as of c3: `actions: 5` **does**
fail (`cannot unmarshal !!int 5 into []config.ActionConfig`), while a null
action entry decodes silently to a zero `ActionConfig` and an unknown action
field is silently ignored. c3's `yeti/OVERVIEW.md` sentence is therefore
rewritten to distinguish the stages explicitly:

> As of this commit, stage 3 does not inspect the `actions` value itself;
> stage 4's whole-document decode still rejects an `actions` value that cannot
> decode into `[]ActionConfig` as `KindParseType`, but it silently accepts a
> null action entry as a zero action and silently ignores an unknown action
> field. Stage 3 gains its own `actions` walk in the next slice.

c4 replaces that paragraph with the final description. Both the c3 wording and
its c4 removal are carried as grep criteria.

**O5 (note) — "Pipeline ordering interpretation I3 … is explicit and
defensible."** No change; I3 is retained verbatim below.

## Interpretations (spec ambiguities resolved, with rationale)

**I1 — Only `parseAndValidate` may be named by a test file.**
`sourcesurface_test.go`'s `directCallAllowlist` is frozen and the spec
authorizes exactly one new entry, `"parseAndValidate": true`. Per
`docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md`
that authorization does not extend to any other identifier, so **every** other
helper this slice adds must be exercised only indirectly, through
`parseAndValidate`. This deliberately overrides
`docs/agents/skills/helper-functions-need-direct-test-calls.md` for this slice:
the spec's explicit, narrower instruction wins, and
`TestSourceHelperDirectCallSurface` mechanically enforces it.

**I2 — New production identifiers must be distinctive multi-word names.**
`TestSourceHelperDirectCallSurface` collects *every* `*ast.Ident` in *every*
`_test.go` file of the package — including local variables and struct field
names — so a production helper named `line`, `detail`, `validate`, `groupKeys`
or `pageNames` would trip the guard (or collide outright at package level; see
`docs/agents/skills/grep-test-files-for-package-level-identifier-collisions.md`
— `groupKeys` and `pageNames` are both already declared in `config_test.go`).
All new helpers therefore use the `validateEffective…` / `validator…` /
`schemaKeyName` / `effectiveNodeLine` shapes, verified absent from
`internal/config/*` today.

**I3 — Validation order is per-entry, in effective mapping order.**
"Classify a mapping name before inspecting that name's ordinary value" is a
*per-entry* rule. Mapping entries are walked in the effective tree's `Content`
order (which `resolveEffective`/`effectiveEntries` already made deterministic),
and for each entry the order is: (a) key shape — scalar with
`ShortTag() == "!!str"`, else `KindParseType`; (b) name known, else
`KindSchema`, without descending into the value; (c) only then inspect the
value. The first failing entry's error is returned. Consequence, stated so it
is not a surprise: `{unknown_page: x, system_page: 3}` is `KindSchema` and
`{system_page: 3, unknown_page: x}` is `KindParseType`. The spec does not
define precedence *between* entries; this is the only order that is both
deterministic and consistent with the resolver's existing entry ordering.

**I4 — Declared-type checking is per known field, via `yaml.Node.Decode` into
`reflect.New(declaredType)`.** This is what produces the real `*yaml.TypeError`
the spec requires to survive in `LoadError.Err`. Traced concretely (per
`docs/agents/skills/trace-one-concrete-input-through-pipeline-order.md`) for
`system_page:\n  system_info_group:\n    enabled: [1, 2]\n`: stage 1 parses,
stage 2 resolves, page `system_page` is known and a mapping, group
`system_info_group` is known and a mapping, field `enabled` is known → decode
its effective value node into a fresh `*bool` → yaml.v3 v3.0.1 returns
`*yaml.TypeError` (`"line 3: cannot unmarshal !!seq into bool"`), preserved in
`Err`, classified `KindParseType`. Measured, not recalled
(`docs/agents/skills/match-dependency-behavior-from-gomodcache-not-memory.md`):
both the per-field `Node.Decode` and the whole-document `Decode` return an
error `errors.As` resolves to `*yaml.TypeError`. Stage 4's whole-document
`doc.Decode(&raw)` is kept as a defensive final step (also `KindParseType`,
`Err` preserved); after c4 it is expected to be unreachable, and no chunk's
acceptance depends on reaching it.

**I5 — `actions` is validated structurally, not by a generic decode.** Two
yaml.v3 behaviors force this, both measured against v3.0.1: `Node.Decode`
silently ignores struct fields it does not know (so an unknown action field
would never become `KindSchema`), and it decodes a null sequence entry into a
zero `ActionConfig` without error (so a null action entry would never become
`KindParseType`). The group-field dispatcher therefore special-cases the
`actions` name and walks it (c4) instead of decoding it into
`*[]ActionConfig`.

**I6 — Key identity uses the *effective* node's `ShortTag()`.** After
`resolveEffective`, aliases are already dereferenced into copies of their
targets and recognized `<<` merge keys are already consumed, so "alias to a
non-string key" arrives at the validator as an ordinary non-`!!str` scalar (or
a mapping/sequence) and is `KindParseType` with no extra machinery. Measured
against v3.0.1 and the merged resolver: a bare `<<` key carries
`Tag == "!!merge"` and is consumed by the resolver, while a quoted `"<<"` key
carries `Tag == "!!str"` and reaches the validator as an ordinary name →
`KindSchema`, exactly as the spec requires. An aliased key's effective node
carries the **anchor's** line, which is what the line assertions use.

**I7 — Name inventories come from the canonical structs only.** Pages from
`SchemaPages()` (reflected off `Config`), groups from `SchemaGroups(page)`
(reflected off `defaultConfig()`), group fields and their declared Go types
from `rawGroupConfig` (the type yaml.v3 actually decodes into, already held to
`GroupConfig` by `TestRawGroupConfigMatchesGroupConfigFields` and to `Config`
by `TestRawConfigMatchesConfigFields`), action fields and types from
`ActionConfig`. No second, hand-maintained list is introduced
(`docs/agents/skills/derive-schema-from-canonical-struct-not-shadow-representation.md`).
`SchemaPages`/`SchemaGroups` return an `error` only for a malformed struct
tag, which cannot happen for the canonical structs; that branch is surfaced
defensively as a `KindSchema` `*LoadError` wrapping the reflect error rather
than ignored or panicked on.

**I8 — The validator is deliberately stricter than the current runtime
merge.** `mergePage` accepts a group name unknown to `defaultConfig()` (it
starts from `GroupConfig{Enabled: true}`); the validator rejects it as
`KindSchema`. That divergence is safe and intentional while `parseAndValidate`
is unwired, and is documented in `yeti/OVERVIEW.md` in c6. `config.go` is not
modified by this slice.

**I9 — Lines are always positive.** Emitted effective nodes copy their source
node's `Line`, so the offending node's own line is used; `effectiveNodeLine`
clamps a non-positive line to 1, mirroring `effectiveOutputLimitError`'s
existing guard, so every validator-created detail contains a positive
`line N`.

**I10 — Documentation cadence.** `yeti/OVERVIEW.md` is updated in every chunk
that changes behavior so no commit leaves a stale or false claim
(`docs/agents/skills/leaf-package-enumeration-docs-update-same-chunk.md`,
`docs/agents/skills/leaf-package-docs-must-enumerate-outcomes-not-summarize.md`).
c3 states the stage-3/stage-4 split for `actions` precisely (see O4); c4
replaces it. c6 then adds the consolidated 16-row decision table once every row
exists, and re-verifies the sibling docs. `AGENTS.md` is not edited: per
`docs/agents/skills/agents-md-is-a-plan-acceptance-criterion.md` the bar is
"relevant", and `AGENTS.md` states no fact about config parsing, validation
strictness, or `Load`'s failure behavior — c6 carries a grep proving that,
rather than padding a chunk with an unnecessary edit.

## Cross-cutting invariants (constrain every chunk)

- **Privilege boundary** — untouched. No chunk adds command execution, shells
  out, or changes `pkexec` targets/policies. `internal/config` executes
  nothing, and no chunk builds a command from config input.
- **GTK main-thread safety / config-driven visibility** — untouched. No chunk
  imports puregotk or adds a `_test.go` to a puregotk package
  (`docs/agents/skills/gtk-headless-tests.md`); all new tests live in
  `internal/config`, which the gates actually run
  (`docs/agents/skills/gate-test-scope-is-internal-only.md`).
- **`internal/config` stays pure Go** — new code imports only `reflect`,
  `fmt`, `errors`, `strings` and `gopkg.in/yaml.v3`.
- **No exported surface change** — `TestSourceConfigExportedSurface` freezes
  it; every new identifier is unexported.
- **Frozen allowlist** — exactly one new entry, `"parseAndValidate": true`,
  added in c1 (I1). No chunk adds another.
- **`Load`/`loadFromPath` unchanged** — no chunk edits `config.go`; c1 adds an
  automated AST test proving neither function references `parseAndValidate`,
  and c6 carries the final scoped grep (excluding `.mill/` and `_test.go`, per
  `docs/agents/skills/grep-removal-criteria-must-exclude-mill-and-tests.md`).
- **No unused code at any commit** — the default golangci-lint set includes
  `unused`, so each chunk adds only helpers it calls in the same chunk. This is
  why levels land strictly top-down.
- **Test names** — every new test starts `TestParseAndValidate…`; no name
  begins `TestI` and none contains `Integration` (`AGENTS.md`'s CI filter
  rule).
- **Every collection entry covered** — page-level tests iterate all six pages'
  names from `SchemaPages()` where the row is name-independent
  (`docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`);
  the exhaustive every-page/every-group matrix itself is explicitly reserved by
  the spec for the following slice.

## Sequencing notes

Chunks land strictly outside-in (document → page → group/group-field →
actions), because each level's validator is the only caller of the next
level's helper; that ordering is what keeps `unused` quiet and keeps each diff
small. No chunk asserts behavior a later chunk changes: c1–c3 add tests only
for rows they own and explicitly do **not** assert that an unknown page/group/
field or a malformed action entry is *accepted* in the interim
(`docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md`).
The only interim claim made anywhere is the stage-3/stage-4 `actions` paragraph
c3 writes into `yeti/OVERVIEW.md` (O4), and c4 lists that file with an explicit
criterion to replace it. c5 is test-only (pipeline precedence and the two
reachable bounds through real YAML text) and c6 is documentation-only.

The spec's constraint that the `errors.As(..., *yaml.TypeError)` decode
regression land in the chunk where all page/group/action validation levels
exist is satisfied by placing it in c4; c3's declared-type tests assert only
`Kind`, `Detail`, `Path` and line for non-`actions` group fields, which c4 does
not change.

Estimated diff sizes: c1 ≈ 330 lines, c2 ≈ 310, c3 ≈ 390, c4 ≈ 390, c5 ≈ 250,
c6 ≈ 120.

## Chunks

### c1 — `parseAndValidate` entry point, document-level shape checks, and the `rawConfig` decode

*Files:* `internal/config/validate.go` (new), `internal/config/validate_test.go`
(new), `internal/config/sourcesurface_test.go`, `yeti/OVERVIEW.md`

Creates the entry point and wires stages 1, 2 and 4 plus the top-level slice of
stage 3. Stage 1 and 2 errors are returned unchanged, so this entry point can
never be used to bypass parser/graph/bound validation. Document level: a nil
document or a null top-level scalar is a valid no-op returning a non-nil empty
`*rawConfig`; a top-level scalar or sequence is `KindParseType`; a mapping is
accepted (its entries are classified from c2 on). Stage 4 skips `Decode`
entirely for the empty/null cases and otherwise decodes the effective document
into `rawConfig`, classifying any error `KindParseType` with the yaml error
preserved (defensive; see I4).

Adds only the shared error/line helpers this chunk actually calls
(`validatorShapeError`, `validatorDecodeError`, `effectiveNodeLine`) — no
helper is added ahead of its first caller, because golangci-lint's default
`unused` linter is part of the chunk gate.

This is the chunk that spends the spec's single allowlist authorization:
`"parseAndValidate": true` is added to `directCallAllowlist` with a comment,
and nothing else in `sourcesurface_test.go` changes. The spec's "final scoped
grep must show no runtime call from `Load` or `loadFromPath`" is implemented
here as a real, gated `go/ast` test
(`TestParseAndValidateStaysOutOfRuntimeLoad`) rather than a manual check, per
`docs/agents/skills/acceptance-criteria-need-automated-checks-not-inspection.md`;
the grep is kept as a criterion too.

### c2 — Page level: key shape, page names, page value shape

*Files:* `internal/config/validate.go`, `internal/config/validate_test.go`,
`yeti/OVERVIEW.md`

Adds `schemaKeyName` (the `!!str`-only name rule), `validatorSchemaError`, and
the top-level mapping walk. Page names come from `SchemaPages()`, i.e. from
`Config`'s yaml tags — never a literal list in `validate.go` (I7). Tests cover
every page-level table row, all seven non-name key shapes (integer, boolean,
null, custom-tagged, sequence, mapping, alias-to-non-string), the quoted `"<<"`
name, and the four-value-shape table proving unknown-name classification
precedes value inspection. The alias-to-non-string page-key fixture is the
verified one from O2.

Because this chunk makes `parseAndValidate` the first code path in the package
that ever produces a `KindSchema` error, it also fixes the pre-existing
`yeti/OVERVIEW.md` sentence claiming `KindSchema` describes a capability "no
code path currently exercises"
(`docs/agents/skills/doc-chunks-must-fix-existing-contradictions.md`), carried
as a grep criterion.

### c3 — Group level and group fields (excluding the `actions` value)

*Files:* `internal/config/validate.go`, `internal/config/validate_test.go`,
`yeti/OVERVIEW.md`

Group names from `SchemaGroups(page)`; group field names and declared Go types
by reflection on `rawGroupConfig`. Known non-`actions` fields are validated by
decoding into a fresh `reflect.New(declaredType)`, preserving the real yaml
error in `Err`.

The `actions` name is recognised as known and its *value* is left uninspected
by stage 3 until c4 (I5). This is the plan's only interim behavior, handled
under `docs/agents/skills/cross-chunk-test-contracts-must-be-tracked-forward.md`:
c3's tests assert nothing about `actions` values, so c4 adds assertions without
invalidating any, and c3's `yeti/OVERVIEW.md` paragraph states the stage-3 /
stage-4 split exactly as measured (O4) rather than claiming blanket acceptance.

### c4 — `actions`, action entries, action fields, and the completed valid-decode contract

*Files:* `internal/config/validate.go`, `internal/config/validate_test.go`,
`yeti/OVERVIEW.md`

Structural `actions` walk (null or sequence; every entry a mapping; a null
entry is explicitly *not* a zero action), action-field names and declared types
from `ActionConfig`. Because all four schema levels now exist, this chunk owns
the two contracts the spec reserves for the complete-pipeline chunk: the
`errors.As(..., *yaml.TypeError)` regression (asserted at both group-field and
action-field level) and the valid-document assertion that explicit `false`,
`""` and `[]` survive as set values rather than becoming omissions. It also
carries the `Path` assertions per the O1 matrix — four schema-name, five shape,
two declared-type — and replaces c3's interim `actions` paragraph.

### c5 — Precedence and the two parser-reachable bounds, through `parseAndValidate`

*Files:* `internal/config/validatebounds_test.go` (new)

Test-only. Drives the stage-1/stage-2 rows through the entry point from real
YAML text, including the two limits the spec requires to be reachable that way,
using the measured boundaries from O3: nested flow sequences at depth 125
(passes bounds → `KindSchema` for unknown page `nope`) versus 126 (
`KindParseType`, detail naming 128); doubling alias chain at n = 14 (passes →
`KindSchema`) versus n = 15 (`KindParseType`, detail naming 100000). Each
fixture is produced by a small generator in the test so the counting rule
(`1 document + 1 top mapping + d nested nodes + 1 leaf scalar`) is written down
next to the numbers. `maxAliasHops` (64) is deliberately not exercised here —
it is unreachable from parser-produced text, and `sourcebounds_test.go`'s
existing direct helper tests keep that boundary, as the spec directs.

Also proves the precedence rule: a document that is both over budget/malformed
*and* contains an unknown name is `KindParseType`, never `KindSchema`.

No documentation change: this chunk changes no behavior and the bounds are
already documented by the earlier slices.

### c6 — Documentation consolidation

*Files:* `yeti/OVERVIEW.md`

Adds the complete pipeline description and the full 16-row decision table, once
every row exists, plus the explicit statement that runtime `Load` is not wired
and that there is no strict validation, no fail-closed loading, no startup
config-error log and no config-error toast, and that the validator is
deliberately stricter than `mergePage` (I8). Reviews `AGENTS.md`, `README.md`,
`CONFIG.md` and `yeti/package-managers.md`: none currently makes a contradicted
claim (verified by grep during planning), so none is edited — but the chunk
carries executable greps proving it, rather than an inspection note.


---

# Mill final review

## Security review — verdict: pass

```json
{
  "verdict": "pass",
  "findings": []
}
```

## Spec compliance review — verdict: pass

```json
{
  "verdict": "pass",
  "matrix": [
    {
      "requirement": "Run after the bounded effective-YAML resolver is merged.",
      "status": "met",
      "evidence": "internal/config/validate.go:82-90 calls the existing parseYAMLDocument and resolveEffective stages first."
    },
    {
      "requirement": "Add package-private pure-Go parseAndValidate(path string, data []byte) (*rawConfig, *LoadError).",
      "status": "met",
      "evidence": "internal/config/validate.go:1-8,81 defines the exact unexported signature using only stdlib and yaml.v3."
    },
    {
      "requirement": "Keep parseAndValidate unwired from Load/loadFromPath and test it directly.",
      "status": "met",
      "evidence": "internal/config/config.go:82-121 remains unchanged; internal/config/validate_test.go:180-207 guards against runtime references."
    },
    {
      "requirement": "Add exactly parseAndValidate to the frozen direct-call allowlist and no other helper.",
      "status": "met",
      "evidence": "internal/config/sourcesurface_test.go:43-47,67-72 adds only parseAndValidate."
    },
    {
      "requirement": "Execute parse, effective resolution, schema/type validation, then rawConfig decoding in that order.",
      "status": "met",
      "evidence": "internal/config/validate.go:82-114 implements the four stages in order."
    },
    {
      "requirement": "Parser, graph, duplicate, and resolver-bound failures must precede schema classification.",
      "status": "met",
      "evidence": "internal/config/validate.go:82-90 returns stage errors immediately; internal/config/validatebounds_test.go:138-185 tests precedence."
    },
    {
      "requirement": "Classify each mapping name before inspecting its value; unknown names are KindSchema and their values are not traversed.",
      "status": "met",
      "evidence": "internal/config/validate.go:143-169,196-222,247-270,319-336; internal/config/validate_test.go:394-439,551-600,888-913."
    },
    {
      "requirement": "Malformed YAML, a second document, or a source duplicate returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:110-153; internal/config/validatebounds_test.go:173-185."
    },
    {
      "requirement": "Cyclic, malformed, source-path-over-budget, or effective-output-over-budget graphs return KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:139-153; internal/config/validatebounds_test.go:48-135; existing cycle coverage remains under internal/config/sourcegraph_test.go."
    },
    {
      "requirement": "Empty input or a top-level null is a valid no-op overlay.",
      "status": "met",
      "evidence": "internal/config/validate.go:92-102; internal/config/validate_test.go:30-76."
    },
    {
      "requirement": "A top-level scalar or sequence returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:97-114; internal/config/validate_test.go:78-108."
    },
    {
      "requirement": "An unknown top-level page returns KindSchema.",
      "status": "met",
      "evidence": "internal/config/validate.go:147-153; internal/config/validate_test.go:209-226."
    },
    {
      "requirement": "A known page with null is a valid no-op.",
      "status": "met",
      "evidence": "internal/config/validate.go:155-159; internal/config/validate_test.go:228-241."
    },
    {
      "requirement": "A known page with a scalar or sequence returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:155-168; internal/config/validate_test.go:243-268."
    },
    {
      "requirement": "An unknown group under a known page returns KindSchema.",
      "status": "met",
      "evidence": "internal/config/validate.go:200-206; internal/config/validate_test.go:441-458."
    },
    {
      "requirement": "A known group with null is a valid no-op.",
      "status": "met",
      "evidence": "internal/config/validate.go:208-212; internal/config/validate_test.go:460-473."
    },
    {
      "requirement": "A known group with a scalar or sequence returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:208-221; internal/config/validate_test.go:475-499."
    },
    {
      "requirement": "An unknown group field returns KindSchema.",
      "status": "met",
      "evidence": "internal/config/validate.go:251-258; internal/config/validate_test.go:501-518."
    },
    {
      "requirement": "An actions value other than null or a sequence returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:281-302; internal/config/validate_test.go:793-830."
    },
    {
      "requirement": "A null or otherwise non-mapping action entry returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:288-297; internal/config/validate_test.go:832-865."
    },
    {
      "requirement": "An unknown action field returns KindSchema.",
      "status": "met",
      "evidence": "internal/config/validate.go:323-330; internal/config/validate_test.go:867-886."
    },
    {
      "requirement": "A known field that cannot decode into its declared Go type returns KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:266-269,332-335; internal/config/validate_test.go:520-549,915-930."
    },
    {
      "requirement": "A valid effective document decodes into rawConfig.",
      "status": "met",
      "evidence": "internal/config/validate.go:103-111; internal/config/validate_test.go:155-178,1057-1100."
    },
    {
      "requirement": "Place the final errors.As(*yaml.TypeError) regression only once all validation levels exist.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:1027-1055 tests both group and action fields against the completed validator."
    },
    {
      "requirement": "Only effective scalar keys whose ShortTag is exactly !!str are schema names; reject all other key shapes as KindParseType.",
      "status": "met",
      "evidence": "internal/config/validate.go:407-423; internal/config/validate_test.go:300-354,602-689,932-979."
    },
    {
      "requirement": "Treat quoted string key \"<<\" as an ordinary unknown name and therefore KindSchema.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:356-372; bare merge handling is distinguished at 374-392."
    },
    {
      "requirement": "Source accepted pages, groups, group fields, and action fields only from canonical inventories.",
      "status": "met",
      "evidence": "internal/config/validate.go:127-141,186-194,241-258,313-330,341-405; internal/config/schema.go:118-166."
    },
    {
      "requirement": "Allow actions only as null or a sequence, and require every sequence entry to be a mapping.",
      "status": "met",
      "evidence": "internal/config/validate.go:275-303."
    },
    {
      "requirement": "Validate each known field against its reflected declared Go type and preserve the actual yaml error in LoadError.Err.",
      "status": "met",
      "evidence": "internal/config/validate.go:266-269,332-335,586-598; internal/config/validate_test.go:1027-1055."
    },
    {
      "requirement": "Schema and synthetic shape/type details must identify the offending name or expected type/location and contain a positive line; every error copies path.",
      "status": "met",
      "evidence": "internal/config/validate.go:425-437,492-550,571-612; internal/config/validate_test.go:1104-1197."
    },
    {
      "requirement": "Empty input and top-level null must return a non-nil empty rawConfig without error.",
      "status": "met",
      "evidence": "internal/config/validate.go:92-102; internal/config/validate_test.go:30-76."
    },
    {
      "requirement": "All tests must live under internal/config and no test name may begin TestI or contain Integration.",
      "status": "met",
      "evidence": "Changed tests are internal/config/validate_test.go and internal/config/validatebounds_test.go; their test declarations at validate_test.go:61-1176 and validatebounds_test.go:60-143 all begin TestParseAndValidate."
    },
    {
      "requirement": "Assert the exact result for every decision-table row through parseAndValidate.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:61-1100 and internal/config/validatebounds_test.go:60-185 cover all sixteen rows."
    },
    {
      "requirement": "Cover non-string and alias-to-non-string keys at page, group, group-field, and action-field levels.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:300-354,602-689,932-979."
    },
    {
      "requirement": "Prove unknown-name classification precedes unknown-value shape inspection at all four name levels.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:394-419,551-600,888-913."
    },
    {
      "requirement": "Exercise the reachable source-path and 100000-node output limits through real YAML and parseAndValidate, asserting path, positive line, and numeric bound; retain the direct alias-hop boundary test.",
      "status": "met",
      "evidence": "internal/config/validatebounds_test.go:48-135; internal/config/sourcebounds_test.go:117-145 retains the 64/65 alias-hop boundary."
    },
    {
      "requirement": "Assert representative exact positive lines for parse/type and schema errors.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:81-108,209-226,342-354,441-458,501-518,660-689,967-979."
    },
    {
      "requirement": "Assert errors.As reaches a real yaml.TypeError for a declared-Go-type failure.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:1027-1055."
    },
    {
      "requirement": "Assert explicit false, empty string, and empty sequence values remain present rather than becoming omissions.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:1057-1100."
    },
    {
      "requirement": "Defer the exhaustive every-page/every-group, full merge-interaction, zero-value pointer-presence, and repository example corpus matrices to the next slice.",
      "status": "deferred",
      "evidence": ".mill/plan.md:284-288 explicitly preserves the spec's deferral to the following slice."
    },
    {
      "requirement": "Update yeti/OVERVIEW.md with the complete package-private pipeline and decision table, explicitly stating runtime Load is not wired.",
      "status": "met",
      "evidence": "yeti/OVERVIEW.md:698-809,942-966."
    },
    {
      "requirement": "Review AGENTS.md, README.md, and yeti/package-managers.md without claiming runtime strict validation, fail-closed loading, startup error logging, or a toast.",
      "status": "met",
      "evidence": ".mill/plan.md:427-430 records the review; yeti/OVERVIEW.md:955-966 explicitly states those behaviors do not exist, and the sibling-doc grep found no contradictory claims."
    },
    {
      "requirement": "Keep internal/config pure Go.",
      "status": "met",
      "evidence": "internal/config/validate.go:1-8 imports only stdlib and gopkg.in/yaml.v3."
    },
    {
      "requirement": "Do not change Load, loadFromPath, search paths, defaults, schema names, GTK/window code, diagnostics, privilege behavior, or command execution.",
      "status": "met",
      "evidence": "The base-to-HEAD diff changes only internal/config/sourcesurface_test.go, validate.go, validator tests, and yeti/OVERVIEW.md; internal/config/config.go:75-121 remains unchanged."
    },
    {
      "requirement": "All chunk gates and final make ci must pass.",
      "status": "met",
      "evidence": ".mill/config.json:2-10 defines the gates; the final make ci execution completed successfully."
    },
    {
      "requirement": "A final scoped grep must show no runtime call from Load or loadFromPath to parseAndValidate.",
      "status": "met",
      "evidence": "internal/config/validate_test.go:180-207 provides an AST guard, and the final scoped grep returned no runtime references."
    }
  ]
}
```


🤖 Generated with the mill (workflows/mill.yaml)