### PR TITLE
fix(config): fail closed on invalid configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,11 @@ An agent must not break these:
   (`config.IsGroupEnabled(page, group)`), so its widgets may never be
   constructed. Code that runs after an async action must not assume a widget
   from another group exists — nil-guard cross-group widget access.
+- **Configuration precedence fails closed.** Only a missing candidate advances
+  to the next configuration search path. The first file that exists is
+  authoritative: read, YAML, or schema errors must disable every configurable
+  group, emit the `CONFIGURATION ERROR` diagnostic, and remain visible in the
+  UI as a persistent toast until the file is fixed and ChairLift is restarted.
 
 ## Documentation
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -8,10 +8,17 @@ ChairLift searches for the configuration file in the following locations (in ord
 
 1. `/etc/chairlift/config.yml` (system-wide configuration - highest priority)
 2. `/usr/share/chairlift/config.yml` (package maintainer defaults)
-3. `chairlift/config.yml` (development/source directory)
+3. `config.yml` beside the ChairLift executable, or in the current working
+   directory when no executable-relative file exists (development fallback)
 
 If no configuration file is found, all features default to enabled, except
 `maintenance_cleanup_group`, which defaults to disabled.
+
+The first file that exists in this order is authoritative. ChairLift does not
+fall through to a lower-priority file when that file is unreadable, malformed,
+or fails schema validation. Instead, it disables every feature group, logs a
+high-signal `CONFIGURATION ERROR`, and displays a persistent error toast naming
+the file and cause. Fix the authoritative file and restart ChairLift.
 
 ## Configuration Format
 
@@ -78,7 +85,7 @@ To create a distribution-specific configuration that disables all Homebrew featu
 
 ```yaml
 updates_page:
-  updates_status_group:
+  bootc_updates_group:
     enabled: true
   flatpak_updates_group:
     enabled: true # Keep Flatpak updates
@@ -158,7 +165,9 @@ install -D -m 644 config.yml debian/tmp/etc/chairlift/config.yml
   - An explicit empty list (e.g. `actions: []`) clears the field
   - A non-empty list, or an explicitly set scalar value, replaces the
     default outright
-- Invalid or unreadable configuration files fall back to the built-in
-  defaults in full (`maintenance_cleanup_group` stays disabled; every other
-  group stays enabled) — not "all features enabled"
+- Page names, group names, and field names must match the documented schema;
+  unknown names and values of the wrong type are configuration errors
+- An unreadable, malformed, or schema-invalid authoritative file fails closed:
+  all feature groups are hidden, lower-priority files are ignored, and
+  ChairLift reports the path and cause in both its log and a persistent toast
 - Changes require restarting ChairLift to take effect

--- a/README.md
+++ b/README.md
@@ -159,7 +159,15 @@ Configuration files are searched in the following locations (in order):
 
 1. `/etc/chairlift/config.yml` (system-wide - highest priority)
 2. `/usr/share/chairlift/config.yml` (package maintainer defaults)
-3. `chairlift/config.yml` (development/source directory)
+3. `config.yml` beside the ChairLift executable, or in the current working
+   directory when no executable-relative file exists (development fallback)
+
+The first file that exists is authoritative. If it is unreadable, malformed,
+or contains unknown pages, groups, fields, or invalid field types, ChairLift
+does not use a lower-priority file: it hides every configurable feature group,
+logs a `CONFIGURATION ERROR`, and shows a persistent error toast with the path
+and cause. Fix the file and restart ChairLift. If every candidate is absent,
+the built-in defaults apply.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -8,9 +8,15 @@ Configuration files are searched in order (first found wins):
 
 1. `/etc/chairlift/config.yml` — system-wide (highest priority)
 2. `/usr/share/chairlift/config.yml` — package maintainer defaults
-3. `config.yml` — relative to executable (development)
+3. `config.yml` — beside the executable when present, otherwise relative to
+   the current working directory (development fallback)
 
-If no file is found, all features default to enabled.
+Only a missing candidate advances the search. The first existing candidate is
+authoritative. If it cannot be read or fails YAML/schema validation, ChairLift
+hides every feature group, logs a `CONFIGURATION ERROR`, and displays a
+persistent toast with the path and cause. Fix the file and restart ChairLift.
+If no file is found, built-in defaults apply: all groups are enabled except
+`maintenance_cleanup_group`.
 
 ## Format
 
@@ -21,7 +27,9 @@ page_name:
     # Optional per-group fields (see below)
 ```
 
-Groups with `enabled: false` are hidden from the UI. Missing entries default to `enabled: true`. Changes require restarting ChairLift.
+Groups with `enabled: false` are hidden from the UI. Missing entries inherit
+their built-in values. Unknown page, group, or field names and wrong field
+types are errors. Changes require restarting ChairLift.
 
 ## Pages and Groups
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,11 +2,10 @@
 package config
 
 import (
+	"errors"
+	"io/fs"
 	"log"
 	"os"
-	"path/filepath"
-
-	"gopkg.in/yaml.v3"
 )
 
 // Config represents the application configuration
@@ -79,46 +78,81 @@ var configPaths = []string{
 	"config.yml",
 }
 
-// Load loads the configuration from available config files
-func Load() *Config {
-	for _, path := range configPaths {
-		cfg, err := loadFromPath(path)
+// readFile is an injection seam for deterministic read-failure tests. Its
+// production value is always os.ReadFile.
+var readFile = os.ReadFile
+
+// Load loads the first existing configuration candidate. A missing candidate
+// continues the documented search order; any other failure in the first
+// existing candidate is authoritative and returns a fail-closed configuration
+// together with the actionable error.
+func Load() (*Config, *LoadError) {
+	for _, candidate := range configPaths {
+		path := resolveCandidatePath(candidate)
+		cfg, err := loadResolvedPath(path)
 		if err == nil {
 			log.Printf("Loaded config from %s", path)
-			return cfg
+			return cfg, nil
 		}
+		if err.Kind == KindRead && errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
+		log.Print(err.LogMessage())
+		return disabledConfig(), err
 	}
 
-	// Return default config if no file found
+	// Preserve built-in defaults only when every candidate is genuinely absent.
 	log.Println("No config file found, using defaults")
-	return defaultConfig()
+	return defaultConfig(), nil
 }
 
 // loadFromPath attempts to load config from a specific path
-func loadFromPath(path string) (*Config, error) {
-	// Handle relative paths
-	if !filepath.IsAbs(path) {
-		// Try relative to executable
-		execDir, err := os.Executable()
-		if err == nil {
-			execPath := filepath.Join(filepath.Dir(execDir), path)
-			if _, err := os.Stat(execPath); err == nil {
-				path = execPath
-			}
+func loadFromPath(path string) (*Config, *LoadError) {
+	return loadResolvedPath(resolveCandidatePath(path))
+}
+
+// loadResolvedPath reads and strictly validates one already-resolved
+// candidate, then overlays it onto the built-in defaults.
+func loadResolvedPath(path string) (*Config, *LoadError) {
+	data, err := readFile(path)
+	if err != nil {
+		return nil, &LoadError{
+			Path:   path,
+			Kind:   KindRead,
+			Detail: "reading configuration file",
+			Err:    err,
 		}
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
+	raw, loadErr := parseAndValidate(path, data)
+	if loadErr != nil {
+		return nil, loadErr
 	}
 
-	var raw rawConfig
-	if err := yaml.Unmarshal(data, &raw); err != nil {
-		return nil, err
-	}
+	return mergeConfig(defaultConfig(), raw), nil
+}
 
-	return mergeConfig(defaultConfig(), &raw), nil
+// disabledConfig retains the canonical pages, groups, and non-visibility
+// defaults while forcing every known group off. It is the only configuration
+// returned for an authoritative read, parse/type, or schema failure.
+func disabledConfig() *Config {
+	cfg := defaultConfig()
+	pages := []PageConfig{
+		cfg.SystemPage,
+		cfg.UpdatesPage,
+		cfg.ApplicationsPage,
+		cfg.MaintenancePage,
+		cfg.FeaturesPage,
+		cfg.HelpPage,
+	}
+	for _, page := range pages {
+		for name, group := range page {
+			group.Enabled = false
+			page[name] = group
+		}
+	}
+	return cfg
 }
 
 // mergeConfig overlays raw (a parsed config file) onto def (defaultConfig())
@@ -137,12 +171,10 @@ func mergeConfig(def *Config, raw *rawConfig) *Config {
 	}
 }
 
-// mergePage overlays raw onto def for a single page. Groups present only in
-// def are kept as-is; groups present only in raw (a group name unknown to
-// defaultConfig() for this page) start from a zero GroupConfig that defaults
-// Enabled to true, matching IsGroupEnabled's existing "missing group ->
-// enabled" fallback for the wholly-absent case. Groups present in both are
-// merged field by field.
+// mergePage overlays raw onto def for a single page. Runtime inputs have
+// already passed strict schema validation, so the unknown-group branch is
+// defensive support for trusted package-internal callers only. Groups present
+// in both maps are merged field by field.
 func mergePage(def PageConfig, raw rawPageConfig) PageConfig {
 	result := make(PageConfig, len(def))
 	for name, group := range def {
@@ -152,7 +184,7 @@ func mergePage(def PageConfig, raw rawPageConfig) PageConfig {
 	for name, rawGroup := range raw {
 		base, ok := def[name]
 		if !ok {
-			// Unknown group: omitted `enabled` still resolves to true.
+			// Preserve the historical package-internal merge behavior.
 			base = GroupConfig{Enabled: true}
 		}
 		result[name] = mergeGroup(base, rawGroup)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -82,7 +82,11 @@ func TestLoadFromPathUnreadablePathReturnsError(t *testing.T) {
 func TestLoadAbsentFileFallsBackToDefaultConfig(t *testing.T) {
 	withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
 
-	got := pagesOf(Load())
+	cfg, loadErr := Load()
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v, want nil for all-absent candidates", loadErr)
+	}
+	got := pagesOf(cfg)
 	want := pagesOf(defaultConfig())
 
 	for _, page := range pageNames {
@@ -128,7 +132,10 @@ func TestMaintenanceCleanupGroupDefaultConsistentAcrossAbsentAndOmitted(t *testi
 
 	// Absent-file case.
 	withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
-	absentCfg := Load()
+	absentCfg, loadErr := Load()
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v, want nil for absent file", loadErr)
+	}
 	groupsEqual(t, "maintenance_page", "maintenance_cleanup_group",
 		absentCfg.MaintenancePage["maintenance_cleanup_group"], wantGroup)
 
@@ -326,7 +333,10 @@ func TestGroupEnabledMatchesExpectedForEveryGroup(t *testing.T) {
 
 	t.Run("absent file", func(t *testing.T) {
 		withConfigPaths(t, []string{filepath.Join(t.TempDir(), "does-not-exist.yml")})
-		cfg := Load()
+		cfg, loadErr := Load()
+		if loadErr != nil {
+			t.Fatalf("Load() error = %v, want nil for absent file", loadErr)
+		}
 
 		for _, page := range pageNames {
 			for name, group := range defPages[page] {

--- a/internal/config/diagnostic.go
+++ b/internal/config/diagnostic.go
@@ -1,0 +1,21 @@
+package config
+
+import "fmt"
+
+// LogMessage renders the high-signal startup diagnostic for an authoritative
+// configuration failure.
+func (e *LoadError) LogMessage() string {
+	return fmt.Sprintf(
+		"CONFIGURATION ERROR: %s; all feature groups were disabled; fix the configuration file and restart ChairLift",
+		e.Error(),
+	)
+}
+
+// ToastMessage renders the persistent user-facing startup diagnostic for an
+// authoritative configuration failure.
+func (e *LoadError) ToastMessage() string {
+	return fmt.Sprintf(
+		"Configuration error: %s. All feature groups are disabled. Fix the configuration file and restart ChairLift.",
+		e.Error(),
+	)
+}

--- a/internal/config/diagnostic_test.go
+++ b/internal/config/diagnostic_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLoadErrorDiagnosticMessages(t *testing.T) {
+	loadErr := &LoadError{
+		Path:   "/etc/chairlift/config.yml",
+		Kind:   KindRead,
+		Detail: "reading configuration file",
+		Err:    errors.New("permission denied"),
+	}
+
+	const wantLog = "CONFIGURATION ERROR: config read error: /etc/chairlift/config.yml: reading configuration file: permission denied; all feature groups were disabled; fix the configuration file and restart ChairLift"
+	if got := loadErr.LogMessage(); got != wantLog {
+		t.Fatalf("LogMessage() = %q, want %q", got, wantLog)
+	}
+
+	const wantToast = "Configuration error: config read error: /etc/chairlift/config.yml: reading configuration file: permission denied. All feature groups are disabled. Fix the configuration file and restart ChairLift."
+	if got := loadErr.ToastMessage(); got != wantToast {
+		t.Fatalf("ToastMessage() = %q, want %q", got, wantToast)
+	}
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+var (
+	executablePath = os.Executable
+	workingDir     = os.Getwd
+	statPath       = os.Stat
+)
+
+// resolveCandidatePath returns the exact path loadFromPath will read and a
+// diagnostic will report. Relative candidates prefer a file alongside the
+// executable, preserving ChairLift's existing development behavior, then
+// fall back to an absolute path under the current working directory.
+func resolveCandidatePath(path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+
+	if executable, err := executablePath(); err == nil {
+		candidate := filepath.Join(filepath.Dir(executable), path)
+		if _, err := statPath(candidate); err == nil || !errors.Is(err, fs.ErrNotExist) {
+			return filepath.Clean(candidate)
+		}
+	}
+
+	if cwd, err := workingDir(); err == nil {
+		return filepath.Join(cwd, path)
+	}
+
+	// A failed Getwd leaves no absolute base to use. Keep the cleaned relative
+	// path so the subsequent read still returns a classified, actionable error.
+	return filepath.Clean(path)
+}

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func withPathResolutionSeams(
+	t *testing.T,
+	executable func() (string, error),
+	cwd func() (string, error),
+) {
+	t.Helper()
+	originalExecutablePath := executablePath
+	originalWorkingDir := workingDir
+	t.Cleanup(func() {
+		executablePath = originalExecutablePath
+		workingDir = originalWorkingDir
+	})
+	executablePath = executable
+	workingDir = cwd
+}
+
+func withStatPath(t *testing.T, stat func(string) (os.FileInfo, error)) {
+	t.Helper()
+	original := statPath
+	t.Cleanup(func() { statPath = original })
+	statPath = stat
+}
+
+func TestResolveCandidatePathBranches(t *testing.T) {
+	root := t.TempDir()
+	exeDir := filepath.Join(root, "bin")
+	cwd := filepath.Join(root, "work")
+	if err := os.MkdirAll(exeDir, 0o755); err != nil {
+		t.Fatalf("creating executable directory: %v", err)
+	}
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("creating working directory: %v", err)
+	}
+	executable := filepath.Join(exeDir, "chairlift")
+
+	t.Run("absolute input is cleaned", func(t *testing.T) {
+		withPathResolutionSeams(t,
+			func() (string, error) { return executable, nil },
+			func() (string, error) { return cwd, nil },
+		)
+		input := filepath.Join(root, "one", "..", "config.yml")
+		if got, want := resolveCandidatePath(input), filepath.Clean(input); got != want {
+			t.Fatalf("resolveCandidatePath(%q) = %q, want %q", input, got, want)
+		}
+	})
+
+	t.Run("executable-relative file wins", func(t *testing.T) {
+		withPathResolutionSeams(t,
+			func() (string, error) { return executable, nil },
+			func() (string, error) { return cwd, nil },
+		)
+		want := filepath.Join(exeDir, "config.yml")
+		if err := os.WriteFile(want, []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("writing executable-relative config: %v", err)
+		}
+		if got := resolveCandidatePath("config.yml"); got != want {
+			t.Fatalf("resolveCandidatePath(config.yml) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("missing executable-relative file uses cwd", func(t *testing.T) {
+		missingExeDir := filepath.Join(root, "missing-bin")
+		withPathResolutionSeams(t,
+			func() (string, error) { return filepath.Join(missingExeDir, "chairlift"), nil },
+			func() (string, error) { return cwd, nil },
+		)
+		want := filepath.Join(cwd, "config.yml")
+		if got := resolveCandidatePath("config.yml"); got != want {
+			t.Fatalf("resolveCandidatePath(config.yml) = %q, want %q", got, want)
+		}
+		if !filepath.IsAbs(want) {
+			t.Fatalf("cwd fallback %q is not absolute", want)
+		}
+	})
+
+	t.Run("inaccessible executable-relative file remains authoritative", func(t *testing.T) {
+		withPathResolutionSeams(t,
+			func() (string, error) { return executable, nil },
+			func() (string, error) { return cwd, nil },
+		)
+		withStatPath(t, func(path string) (os.FileInfo, error) {
+			return nil, &os.PathError{Op: "stat", Path: path, Err: fs.ErrPermission}
+		})
+		want := filepath.Join(exeDir, "config.yml")
+		if got := resolveCandidatePath("config.yml"); got != want {
+			t.Fatalf("resolveCandidatePath(config.yml) = %q, want inaccessible authoritative path %q", got, want)
+		}
+	})
+
+	t.Run("working-directory failure preserves cleaned relative path", func(t *testing.T) {
+		withPathResolutionSeams(t,
+			func() (string, error) { return "", errors.New("no executable") },
+			func() (string, error) { return "", errors.New("no working directory") },
+		)
+		if got, want := resolveCandidatePath("./config.yml"), "config.yml"; got != want {
+			t.Fatalf("resolveCandidatePath(./config.yml) = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestLoadFromPathReadsResolvedCandidate(t *testing.T) {
+	root := t.TempDir()
+	exeDir := filepath.Join(root, "bin")
+	cwd := filepath.Join(root, "work")
+	if err := os.MkdirAll(exeDir, 0o755); err != nil {
+		t.Fatalf("creating executable directory: %v", err)
+	}
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("creating working directory: %v", err)
+	}
+	withPathResolutionSeams(t,
+		func() (string, error) { return filepath.Join(exeDir, "chairlift"), nil },
+		func() (string, error) { return cwd, nil },
+	)
+
+	exeConfig := filepath.Join(exeDir, "config.yml")
+	cwdConfig := filepath.Join(cwd, "config.yml")
+	if err := os.WriteFile(exeConfig, []byte("system_page:\n  health_group:\n    app_id: exe\n"), 0o600); err != nil {
+		t.Fatalf("writing executable-relative config: %v", err)
+	}
+	if err := os.WriteFile(cwdConfig, []byte("system_page:\n  health_group:\n    app_id: cwd\n"), 0o600); err != nil {
+		t.Fatalf("writing cwd config: %v", err)
+	}
+
+	cfg, loadErr := loadFromPath("config.yml")
+	if loadErr != nil {
+		t.Fatalf("loadFromPath executable-relative candidate: %v", loadErr)
+	}
+	if got := cfg.SystemPage["health_group"].AppID; got != "exe" {
+		t.Fatalf("executable-relative AppID = %q, want %q", got, "exe")
+	}
+
+	if err := os.Remove(exeConfig); err != nil {
+		t.Fatalf("removing executable-relative config: %v", err)
+	}
+	cfg, loadErr = loadFromPath("config.yml")
+	if loadErr != nil {
+		t.Fatalf("loadFromPath cwd candidate: %v", loadErr)
+	}
+	if got := cfg.SystemPage["health_group"].AppID; got != "cwd" {
+		t.Fatalf("cwd AppID = %q, want %q", got, "cwd")
+	}
+}

--- a/internal/config/runtime_test.go
+++ b/internal/config/runtime_test.go
@@ -1,0 +1,294 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func withReadFile(t *testing.T, fn func(string) ([]byte, error)) {
+	t.Helper()
+	original := readFile
+	t.Cleanup(func() { readFile = original })
+	readFile = fn
+}
+
+func assertAllKnownGroupsDisabled(t *testing.T, got *Config) {
+	t.Helper()
+	pages, err := SchemaPages()
+	if err != nil {
+		t.Fatalf("SchemaPages(): %v", err)
+	}
+	if len(pages) == 0 {
+		t.Fatal("SchemaPages() returned no pages")
+	}
+
+	defaults := defaultConfig()
+	for _, page := range pages {
+		groups, err := SchemaGroups(page)
+		if err != nil {
+			t.Fatalf("SchemaGroups(%q): %v", page, err)
+		}
+		if len(groups) == 0 {
+			t.Fatalf("SchemaGroups(%q) returned no groups", page)
+		}
+		for _, group := range groups {
+			gotGroup := got.GetGroupConfig(page, group)
+			if gotGroup == nil {
+				t.Errorf("fail-closed config missing %s.%s", page, group)
+				continue
+			}
+			if gotGroup.Enabled {
+				t.Errorf("fail-closed config left %s.%s enabled", page, group)
+			}
+
+			wantGroup := defaults.GetGroupConfig(page, group)
+			if wantGroup == nil {
+				t.Errorf("default config missing canonical %s.%s", page, group)
+				continue
+			}
+			wantGroup.Enabled = false
+			if !reflect.DeepEqual(*gotGroup, *wantGroup) {
+				t.Errorf("fail-closed %s.%s = %+v, want defaults with Enabled=false: %+v",
+					page, group, *gotGroup, *wantGroup)
+			}
+		}
+	}
+}
+
+func TestLoadMissingHigherPriorityContinuesToValidCandidate(t *testing.T) {
+	dir := t.TempDir()
+	high := filepath.Join(dir, "missing.yml")
+	low := writeConfigFile(t, "system_page:\n  health_group:\n    enabled: false\n")
+	withConfigPaths(t, []string{high, low})
+
+	cfg, loadErr := Load()
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v, want nil", loadErr)
+	}
+	if cfg.SystemPage["health_group"].Enabled {
+		t.Fatal("lower-priority valid overlay was not loaded after absent candidate")
+	}
+}
+
+func TestLoadReadFailureStopsPrecedenceAndFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	high := filepath.Join(dir, "high.yml")
+	low := filepath.Join(dir, "low.yml")
+	withConfigPaths(t, []string{high, low})
+
+	var reads []string
+	withReadFile(t, func(path string) ([]byte, error) {
+		reads = append(reads, path)
+		switch path {
+		case high:
+			return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrPermission}
+		case low:
+			return []byte("system_page:\n  health_group:\n    enabled: true\n"), nil
+		default:
+			return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrNotExist}
+		}
+	})
+
+	cfg, loadErr := Load()
+	if loadErr == nil {
+		t.Fatal("Load() error = nil, want authoritative read failure")
+	}
+	if loadErr.Kind != KindRead {
+		t.Fatalf("Load() error kind = %q, want %q", loadErr.Kind, KindRead)
+	}
+	if loadErr.Path != high {
+		t.Fatalf("Load() error path = %q, want %q", loadErr.Path, high)
+	}
+	if !errors.Is(loadErr, fs.ErrPermission) {
+		t.Fatalf("errors.Is(%v, fs.ErrPermission) = false", loadErr)
+	}
+	if !reflect.DeepEqual(reads, []string{high}) {
+		t.Fatalf("read paths = %v, want only authoritative candidate %q", reads, high)
+	}
+	assertAllKnownGroupsDisabled(t, cfg)
+}
+
+func TestLoadInvalidAuthoritativeStopsPrecedenceAndFailsClosed(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		wantKind ErrorKind
+	}{
+		{
+			name:     "schema",
+			contents: "updates_pages:\n  brew_updates_group:\n    enabled: false\n",
+			wantKind: KindSchema,
+		},
+		{
+			name:     "parse-type",
+			contents: "system_page: [\n",
+			wantKind: KindParseType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			high := filepath.Join(dir, "high.yml")
+			low := filepath.Join(dir, "low.yml")
+			withConfigPaths(t, []string{high, low})
+
+			var reads []string
+			withReadFile(t, func(path string) ([]byte, error) {
+				reads = append(reads, path)
+				switch path {
+				case high:
+					return []byte(tt.contents), nil
+				case low:
+					return []byte("system_page:\n  health_group:\n    enabled: true\n"), nil
+				default:
+					return nil, &fs.PathError{Op: "open", Path: path, Err: fs.ErrNotExist}
+				}
+			})
+
+			cfg, loadErr := Load()
+			if loadErr == nil {
+				t.Fatal("Load() error = nil, want authoritative validation failure")
+			}
+			if loadErr.Kind != tt.wantKind {
+				t.Fatalf("Load() error kind = %q, want %q: %v", loadErr.Kind, tt.wantKind, loadErr)
+			}
+			if loadErr.Path != high {
+				t.Fatalf("Load() error path = %q, want %q", loadErr.Path, high)
+			}
+			if !reflect.DeepEqual(reads, []string{high}) {
+				t.Fatalf("read paths = %v, want only authoritative candidate %q", reads, high)
+			}
+			assertAllKnownGroupsDisabled(t, cfg)
+		})
+	}
+}
+
+func TestLoadFromPathRejectsUnknownSchemaName(t *testing.T) {
+	path := writeConfigFile(t, "not_a_page:\n  anything: true\n")
+	cfg, loadErr := loadFromPath(path)
+	if cfg != nil {
+		t.Fatalf("loadFromPath(%q) config = %+v, want nil", path, cfg)
+	}
+	if loadErr == nil || loadErr.Kind != KindSchema {
+		t.Fatalf("loadFromPath(%q) error = %v, want KindSchema", path, loadErr)
+	}
+	if loadErr.Path != path || !strings.Contains(loadErr.Detail, "not_a_page") {
+		t.Fatalf("loadFromPath(%q) error = %+v, want path and offending key", path, loadErr)
+	}
+}
+
+func TestLoadAuthoritativeFailureLogsHighSignalDiagnostic(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yml")
+	withConfigPaths(t, []string{path})
+	withReadFile(t, func(got string) ([]byte, error) {
+		return nil, &fs.PathError{Op: "open", Path: got, Err: fs.ErrPermission}
+	})
+
+	var output bytes.Buffer
+	originalOutput := log.Writer()
+	originalFlags := log.Flags()
+	originalPrefix := log.Prefix()
+	t.Cleanup(func() {
+		log.SetOutput(originalOutput)
+		log.SetFlags(originalFlags)
+		log.SetPrefix(originalPrefix)
+	})
+	log.SetOutput(&output)
+	log.SetFlags(0)
+	log.SetPrefix("")
+
+	_, loadErr := Load()
+	if loadErr == nil {
+		t.Fatal("Load() error = nil, want read failure")
+	}
+	got := output.String()
+	for _, want := range []string{
+		"CONFIGURATION ERROR",
+		path,
+		"permission denied",
+		"all feature groups were disabled",
+		"restart ChairLift",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("startup log %q does not contain %q", got, want)
+		}
+	}
+}
+
+func TestLoadAllCandidatesAbsentReturnsDefaultsWithoutError(t *testing.T) {
+	dir := t.TempDir()
+	withConfigPaths(t, []string{
+		filepath.Join(dir, "one.yml"),
+		filepath.Join(dir, "two.yml"),
+		filepath.Join(dir, "three.yml"),
+	})
+	withReadFile(t, func(path string) ([]byte, error) {
+		return nil, &fs.PathError{Op: "open", Path: path, Err: os.ErrNotExist}
+	})
+
+	cfg, loadErr := Load()
+	if loadErr != nil {
+		t.Fatalf("Load() error = %v, want nil", loadErr)
+	}
+	if !reflect.DeepEqual(cfg, defaultConfig()) {
+		t.Fatalf("Load() all-absent config = %+v, want built-in defaults %+v", cfg, defaultConfig())
+	}
+}
+
+func TestWindowConfigFailureWiringIsPersistent(t *testing.T) {
+	sourcePath := filepath.Join(repoRoot(), "internal", "window", "window.go")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+
+	text := string(source)
+	for _, required := range []string{
+		"config.Load()",
+		"configError:       configErr",
+		"w.ShowErrorToast(w.configError.ToastMessage())",
+		"toast.SetTimeout(0)",
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("window config-error wiring does not contain %q", required)
+		}
+	}
+}
+
+func TestConfigurationGuideExamplePassesStrictValidation(t *testing.T) {
+	guidePath := filepath.Join(repoRoot(), "CONFIG.md")
+	guide, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", guidePath, err)
+	}
+
+	const heading = "## Example: Disabling Homebrew Features"
+	afterHeading := string(guide)
+	headingIndex := strings.Index(afterHeading, heading)
+	if headingIndex < 0 {
+		t.Fatalf("%s does not contain %q", guidePath, heading)
+	}
+	afterHeading = afterHeading[headingIndex+len(heading):]
+	fenceStart := strings.Index(afterHeading, "```yaml")
+	if fenceStart < 0 {
+		t.Fatalf("%s example has no YAML fence", heading)
+	}
+	afterFence := afterHeading[fenceStart+len("```yaml"):]
+	fenceEnd := strings.Index(afterFence, "```")
+	if fenceEnd < 0 {
+		t.Fatalf("%s example has no closing fence", heading)
+	}
+
+	example := []byte(afterFence[:fenceEnd])
+	if _, loadErr := parseAndValidate(guidePath, example); loadErr != nil {
+		t.Fatalf("%s documented YAML is rejected by the runtime validator: %v", heading, loadErr)
+	}
+}

--- a/internal/config/sourcesurface_test.go
+++ b/internal/config/sourcesurface_test.go
@@ -45,6 +45,10 @@ import (
 //     docs/agents/skills/frozen-allowlist-authorization-is-per-entry-not-per-chunk.md.
 //     No other new production helper c1 adds may be added here; they are
 //     exercised only indirectly, through parseAndValidate.
+//   - resolveCandidatePath is the runtime-wiring slice's one direct-test
+//     authorization. Path resolution is observable security/diagnostic
+//     behavior and its executable/cwd branches are tested directly; all other
+//     runtime-loading helpers remain exercised through Load/loadFromPath.
 var directCallAllowlist = map[string]bool{
 	"parseYAMLDocument": true,
 
@@ -69,6 +73,8 @@ var directCallAllowlist = map[string]bool{
 	"effectiveKeyIdentity": true,
 
 	"parseAndValidate": true,
+
+	"resolveCandidatePath": true,
 }
 
 // packageGoFiles lists the *.go files directly in this package's directory
@@ -219,7 +225,7 @@ func TestSourceConfigExportedSurface(t *testing.T) {
 	assertExactNameSet(t, "exported funcs", funcs,
 		[]string{"Load", "SchemaActionFields", "SchemaGroupFields", "SchemaGroups", "SchemaPages"})
 	assertExactNameSet(t, "exported methods", methods,
-		[]string{"Config.GetGroupConfig", "Config.IsGroupEnabled", "LoadError.Error", "LoadError.Unwrap"})
+		[]string{"Config.GetGroupConfig", "Config.IsGroupEnabled", "LoadError.Error", "LoadError.LogMessage", "LoadError.ToastMessage", "LoadError.Unwrap"})
 	assertExactNameSet(t, "exported types", types,
 		[]string{"ActionConfig", "Config", "ErrorKind", "GroupConfig", "LoadError", "PageConfig"})
 	assertExactNameSet(t, "exported values", values,

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -177,32 +177,36 @@ func TestParseAndValidateMinimalMapping(t *testing.T) {
 	}
 }
 
-// TestParseAndValidateStaysOutOfRuntimeLoad proves, via go/ast over
-// internal/config/config.go, that neither Load nor loadFromPath's function
-// body references parseAndValidate: this chunk adds parseAndValidate as a
-// standalone capability without wiring it into the runtime config-loading
-// path.
-func TestParseAndValidateStaysOutOfRuntimeLoad(t *testing.T) {
+// TestRuntimeLoadUsesStrictValidator proves, via go/ast over config.go, that
+// the resolved-file loader calls parseAndValidate. This prevents a future
+// refactor from silently restoring permissive yaml.Unmarshal runtime loading.
+func TestRuntimeLoadUsesStrictValidator(t *testing.T) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "config.go", nil, 0)
 	if err != nil {
 		t.Fatalf("parsing config.go: %v", err)
 	}
 
+	foundLoader := false
 	for _, decl := range f.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
+		if !ok || fn.Body == nil || fn.Name.Name != "loadResolvedPath" {
 			continue
 		}
-		if fn.Name.Name != "Load" && fn.Name.Name != "loadFromPath" {
-			continue
-		}
+		foundLoader = true
+		foundValidator := false
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			if id, ok := n.(*ast.Ident); ok && id.Name == "parseAndValidate" {
-				t.Fatalf("%s references parseAndValidate, want it left unwired in this chunk", fn.Name.Name)
+				foundValidator = true
 			}
 			return true
 		})
+		if !foundValidator {
+			t.Fatal("loadResolvedPath does not reference parseAndValidate")
+		}
+	}
+	if !foundLoader {
+		t.Fatal("config.go has no loadResolvedPath function")
 	}
 }
 

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -37,6 +37,7 @@ type Window struct {
 	pages       map[string]*adw.ToolbarView
 	navRows     map[string]*adw.ActionRow // Store references to nav rows for badges
 	config      *config.Config
+	configError *config.LoadError
 	views       *views.UserHome
 	updateBadge *gtk.Button // Badge for updates count
 }
@@ -74,7 +75,7 @@ func init() {
 				o.Cast(&parent)
 
 				cfgStart := time.Now()
-				cfg := config.Load()
+				cfg, configErr := config.Load()
 				log.Printf("window: config loaded in %s", time.Since(cfgStart))
 
 				w := &Window{
@@ -82,6 +83,7 @@ func init() {
 					pages:             make(map[string]*adw.ToolbarView),
 					navRows:           make(map[string]*adw.ActionRow),
 					config:            cfg,
+					configError:       configErr,
 				}
 
 				reg.Pin(o, unsafe.Pointer(w))
@@ -89,6 +91,12 @@ func init() {
 				w.SetDefaultSize(900, 700)
 				w.SetTitle("ChairLift")
 				w.buildUI()
+				if w.configError != nil {
+					// OverrideConstructed and buildUI both run on GTK's main
+					// thread; the toast overlay now exists and timeout 0 makes
+					// this diagnostic persist until dismissed.
+					w.ShowErrorToast(w.configError.ToastMessage())
+				}
 				w.setupActions()
 
 				log.Printf("window: constructed in %s", time.Since(windowStart))

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -131,9 +131,11 @@ pointer means the file omitted (or explicitly nulled) that key, so
 key — including to an empty string or empty slice — so it replaces the
 default outright. This is why `maintenance_cleanup_group` stays disabled
 overall (and keeps its default `actions` entry) when a config file mentions
-the group only to flip an unrelated field, and why `Load()` falling back to
-`defaultConfig()` when no file is found or the file is unreadable/invalid
-preserves that same per-group default — it is never "all features enabled."
+the group only to flip an unrelated field. When every search candidate is
+absent, `Load()` returns `defaultConfig()`. An authoritative file that cannot
+be read or validated instead returns `disabledConfig()`: the same defaults
+for non-visibility fields, with every canonical group's `Enabled` field
+forced to false.
 
 **Structured load-error vocabulary (`internal/config/loaderror.go`).** A
 stable `ErrorKind` enumerates why loading/validating a config file could
@@ -186,29 +188,12 @@ YAML document, with a fixed cardinality outcome per input shape:
   error and line in `Err`/`Detail`, just like a malformed first document
   would.
 
-As of this writing `parseYAMLDocument`, `validateSourceGraph`,
-`resolveEffective`, and `parseAndValidate` (the four-stage entry point tying
-them together, described below alongside the schema inventory) are not
-wired into `Load()` or `loadFromPath()` — both are unchanged and still fall
-back to `defaultConfig()` on any read or parse failure, so there is no
-strict parsing and no fail-closed runtime behavior yet, and neither
-`resolveEffective`'s nor `parseAndValidate`'s output feeds ChairLift's
-strict schema validation either. This is the first of several package-private
-capabilities (document parsing, reachable source-graph shape validation,
-merge-operand shape validation, duplicate-explicit-key detection, the
-memoized alias-hop bound and the memoized source-node path-visit bound
-(both with all-paths line attribution), and now a validate-first
-alias/anchor-resolving, merge-precedence-resolving, bounded-output emitter
-with its own post-alias key-identity-collision rule) meant to
-eventually replace `loadFromPath()`'s current `yaml.Unmarshal` call with
-fail-closed, single-document, structurally validated loading — but none of
-that wiring exists yet, so `KindRead` still describes a capability the
-package's vocabulary anticipates but no code path yet reaches. `KindSchema`
-no longer belongs in that list:
-`parseAndValidate`'s page-level walk (described below) is the package's
-first code path that actually produces a `KindSchema` error — an unknown
-top-level page name — even though `Load()`/`loadFromPath()` still never call
-`parseAndValidate` and so never see it.
+These capabilities are now the runtime loading path:
+`Load`/`loadFromPath` → `loadResolvedPath` → `parseAndValidate` →
+`parseYAMLDocument`/`resolveEffective`/`validateSourceGraph`. Read failures
+produce `KindRead`; malformed or wrong-type YAML produces `KindParseType`;
+unknown schema names and invalid shapes produce `KindSchema`. No runtime
+load uses the old permissive `yaml.Unmarshal` path.
 
 **Exact merge-key recognition and tag normalization
 (`internal/config/sourcegraph.go`).** `isMergeKey(n *yaml.Node) bool` and
@@ -237,7 +222,8 @@ unit test (`TestMergeKeyRecognition`, `TestShortYAMLTagNormalization` in
 `sourcegraph_test.go`) rather than only exercising them through an exported
 entry point, per
 `docs/agents/skills/helper-functions-need-direct-test-calls.md`; neither
-helper is wired into any call path yet — that wiring is later work.
+helper is called directly by runtime loading, but both are reached indirectly
+through `resolveEffective` in the strict validator pipeline.
 
 **Reachable source-graph shape validation
 (`internal/config/sourcegraph.go`).** `validateSourceGraph(path string, doc
@@ -279,7 +265,8 @@ mapping's explicit keys must also be pairwise unique (see the duplicate-key
 paragraph below); the memoized 64-consecutive-alias-hop bound and the
 memoized 128-source-node-path-visit bound, both described below, now run
 as a second pass once these checks prove the graph acyclic.
-`validateSourceGraph` is not wired into any call path yet either.
+Runtime loading reaches `validateSourceGraph` through
+`parseAndValidate` → `resolveEffective`.
 
 **Merge-operand shape validation (`internal/config/sourcegraph.go`).**
 Layered onto the traversal above: every mapping entry whose key
@@ -562,10 +549,9 @@ names any of them directly — `effective_test.go`, `effectivebound_test.go`,
 `effectivemerge_test.go`, and `effectiveidentity_test.go` exercise them
 only through `resolveEffective` itself, alongside `resolveEffective` and
 `effectiveKeyIdentity`, the two additions that allowlist authorizes.
-`resolveEffective` itself is still not yet wired into `Load()`,
-`loadFromPath()`, or ChairLift's strict schema validation — it remains a
-standalone capability, like `parseYAMLDocument` and `validateSourceGraph`
-before it.
+Runtime loading reaches `resolveEffective` only through
+`parseAndValidate`; its lower-level helpers remain encapsulated behind that
+validator entry point.
 
 **Reachable inventory, all-paths line attribution, and the 64
 consecutive-alias-hop and 128-source-node-path-visit bounds
@@ -689,11 +675,9 @@ it (ignoring only that pointer-vs-value difference and `omitempty`) — so
 `SchemaActionFields()` reads `ActionConfig`'s yaml tags directly, since
 `ActionConfig` has no raw/pointer mirror. Both return a freshly allocated
 slice on every call and report an empty or duplicate field name as an error,
-never a panic, `log.Fatal`, or `os.Exit`. As of this writing no production
-code path — neither `Load()`/`loadFromPath()` nor any runtime diagnostic —
-consumes this inventory yet, and this slice adds no strict parsing and no
-unknown-key rejection; `Load()` still falls back to `defaultConfig()` on any
-read or parse failure. The inventory exists for a later change to build on.
+never a panic, `log.Fatal`, or `os.Exit`. `parseAndValidate` consumes this
+inventory in production, so unknown pages, groups, and fields are rejected by
+the runtime loader rather than silently ignored.
 
 **The four-stage validator entry point (`internal/config/validate.go`).**
 `parseAndValidate(path string, data []byte) (*rawConfig, *LoadError)` is the
@@ -792,21 +776,16 @@ added only to `defaultConfig()`'s map (with no corresponding struct field)
 still changes the accepted schema, and a parity test keeps that map's keys
 from drifting out of sync with the fields the validator otherwise expects.
 
-**Interpretation I8: the validator is deliberately stricter than
-`mergePage`'s unknown-group tolerance.** `mergePage` (config.go) already
+**Interpretation I8: runtime validation precedes `mergePage`'s tolerant
+mechanics.** `mergePage` (config.go) mechanically
 tolerates a group name absent from `defaultConfig()` for a page: it
 synthesizes a zero `GroupConfig{Enabled: true}` as the merge base and
 proceeds, matching `IsGroupEnabled`'s "missing group -> enabled" fallback.
 `parseAndValidate`'s `validateGroupEntries`, by contrast, rejects that same
-unknown group name outright as `KindSchema` — it never reaches `mergePage`
-at all. These two behaviors diverge on the same input class, and that
-divergence is intentional and currently safe: `parseAndValidate` is not
-wired into `Load()`/`loadFromPath()` (see below), so `mergePage` is the only
-one of the two that any runtime config load actually exercises today. A
-future slice that wires `parseAndValidate` into runtime loading must resolve
-this divergence explicitly — either by loosening the validator to match
-`mergePage`'s tolerance or by tightening `mergePage`/`defaultConfig()` to
-match the validator — rather than leaving both behaviors live at once.
+unknown group name outright as `KindSchema`. Runtime loading always calls
+`parseAndValidate` before `mergeConfig`, so unrecognized groups can never
+reach `mergePage`; its tolerance remains useful only to package-internal
+callers operating on already trusted `rawConfig` values.
 
 Once both prior stages succeed, stage 3 classifies the effective document by
 its top-level node shape into exactly one of these outcomes:
@@ -939,8 +918,9 @@ its top-level node shape into exactly one of these outcomes:
   precisely so a merge onto `defaultConfig()` can tell "explicitly set to
   the zero value" apart from "key absent."
 
-Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
-`parseAndValidate` is the only addition this slice's authorization spends;
+Per the guarded `directCallAllowlist` in `sourcesurface_test.go`,
+`parseAndValidate` and `resolveCandidatePath` are the runtime entry helpers
+authorized for direct test calls;
 `validatorShapeError`, `validatorDecodeError`, `effectiveNodeLine`,
 `validatePageEntries`, `schemaKeyName`, `validatorSchemaError`,
 `validatorSchemaPagesError`, `validatorKeyShapeError`,
@@ -952,18 +932,35 @@ Per the frozen `directCallAllowlist` in `sourcesurface_test.go`,
 `validatorActionEntryShapeError`, `validateActionFieldEntries`,
 `actionFieldTypes`, and `validatorActionFieldTypesError` are all exercised
 only indirectly, through `parseAndValidate`, in `validate_test.go`.
-`parseAndValidate` itself is, like `parseYAMLDocument`, `validateSourceGraph`,
-and `resolveEffective` before it, still not wired into `Load()` or
-`loadFromPath()` — a `go/ast`-based test
-(`TestParseAndValidateStaysOutOfRuntimeLoad`) proves neither function's body
-references it, so this remains a standalone capability rather than a change
-in runtime behavior. Concretely: `Load()` and `loadFromPath()` are unchanged
-from before this slice; there is no strict runtime config validation and no
-fail-closed config loading — a malformed or schema-invalid config file still
-falls back silently to `defaultConfig()`, exactly as before; and there is no
-startup config-error log line and no config-error toast/notification
-surfaced anywhere in the UI. `parseAndValidate` is reachable only from tests
-in `internal/config` until a later issue-69 slice wires it in.
+
+**Runtime loading, precedence, and diagnostics
+(`internal/config/config.go`, `paths.go`, `diagnostic.go`).** `Load` resolves
+each configured candidate to the exact path it will read, then calls
+`loadResolvedPath`, which reads bytes, runs `parseAndValidate`, and only then
+merges the validated overlay onto `defaultConfig()`. A missing candidate
+(`errors.Is(err, fs.ErrNotExist)`) advances to the next search location. Any
+other read failure, or any parse/type/schema failure in the first file that
+exists, makes that file authoritative: lower-priority files are not read,
+`Load` returns `disabledConfig()` plus the structured `*LoadError`, and every
+canonical feature group is hidden while non-visibility defaults remain
+available. If all candidates are absent, the ordinary built-in defaults and
+a nil error are returned.
+
+`resolveCandidatePath` makes diagnostic paths deterministic and absolute when
+the operating system supplies a working directory: absolute candidates are
+cleaned; a relative candidate prefers a file beside the executable and
+otherwise resolves against the current working directory. Filesystem reads,
+the executable path, and the working directory have narrow package-level
+seams so precedence and permission failures are testable without relying on
+host permissions.
+
+On an authoritative failure, `LoadError.LogMessage` prefixes the full
+path-and-cause diagnostic with `CONFIGURATION ERROR`, states that all groups
+were disabled, and instructs the user to restart after fixing the file.
+`window.New` retains the same `LoadError`, builds the toast overlay, then calls
+`ShowErrorToast` with `LoadError.ToastMessage`. `ShowErrorToast` sets timeout
+zero, so the startup error remains visible instead of expiring; construction
+and the toast call both occur on the GTK main thread.
 
 ### Package manager wrapper pattern
 
@@ -1055,9 +1052,15 @@ Help page links are opened via `xdg-open` using `exec.Command`. The process is s
 
 1. `/etc/chairlift/config.yml` — system-wide (highest priority)
 2. `/usr/share/chairlift/config.yml` — package maintainer defaults
-3. `config.yml` — relative to executable (development)
+3. `config.yml` — beside the executable when present, otherwise relative to
+   the current working directory (development fallback)
 
-If no file is found, all features default to enabled (except `maintenance_cleanup_group` which defaults to disabled). See [CONFIG.md](../CONFIG.md) for the full reference.
+Only a missing candidate advances the search. The first existing candidate is
+authoritative; a read, parse, type, or schema error disables every feature
+group and produces both a high-signal log entry and a persistent toast. If no
+file is found, all features default to enabled except
+`maintenance_cleanup_group`, which defaults to disabled. See
+[CONFIG.md](../CONFIG.md) for the full reference.
 
 ### Config structure
 


### PR DESCRIPTION
## Summary

- wire the merged strict YAML/schema validator into runtime configuration loading
- treat only missing files as fall-through; fail closed on authoritative read, parse, type, or schema errors
- surface the resolved path and cause through a high-signal startup log and persistent UI toast
- document precedence and fail-closed behavior across the configuration references

## Adversarial review

- correctness: covered missing, permission, malformed YAML, unknown schema, precedence, path resolution, exhaustive group disabling, and the documented example
- security: verified no privileged command, PolicyKit, helper-path, or mutation boundary changed
- UI/compliance: verified the diagnostic is added after the toast overlay exists on the GTK main thread and remains persistent
- stability: repeated the config suite 20 times after the full CI mirror

## Validation

- make ci
- go test -count=20 ./internal/config
- git diff --check

Closes #69