### PR TITLE
Make keyboard navigation match sidebar behavior and wire F1 Help

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,13 @@ An agent must not break these:
   UI update marshals back to the GTK main thread via
   `snowkit`'s `sgtk.RunOnMainThread(...)`. Never touch a widget directly from a
   worker goroutine.
+- **Navigation behavior has one authority.** Page order, titles, icons, and
+  advertised/registered accelerators live in the pure
+  `internal/navigation` package. Mouse activation and window navigation
+  actions must both call `Window.navigateToPage`, which applies the complete
+  `navigation.Resolve` transition (selected row, visible child, title, and
+  collapsed-layout content reveal). Do not reintroduce a second page or
+  shortcut inventory in `internal/window` or `internal/app`.
 - **Config-driven visibility is real.** Any group can be disabled in config
   (`config.IsGroupEnabled(page, group)`), so its widgets may never be
   constructed. Code that runs after an async action must not assume a widget

--- a/README.md
+++ b/README.md
@@ -112,11 +112,24 @@ chairlift
 
 ### Main Sections
 
-1. **System**: Monitor system health and performance
-2. **Updates**: Stage bootc system updates, manage Homebrew updates and outdated packages, apply Flatpak updates, and trust Homebrew taps
-3. **Applications**: View installed packages, search for new ones, and install curated bundles
-4. **Maintenance**: System cleanup and maintenance tools (Homebrew, Flatpak, custom scripts)
-5. **Help**: Documentation and support resources (coming soon)
+1. **Applications**: View installed packages, search for new ones, and install curated bundles
+2. **Maintenance**: System cleanup and maintenance tools (Homebrew, Flatpak, custom scripts)
+3. **Updates**: Stage bootc system updates, manage Homebrew updates and outdated packages, apply Flatpak updates, and trust Homebrew taps
+4. **System**: Monitor deployment, health, and performance information
+5. **Features**: Enable, disable, and update configured system features
+6. **Help**: Documentation and support resources
+
+### Keyboard Shortcuts
+
+- `Alt+1` through `Alt+6`: open Applications, Maintenance, Updates, System,
+  Features, or Help respectively
+- `F1`: open Help
+- `Ctrl+?`: show the keyboard-shortcuts window
+- `Ctrl+Q`: quit
+
+Mouse and keyboard navigation have identical behavior in a collapsed window:
+selecting a destination reveals its content as well as updating the selected
+sidebar row and page title.
 
 ### Managing Packages
 
@@ -190,6 +203,7 @@ chairlift/
 ├── internal/
 │   ├── app/       # GObject-registered Application (adw.Application subtype)
 │   ├── window/    # Main window: NavigationSplitView, sidebar, content stack
+│   ├── navigation/ # Canonical pages, shortcuts, and headless transition logic
 │   ├── views/     # Page builders and event handlers (one file per page)
 │   ├── config/    # YAML config loading, feature group enablement
 │   ├── homebrew/  # Homebrew CLI wrapper (incl. tap trust)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/frostyard/chairlift/internal/bootc"
 	"github.com/frostyard/chairlift/internal/flatpak"
 	"github.com/frostyard/chairlift/internal/homebrew"
+	"github.com/frostyard/chairlift/internal/navigation"
 	"github.com/frostyard/chairlift/internal/updex"
 	"github.com/frostyard/chairlift/internal/views"
 	"github.com/frostyard/chairlift/internal/window"
@@ -119,14 +120,9 @@ func (a *Application) onActivate() {
 
 // setupKeyboardShortcuts sets up application-wide keyboard shortcuts
 func (a *Application) setupKeyboardShortcuts() {
-	a.SetAccelsForAction("app.quit", []string{"<Primary>q"})
-	a.SetAccelsForAction("win.show-shortcuts", []string{"<Primary>question"})
-	a.SetAccelsForAction("win.navigate-applications", []string{"<Alt>1"})
-	a.SetAccelsForAction("win.navigate-maintenance", []string{"<Alt>2"})
-	a.SetAccelsForAction("win.navigate-updates", []string{"<Alt>3"})
-	a.SetAccelsForAction("win.navigate-system", []string{"<Alt>4"})
-	a.SetAccelsForAction("win.navigate-features", []string{"<Alt>5"})
-	a.SetAccelsForAction("win.navigate-help", []string{"<Alt>6"})
+	for _, binding := range navigation.Bindings() {
+		a.SetAccelsForAction(binding.Action, binding.Accelerators)
+	}
 }
 
 // registerOptions registers command line options

--- a/internal/navigation/navigation.go
+++ b/internal/navigation/navigation.go
@@ -1,0 +1,115 @@
+// Package navigation owns ChairLift's canonical page and keyboard-shortcut
+// inventory plus the widget-free state transition for selecting a page.
+package navigation
+
+// Shortcut groups used by the shortcuts dialog.
+const (
+	GroupNavigation = "navigation"
+	GroupGeneral    = "general"
+)
+
+// Item describes one page in sidebar order.
+type Item struct {
+	Name        string
+	Title       string
+	Icon        string
+	Accelerator string
+	Display     string
+}
+
+// Shortcut describes one advertised and registered keyboard shortcut.
+type Shortcut struct {
+	Action      string
+	Accelerator string
+	Display     string
+	Title       string
+	Group       string
+}
+
+// Binding groups every accelerator registered for one application action.
+type Binding struct {
+	Action       string
+	Accelerators []string
+}
+
+// Transition is the complete UI state change for navigating to one page.
+type Transition struct {
+	SelectedIndex int
+	VisibleChild  string
+	Title         string
+	ShowContent   bool
+}
+
+var items = []Item{
+	{Name: "applications", Title: "Applications", Icon: "application-x-executable-symbolic", Accelerator: "<Alt>1", Display: "Alt+1"},
+	{Name: "maintenance", Title: "Maintenance", Icon: "emblem-system-symbolic", Accelerator: "<Alt>2", Display: "Alt+2"},
+	{Name: "updates", Title: "Updates", Icon: "software-update-available-symbolic", Accelerator: "<Alt>3", Display: "Alt+3"},
+	{Name: "system", Title: "System", Icon: "computer-symbolic", Accelerator: "<Alt>4", Display: "Alt+4"},
+	{Name: "features", Title: "Features", Icon: "application-x-addon-symbolic", Accelerator: "<Alt>5", Display: "Alt+5"},
+	{Name: "help", Title: "Help", Icon: "help-browser-symbolic", Accelerator: "<Alt>6", Display: "Alt+6"},
+}
+
+var generalShortcuts = []Shortcut{
+	{Action: "win.show-shortcuts", Accelerator: "<Primary>question", Display: "Ctrl+?", Title: "Keyboard Shortcuts", Group: GroupGeneral},
+	{Action: "app.quit", Accelerator: "<Primary>q", Display: "Ctrl+Q", Title: "Quit", Group: GroupGeneral},
+	{Action: "win.navigate-help", Accelerator: "F1", Display: "F1", Title: "Help", Group: GroupGeneral},
+}
+
+// Items returns a copy of the canonical sidebar inventory.
+func Items() []Item {
+	return append([]Item(nil), items...)
+}
+
+// Shortcuts returns a copy of the canonical advertised shortcut inventory.
+func Shortcuts() []Shortcut {
+	result := make([]Shortcut, 0, len(items)+len(generalShortcuts))
+	for _, item := range items {
+		result = append(result, Shortcut{
+			Action:      "win.navigate-" + item.Name,
+			Accelerator: item.Accelerator,
+			Display:     item.Display,
+			Title:       "Go to " + item.Title,
+			Group:       GroupNavigation,
+		})
+	}
+	return append(result, generalShortcuts...)
+}
+
+// Bindings groups the canonical shortcuts by action for GTK registration.
+func Bindings() []Binding {
+	shortcuts := Shortcuts()
+	indexes := make(map[string]int, len(shortcuts))
+	bindings := make([]Binding, 0, len(shortcuts))
+	for _, shortcut := range shortcuts {
+		index, ok := indexes[shortcut.Action]
+		if !ok {
+			index = len(bindings)
+			indexes[shortcut.Action] = index
+			bindings = append(bindings, Binding{Action: shortcut.Action})
+		}
+		bindings[index].Accelerators = append(
+			bindings[index].Accelerators,
+			shortcut.Accelerator,
+		)
+	}
+	return bindings
+}
+
+// Resolve derives every state mutation needed to navigate to pageName.
+// It rejects unknown pages and pages the caller did not construct.
+func Resolve(pageName string, available func(string) bool) (Transition, bool) {
+	if available == nil || !available(pageName) {
+		return Transition{}, false
+	}
+	for index, item := range items {
+		if item.Name == pageName {
+			return Transition{
+				SelectedIndex: index,
+				VisibleChild:  item.Name,
+				Title:         item.Title,
+				ShowContent:   true,
+			}, true
+		}
+	}
+	return Transition{}, false
+}

--- a/internal/navigation/navigation_test.go
+++ b/internal/navigation/navigation_test.go
@@ -1,0 +1,155 @@
+package navigation
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolveCoversEveryNavigationMutation(t *testing.T) {
+	for index, item := range Items() {
+		t.Run(item.Name, func(t *testing.T) {
+			got, ok := Resolve(item.Name, func(name string) bool {
+				return name == item.Name
+			})
+			if !ok {
+				t.Fatalf("Resolve(%q) rejected an available canonical page", item.Name)
+			}
+			want := Transition{
+				SelectedIndex: index,
+				VisibleChild:  item.Name,
+				Title:         item.Title,
+				ShowContent:   true,
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Resolve(%q) = %#v, want %#v", item.Name, got, want)
+			}
+		})
+	}
+}
+
+func TestResolveRejectsUnavailableAndUnknownPages(t *testing.T) {
+	tests := []struct {
+		name      string
+		page      string
+		available func(string) bool
+	}{
+		{name: "unavailable", page: "help", available: func(string) bool { return false }},
+		{name: "unknown", page: "not-a-page", available: func(string) bool { return true }},
+		{name: "nil availability predicate", page: "help"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if transition, ok := Resolve(tt.page, tt.available); ok {
+				t.Fatalf("Resolve(%q) = %#v, true; want rejection", tt.page, transition)
+			}
+		})
+	}
+}
+
+func TestShortcutsRegisterEveryAdvertisedAccelerator(t *testing.T) {
+	advertised := make(map[string]Shortcut)
+	for _, shortcut := range Shortcuts() {
+		key := shortcut.Action + "\x00" + shortcut.Accelerator
+		if _, exists := advertised[key]; exists {
+			t.Fatalf("duplicate shortcut for action %q accelerator %q", shortcut.Action, shortcut.Accelerator)
+		}
+		advertised[key] = shortcut
+	}
+
+	registered := make(map[string]bool)
+	for _, binding := range Bindings() {
+		for _, accelerator := range binding.Accelerators {
+			registered[binding.Action+"\x00"+accelerator] = true
+		}
+	}
+	if len(registered) != len(advertised) {
+		t.Fatalf("registered shortcut count = %d, advertised count = %d", len(registered), len(advertised))
+	}
+	for key, shortcut := range advertised {
+		if !registered[key] {
+			t.Errorf("advertised shortcut %s (%s) is not registered", shortcut.Display, shortcut.Title)
+		}
+	}
+	for _, item := range Items() {
+		key := "win.navigate-" + item.Name + "\x00" + item.Accelerator
+		shortcut, ok := advertised[key]
+		if !ok {
+			t.Errorf("page %q has no advertised navigation shortcut", item.Name)
+			continue
+		}
+		if shortcut.Display != item.Display ||
+			shortcut.Title != "Go to "+item.Title ||
+			shortcut.Group != GroupNavigation {
+			t.Errorf("page %q shortcut = %#v, want canonical item metadata", item.Name, shortcut)
+		}
+	}
+
+	help, ok := advertised["win.navigate-help\x00F1"]
+	if !ok {
+		t.Fatal("F1 is not mapped to the Help navigation action")
+	}
+	if help.Display != "F1" || help.Title != "Help" || help.Group != GroupGeneral {
+		t.Fatalf("F1 shortcut = %#v, want advertised General/Help entry", help)
+	}
+}
+
+func TestReturnedInventoriesCannotMutateCanonicalState(t *testing.T) {
+	gotItems := Items()
+	gotItems[0].Name = "changed"
+	if Items()[0].Name == "changed" {
+		t.Fatal("Items returned mutable canonical storage")
+	}
+
+	gotShortcuts := Shortcuts()
+	gotShortcuts[0].Action = "changed"
+	if Shortcuts()[0].Action == "changed" {
+		t.Fatal("Shortcuts returned mutable canonical storage")
+	}
+
+	gotBindings := Bindings()
+	gotBindings[0].Accelerators[0] = "changed"
+	if Bindings()[0].Accelerators[0] == "changed" {
+		t.Fatal("Bindings returned mutable canonical storage")
+	}
+}
+
+func TestWindowAndAppUseCanonicalNavigation(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not locate navigation_test.go")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+
+	checks := map[string][]string{
+		filepath.Join(repoRoot, "internal", "window", "window.go"): {
+			`w.navigateToPage(name)`,
+			`transition, ok := navigation.Resolve(pageName, func(name string) bool {`,
+			`w.sidebarList.GetRowAtIndex(int32(transition.SelectedIndex))`,
+			`w.contentStack.SetVisibleChildName(transition.VisibleChild)`,
+			`w.contentPage.SetTitle(transition.Title)`,
+			`w.splitView.SetShowContent(transition.ShowContent)`,
+			`action := gio.NewSimpleAction("navigate-"+itemName, nil)`,
+			`for _, shortcut := range navigation.Shortcuts()`,
+		},
+		filepath.Join(repoRoot, "internal", "app", "app.go"): {
+			`for _, binding := range navigation.Bindings()`,
+			`a.SetAccelsForAction(binding.Action, binding.Accelerators)`,
+		},
+	}
+
+	for path, required := range checks {
+		source, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		for _, fragment := range required {
+			if !strings.Contains(string(source), fragment) {
+				t.Errorf("%s does not contain canonical navigation wiring %q", path, fragment)
+			}
+		}
+	}
+}

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -8,6 +8,7 @@ import (
 	"unsafe"
 
 	"github.com/frostyard/chairlift/internal/config"
+	"github.com/frostyard/chairlift/internal/navigation"
 	"github.com/frostyard/chairlift/internal/version"
 	"github.com/frostyard/chairlift/internal/views"
 
@@ -40,23 +41,6 @@ type Window struct {
 	configError *config.LoadError
 	views       *views.UserHome
 	updateBadge *gtk.Button // Badge for updates count
-}
-
-// NavItem represents a navigation item in the sidebar
-type NavItem struct {
-	Name  string
-	Title string
-	Icon  string
-}
-
-// navItems defines the sidebar navigation structure
-var navItems = []NavItem{
-	{Name: "applications", Title: "Applications", Icon: "application-x-executable-symbolic"},
-	{Name: "maintenance", Title: "Maintenance", Icon: "emblem-system-symbolic"},
-	{Name: "updates", Title: "Updates", Icon: "software-update-available-symbolic"},
-	{Name: "system", Title: "System", Icon: "computer-symbolic"},
-	{Name: "features", Title: "Features", Icon: "application-x-addon-symbolic"},
-	{Name: "help", Title: "Help", Icon: "help-browser-symbolic"},
 }
 
 func init() {
@@ -167,7 +151,7 @@ func (w *Window) buildSidebar() *adw.NavigationPage {
 	w.sidebarList.AddCssClass("navigation-sidebar")
 
 	// Add navigation items
-	for _, item := range navItems {
+	for _, item := range navigation.Items() {
 		row := w.createNavRow(item)
 		w.sidebarList.Append(&row.Widget)
 	}
@@ -190,7 +174,7 @@ func (w *Window) buildSidebar() *adw.NavigationPage {
 }
 
 // createNavRow creates a navigation row for the sidebar
-func (w *Window) createNavRow(item NavItem) *adw.ActionRow {
+func (w *Window) createNavRow(item navigation.Item) *adw.ActionRow {
 	row := adw.NewActionRow()
 	row.SetTitle(item.Title)
 	row.SetActivatable(true)
@@ -224,7 +208,8 @@ func (w *Window) buildContentArea() *adw.NavigationPage {
 	w.contentStack.SetTransitionType(gtk.StackTransitionTypeCrossfadeValue)
 
 	// Add pages to the stack
-	for _, item := range navItems {
+	items := navigation.Items()
+	for _, item := range items {
 		page := w.views.GetPage(item.Name)
 		if page != nil {
 			w.pages[item.Name] = page
@@ -234,17 +219,17 @@ func (w *Window) buildContentArea() *adw.NavigationPage {
 
 	// Create navigation page with initial title from first nav item
 	initialTitle := "Content"
-	if len(navItems) > 0 {
-		initialTitle = navItems[0].Title
+	if len(items) > 0 {
+		initialTitle = items[0].Title
 	}
 	w.contentPage = adw.NewNavigationPage(&w.contentStack.Widget, initialTitle)
 
 	// Select first item by default
-	if len(navItems) > 0 {
+	if len(items) > 0 {
 		firstRow := w.sidebarList.GetRowAtIndex(0)
 		if firstRow != nil {
 			w.sidebarList.SelectRow(firstRow)
-			w.contentStack.SetVisibleChildName(navItems[0].Name)
+			w.contentStack.SetVisibleChildName(items[0].Name)
 		}
 	}
 
@@ -265,19 +250,7 @@ func (w *Window) onSidebarRowActivated(row gtk.ListBoxRow) {
 		return
 	}
 
-	// Switch to the corresponding page
-	if _, ok := w.pages[name]; ok {
-		w.contentStack.SetVisibleChildName(name)
-		w.splitView.SetShowContent(true)
-
-		// Update the content page title
-		for _, item := range navItems {
-			if item.Name == name {
-				w.contentPage.SetTitle(item.Title)
-				break
-			}
-		}
-	}
+	w.navigateToPage(name)
 }
 
 // buildMenuButton creates the hamburger menu button
@@ -317,7 +290,7 @@ func (w *Window) setupActions() {
 	w.AddAction(aboutAction)
 
 	// Navigation actions
-	for _, item := range navItems {
+	for _, item := range navigation.Items() {
 		itemName := item.Name // Capture for closure
 		action := gio.NewSimpleAction("navigate-"+itemName, nil)
 		navActivateCb := func(action gio.SimpleAction, param uintptr) {
@@ -330,21 +303,21 @@ func (w *Window) setupActions() {
 
 // navigateToPage navigates to a specific page
 func (w *Window) navigateToPage(pageName string) {
-	if _, ok := w.pages[pageName]; ok {
-		w.contentStack.SetVisibleChildName(pageName)
-
-		// Select the corresponding row and update title
-		for i, item := range navItems {
-			if item.Name == pageName {
-				row := w.sidebarList.GetRowAtIndex(int32(i))
-				if row != nil {
-					w.sidebarList.SelectRow(row)
-				}
-				w.contentPage.SetTitle(item.Title)
-				break
-			}
-		}
+	transition, ok := navigation.Resolve(pageName, func(name string) bool {
+		_, exists := w.pages[name]
+		return exists
+	})
+	if !ok {
+		return
 	}
+
+	row := w.sidebarList.GetRowAtIndex(int32(transition.SelectedIndex))
+	if row != nil {
+		w.sidebarList.SelectRow(row)
+	}
+	w.contentStack.SetVisibleChildName(transition.VisibleChild)
+	w.contentPage.SetTitle(transition.Title)
+	w.splitView.SetShowContent(transition.ShowContent)
 }
 
 // onShowShortcuts shows the keyboard shortcuts window
@@ -383,23 +356,14 @@ func (w *Window) onShowShortcuts() {
 	navGroup := adw.NewPreferencesGroup()
 	navGroup.SetTitle("Navigation")
 
-	navShortcuts := []struct {
-		accel string
-		title string
-	}{
-		{"Alt+1", "Go to Applications"},
-		{"Alt+2", "Go to Maintenance"},
-		{"Alt+3", "Go to Updates"},
-		{"Alt+4", "Go to System"},
-		{"Alt+5", "Go to Features"},
-		{"Alt+6", "Go to Help"},
-	}
-
-	for _, s := range navShortcuts {
+	for _, shortcut := range navigation.Shortcuts() {
+		if shortcut.Group != navigation.GroupNavigation {
+			continue
+		}
 		row := adw.NewActionRow()
-		row.SetTitle(s.title)
+		row.SetTitle(shortcut.Title)
 
-		label := gtk.NewLabel(s.accel)
+		label := gtk.NewLabel(shortcut.Display)
 		label.AddCssClass("dim-label")
 		row.AddSuffix(&label.Widget)
 
@@ -412,20 +376,14 @@ func (w *Window) onShowShortcuts() {
 	generalGroup := adw.NewPreferencesGroup()
 	generalGroup.SetTitle("General")
 
-	generalShortcuts := []struct {
-		accel string
-		title string
-	}{
-		{"Ctrl+?", "Keyboard Shortcuts"},
-		{"Ctrl+Q", "Quit"},
-		{"F1", "Help"},
-	}
-
-	for _, s := range generalShortcuts {
+	for _, shortcut := range navigation.Shortcuts() {
+		if shortcut.Group != navigation.GroupGeneral {
+			continue
+		}
 		row := adw.NewActionRow()
-		row.SetTitle(s.title)
+		row.SetTitle(shortcut.Title)
 
-		label := gtk.NewLabel(s.accel)
+		label := gtk.NewLabel(shortcut.Display)
 		label.AddCssClass("dim-label")
 		row.AddSuffix(&label.Widget)
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -23,6 +23,7 @@ internal/views/                 Page builders and event handlers (one file per p
         │                       └── internal/views/featurestatus/ ┘ text, unit-tested headlessly
         │
         ├── internal/config/    YAML config loading, feature group enablement
+        ├── internal/navigation/ Canonical pages, shortcuts, and pure navigation transitions
         ├── internal/homebrew/  Homebrew CLI wrapper (JSON output parsing)
         ├── internal/flatpak/   Flatpak CLI wrapper (tabular output parsing)
         ├── internal/bootc/     bootc wrapper (status reads, pkexec stage script, line streaming)
@@ -33,7 +34,8 @@ internal/views/                 Page builders and event handlers (one file per p
 
 ### Dependency flow
 
-`cmd → app → window → views → {config, homebrew, flatpak, bootc, updex}`
+`cmd → app → window → views → {config, homebrew, flatpak, bootc, updex}`.
+`app` and `window` also depend on the pure `navigation` package.
 
 External shared library: `github.com/frostyard/snowkit` (published module, pinned in go.mod) provides:
 - `gobj` — GObject type registration and instance registry
@@ -1036,10 +1038,30 @@ Configurable maintenance scripts (from `config.yml` `actions` entries) are execu
 
 ### Keyboard shortcuts
 
-The window registers keyboard accelerators (`internal/window/window.go`):
+`internal/navigation` is the single puregotk-free authority for sidebar page
+order, titles, icons, advertised shortcuts, registered accelerators, and the
+complete page-selection transition. `internal/app` registers
+`navigation.Bindings()`, while the custom shortcuts dialog in
+`internal/window` renders `navigation.Shortcuts()`; the two surfaces therefore
+cannot advertise and register different keys.
+
+The canonical accelerators are:
+
 - `Ctrl+Q` → quit
 - `Ctrl+?` → show shortcuts dialog
 - `Alt+1` through `Alt+6` → navigate to each page (Applications, Maintenance, Updates, System, Features, Help)
+- `F1` → navigate to Help (the same `win.navigate-help` action as `Alt+6`)
+
+Mouse row activation and keyboard navigation actions both call
+`Window.navigateToPage`. That method calls `navigation.Resolve`, rejects a
+page that was not constructed, then applies all four successful outcomes:
+select the canonical sidebar row, set the stack's visible child, update the
+content-page title, and set `NavigationSplitView.show-content` true so a
+collapsed layout reveals the destination. `internal/navigation` tests every
+canonical page's index/title/visible-child/reveal result, unavailable and
+unknown rejection, the complete advertised-to-registered shortcut inventory,
+the F1 Help binding, and static app/window wiring. No `_test.go` is added to
+the puregotk-importing `internal/window` or `internal/app` packages.
 
 Note: `GtkShortcutsWindow` is not available in puregotk, so a custom `adw.Window` with `adw.PreferencesGroup` rows is used for the shortcuts dialog.
 


### PR DESCRIPTION
## Summary

- make page order, metadata, advertised shortcuts, and registered accelerators one canonical headless inventory
- route mouse activation and keyboard actions through the same complete navigation transition
- reveal content in collapsed layouts for Alt navigation and map F1 to Help
- add gated regression coverage for row selection, title, visible child, collapsed-state reveal, shortcut registration, and GTK wiring

## Adversarial review

- kept `internal/window` and `internal/app` test-free because both import puregotk
- placed all decidable behavior in `internal/navigation`, whose dependency graph contains no puregotk
- rejected unknown or unconstructed pages without mutating UI state
- checked that every advertised accelerator is registered, including both Alt+6 and F1 for Help
- changed no command execution or privilege-boundary code

## Validation

- `make ci`
- `go test -count=100 ./internal/navigation`

Closes #71