### PR TITLE
feat(navigation): omit empty configured pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,11 +63,15 @@ An agent must not break these:
   worker goroutine.
 - **Navigation behavior has one authority.** Page order, titles, icons, and
   advertised/registered accelerators live in the pure
-  `internal/navigation` package. Mouse activation and window navigation
-  actions must both call `Window.navigateToPage`, which applies the complete
-  `navigation.Resolve` transition (selected row, visible child, title, and
-  collapsed-layout content reveal). Do not reintroduce a second page or
-  shortcut inventory in `internal/window` or `internal/app`.
+  `internal/navigation` package. It also decides page visibility from static
+  group configuration: omit a functional page when all of its builder-backed
+  groups are disabled, always retain Help, and compact Alt+number over visible
+  pages. Mouse activation and window navigation actions must both call
+  `Window.navigateToPage`, which applies the complete `navigation.Resolve`
+  transition (visible-row index, visible child, title, and collapsed-layout
+  content reveal). The app and shortcuts dialog must use the window's same
+  visible inventory. Do not reintroduce a second page or shortcut inventory in
+  `internal/window` or `internal/app`.
 - **Homebrew update actions preserve known state.** Per-package upgrades and
   the top-level metadata update use `internal/views/actionstate` gates before
   spawning work. Failures and dry-run previews restore their controls without

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -30,6 +30,12 @@ page_name:
     enabled: true/false
 ```
 
+When every functional group on a page is disabled, that page is omitted from
+the sidebar, content stack, shortcuts dialog, and Alt+number bindings. The
+remaining Alt+number shortcuts compact in sidebar order. Help remains visible
+even when `help_resources_group` is disabled, so the application always has a
+valid page.
+
 ## Available Pages and Groups
 
 ### System Page (`system_page`)

--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ chairlift
 
 ### Keyboard Shortcuts
 
-- `Alt+1` through `Alt+6`: open Applications, Maintenance, Updates, System,
-  Features, or Help respectively
+- `Alt+1` through `Alt+N`: open the first through Nth visible page in sidebar
+  order. Pages whose configurable groups are all disabled are omitted, so the
+  numbers compact without gaps; Help is always retained.
 - `F1`: open Help
 - `Ctrl+?`: show the keyboard-shortcuts window
 - `Ctrl+Q`: quit

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,7 @@
 # ChairLift Configuration
 # This file controls which preference groups are shown in the application
-# Set "enabled: false" to hide a preference group on any page
+# Set "enabled: false" to hide a preference group on any page. A functional
+# page is omitted when all of its groups are disabled; Help is always retained.
 
 system_page:
   system_info_group:

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The UI is YAML-configuration-driven, making it portable to other Linux distribut
 
 ## Pages
 
-ChairLift organizes its functionality into six pages:
+ChairLift provides six configurable pages:
 
 | Page | Description |
 |------|-------------|
@@ -17,18 +17,17 @@ ChairLift organizes its functionality into six pages:
 | **Features** | Toggle system features managed by updex. |
 | **Help** | Links to the project website, issue tracker, and community chat. |
 
+A functional page is omitted when all of its groups are disabled. Help is
+always retained so the window always has a valid destination.
+
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
 | `Ctrl+Q` | Quit |
 | `Ctrl+?` | Show shortcuts dialog |
-| `Alt+1` | Applications |
-| `Alt+2` | Maintenance |
-| `Alt+3` | Updates |
-| `Alt+4` | System |
-| `Alt+5` | Features |
-| `Alt+6` | Help |
+| `Alt+1` … `Alt+N` | Open the first through Nth visible page in sidebar order; omitted pages leave no gaps |
+| `F1` | Help |
 
 ## Command-Line Flags
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -31,6 +31,11 @@ Groups with `enabled: false` are hidden from the UI. Missing entries inherit
 their built-in values. Unknown page, group, or field names and wrong field
 types are errors. Changes require restarting ChairLift.
 
+When every builder-backed group on a functional page is disabled, the page is
+also omitted from the sidebar, content stack, shortcuts dialog, and
+Alt+number bindings. Alt+number is compacted over the remaining pages in the
+order below. Help is always retained.
+
 ## Pages and Groups
 
 ### System Page (`system_page`)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -90,9 +90,6 @@ func New() *Application {
 		}
 	}
 
-	// Set up keyboard shortcuts
-	app.setupKeyboardShortcuts()
-
 	// Register command line options
 	app.registerOptions()
 
@@ -114,13 +111,14 @@ func (a *Application) onActivate() {
 	win := window.New(a.Application)
 	a.window = win
 	a.AddWindow(&win.Window)
+	a.setupKeyboardShortcuts(win.NavigationItems())
 	win.Present()
 	log.Printf("app: window presented in %s (since activate)", time.Since(activateStart))
 }
 
 // setupKeyboardShortcuts sets up application-wide keyboard shortcuts
-func (a *Application) setupKeyboardShortcuts() {
-	for _, binding := range navigation.Bindings() {
+func (a *Application) setupKeyboardShortcuts(items []navigation.Item) {
+	for _, binding := range navigation.Bindings(items) {
 		a.SetAccelsForAction(binding.Action, binding.Accelerators)
 	}
 }

--- a/internal/navigation/navigation.go
+++ b/internal/navigation/navigation.go
@@ -2,6 +2,8 @@
 // inventory plus the widget-free state transition for selecting a page.
 package navigation
 
+import "strconv"
+
 // Shortcut groups used by the shortcuts dialog.
 const (
 	GroupNavigation = "navigation"
@@ -15,6 +17,9 @@ type Item struct {
 	Icon        string
 	Accelerator string
 	Display     string
+	ConfigPage  string
+	Groups      []string
+	AlwaysShow  bool
 }
 
 // Shortcut describes one advertised and registered keyboard shortcut.
@@ -41,12 +46,70 @@ type Transition struct {
 }
 
 var items = []Item{
-	{Name: "applications", Title: "Applications", Icon: "application-x-executable-symbolic", Accelerator: "<Alt>1", Display: "Alt+1"},
-	{Name: "maintenance", Title: "Maintenance", Icon: "emblem-system-symbolic", Accelerator: "<Alt>2", Display: "Alt+2"},
-	{Name: "updates", Title: "Updates", Icon: "software-update-available-symbolic", Accelerator: "<Alt>3", Display: "Alt+3"},
-	{Name: "system", Title: "System", Icon: "computer-symbolic", Accelerator: "<Alt>4", Display: "Alt+4"},
-	{Name: "features", Title: "Features", Icon: "application-x-addon-symbolic", Accelerator: "<Alt>5", Display: "Alt+5"},
-	{Name: "help", Title: "Help", Icon: "help-browser-symbolic", Accelerator: "<Alt>6", Display: "Alt+6"},
+	{
+		Name:       "applications",
+		Title:      "Applications",
+		Icon:       "application-x-executable-symbolic",
+		ConfigPage: "applications_page",
+		Groups: []string{
+			"applications_installed_group",
+			"flatpak_user_group",
+			"flatpak_system_group",
+			"brew_group",
+			"brew_search_group",
+			"brew_bundles_group",
+		},
+	},
+	{
+		Name:       "maintenance",
+		Title:      "Maintenance",
+		Icon:       "emblem-system-symbolic",
+		ConfigPage: "maintenance_page",
+		Groups: []string{
+			"maintenance_cleanup_group",
+			"maintenance_brew_group",
+			"maintenance_flatpak_group",
+			"maintenance_optimization_group",
+		},
+	},
+	{
+		Name:       "updates",
+		Title:      "Updates",
+		Icon:       "software-update-available-symbolic",
+		ConfigPage: "updates_page",
+		Groups: []string{
+			"bootc_updates_group",
+			"flatpak_updates_group",
+			"brew_updates_group",
+			"brew_trust_group",
+		},
+	},
+	{
+		Name:       "system",
+		Title:      "System",
+		Icon:       "computer-symbolic",
+		ConfigPage: "system_page",
+		Groups: []string{
+			"system_info_group",
+			"bootc_status_group",
+			"health_group",
+		},
+	},
+	{
+		Name:       "features",
+		Title:      "Features",
+		Icon:       "application-x-addon-symbolic",
+		ConfigPage: "features_page",
+		Groups:     []string{"features_group"},
+	},
+	{
+		Name:       "help",
+		Title:      "Help",
+		Icon:       "help-browser-symbolic",
+		ConfigPage: "help_page",
+		Groups:     []string{"help_resources_group"},
+		AlwaysShow: true,
+	},
 }
 
 var generalShortcuts = []Shortcut{
@@ -55,15 +118,30 @@ var generalShortcuts = []Shortcut{
 	{Action: "win.navigate-help", Accelerator: "F1", Display: "F1", Title: "Help", Group: GroupGeneral},
 }
 
-// Items returns a copy of the canonical sidebar inventory.
+// Items returns a copy of the complete canonical sidebar inventory, with
+// accelerators assigned as though every page were visible.
 func Items() []Item {
-	return append([]Item(nil), items...)
+	return compact(items)
 }
 
-// Shortcuts returns a copy of the canonical advertised shortcut inventory.
-func Shortcuts() []Shortcut {
-	result := make([]Shortcut, 0, len(items)+len(generalShortcuts))
+// VisibleItems filters the canonical inventory using static group
+// configuration and compacts Alt+number accelerators over the result. Help is
+// always retained so the window always has a valid destination.
+func VisibleItems(enabled func(page, group string) bool) []Item {
+	visible := make([]Item, 0, len(items))
 	for _, item := range items {
+		if item.AlwaysShow || anyGroupEnabled(item, enabled) {
+			visible = append(visible, item)
+		}
+	}
+	return compact(visible)
+}
+
+// Shortcuts returns the advertised shortcuts for the supplied visible pages
+// plus the canonical general shortcuts.
+func Shortcuts(visible []Item) []Shortcut {
+	result := make([]Shortcut, 0, len(visible)+len(generalShortcuts))
+	for _, item := range visible {
 		result = append(result, Shortcut{
 			Action:      "win.navigate-" + item.Name,
 			Accelerator: item.Accelerator,
@@ -75,9 +153,10 @@ func Shortcuts() []Shortcut {
 	return append(result, generalShortcuts...)
 }
 
-// Bindings groups the canonical shortcuts by action for GTK registration.
-func Bindings() []Binding {
-	shortcuts := Shortcuts()
+// Bindings groups the shortcuts for the supplied visible pages by action for
+// GTK registration.
+func Bindings(visible []Item) []Binding {
+	shortcuts := Shortcuts(visible)
 	indexes := make(map[string]int, len(shortcuts))
 	bindings := make([]Binding, 0, len(shortcuts))
 	for _, shortcut := range shortcuts {
@@ -97,11 +176,11 @@ func Bindings() []Binding {
 
 // Resolve derives every state mutation needed to navigate to pageName.
 // It rejects unknown pages and pages the caller did not construct.
-func Resolve(pageName string, available func(string) bool) (Transition, bool) {
+func Resolve(pageName string, visible []Item, available func(string) bool) (Transition, bool) {
 	if available == nil || !available(pageName) {
 		return Transition{}, false
 	}
-	for index, item := range items {
+	for index, item := range visible {
 		if item.Name == pageName {
 			return Transition{
 				SelectedIndex: index,
@@ -112,4 +191,28 @@ func Resolve(pageName string, available func(string) bool) (Transition, bool) {
 		}
 	}
 	return Transition{}, false
+}
+
+func anyGroupEnabled(item Item, enabled func(page, group string) bool) bool {
+	if enabled == nil {
+		return false
+	}
+	for _, group := range item.Groups {
+		if enabled(item.ConfigPage, group) {
+			return true
+		}
+	}
+	return false
+}
+
+func compact(source []Item) []Item {
+	result := make([]Item, len(source))
+	for index, item := range source {
+		number := strconv.Itoa(index + 1)
+		item.Groups = append([]string(nil), item.Groups...)
+		item.Accelerator = "<Alt>" + number
+		item.Display = "Alt+" + number
+		result[index] = item
+	}
+	return result
 }

--- a/internal/navigation/navigation_test.go
+++ b/internal/navigation/navigation_test.go
@@ -5,14 +5,16 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func TestResolveCoversEveryNavigationMutation(t *testing.T) {
-	for index, item := range Items() {
+	items := Items()
+	for index, item := range items {
 		t.Run(item.Name, func(t *testing.T) {
-			got, ok := Resolve(item.Name, func(name string) bool {
+			got, ok := Resolve(item.Name, items, func(name string) bool {
 				return name == item.Name
 			})
 			if !ok {
@@ -43,7 +45,7 @@ func TestResolveRejectsUnavailableAndUnknownPages(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if transition, ok := Resolve(tt.page, tt.available); ok {
+			if transition, ok := Resolve(tt.page, Items(), tt.available); ok {
 				t.Fatalf("Resolve(%q) = %#v, true; want rejection", tt.page, transition)
 			}
 		})
@@ -51,8 +53,9 @@ func TestResolveRejectsUnavailableAndUnknownPages(t *testing.T) {
 }
 
 func TestShortcutsRegisterEveryAdvertisedAccelerator(t *testing.T) {
+	items := Items()
 	advertised := make(map[string]Shortcut)
-	for _, shortcut := range Shortcuts() {
+	for _, shortcut := range Shortcuts(items) {
 		key := shortcut.Action + "\x00" + shortcut.Accelerator
 		if _, exists := advertised[key]; exists {
 			t.Fatalf("duplicate shortcut for action %q accelerator %q", shortcut.Action, shortcut.Accelerator)
@@ -61,7 +64,7 @@ func TestShortcutsRegisterEveryAdvertisedAccelerator(t *testing.T) {
 	}
 
 	registered := make(map[string]bool)
-	for _, binding := range Bindings() {
+	for _, binding := range Bindings(items) {
 		for _, accelerator := range binding.Accelerators {
 			registered[binding.Action+"\x00"+accelerator] = true
 		}
@@ -74,7 +77,7 @@ func TestShortcutsRegisterEveryAdvertisedAccelerator(t *testing.T) {
 			t.Errorf("advertised shortcut %s (%s) is not registered", shortcut.Display, shortcut.Title)
 		}
 	}
-	for _, item := range Items() {
+	for _, item := range items {
 		key := "win.navigate-" + item.Name + "\x00" + item.Accelerator
 		shortcut, ok := advertised[key]
 		if !ok {
@@ -100,20 +103,177 @@ func TestShortcutsRegisterEveryAdvertisedAccelerator(t *testing.T) {
 func TestReturnedInventoriesCannotMutateCanonicalState(t *testing.T) {
 	gotItems := Items()
 	gotItems[0].Name = "changed"
+	gotItems[0].Groups[0] = "changed"
 	if Items()[0].Name == "changed" {
 		t.Fatal("Items returned mutable canonical storage")
 	}
+	if Items()[0].Groups[0] == "changed" {
+		t.Fatal("Items returned mutable canonical group storage")
+	}
 
-	gotShortcuts := Shortcuts()
+	gotShortcuts := Shortcuts(Items())
 	gotShortcuts[0].Action = "changed"
-	if Shortcuts()[0].Action == "changed" {
+	if Shortcuts(Items())[0].Action == "changed" {
 		t.Fatal("Shortcuts returned mutable canonical storage")
 	}
 
-	gotBindings := Bindings()
+	gotBindings := Bindings(Items())
 	gotBindings[0].Accelerators[0] = "changed"
-	if Bindings()[0].Accelerators[0] == "changed" {
+	if Bindings(Items())[0].Accelerators[0] == "changed" {
 		t.Fatal("Bindings returned mutable canonical storage")
+	}
+}
+
+func TestVisiblePagesOmitEveryFullyDisabledFunctionalPage(t *testing.T) {
+	for _, disabled := range Items() {
+		if disabled.AlwaysShow {
+			continue
+		}
+		t.Run(disabled.Name, func(t *testing.T) {
+			got := VisibleItems(func(page, group string) bool {
+				return page != disabled.ConfigPage
+			})
+			if containsPage(got, disabled.Name) {
+				t.Fatalf("VisibleItems retained %q when all of its groups were disabled", disabled.Name)
+			}
+			if !containsPage(got, "help") {
+				t.Fatal("VisibleItems omitted Help")
+			}
+		})
+	}
+}
+
+func TestPageMetadataCoversEveryBuilderBackedGroup(t *testing.T) {
+	want := map[string][]string{
+		"applications": {
+			"applications_installed_group",
+			"flatpak_user_group",
+			"flatpak_system_group",
+			"brew_group",
+			"brew_search_group",
+			"brew_bundles_group",
+		},
+		"maintenance": {
+			"maintenance_cleanup_group",
+			"maintenance_brew_group",
+			"maintenance_flatpak_group",
+			"maintenance_optimization_group",
+		},
+		"updates": {
+			"bootc_updates_group",
+			"flatpak_updates_group",
+			"brew_updates_group",
+			"brew_trust_group",
+		},
+		"system": {
+			"system_info_group",
+			"bootc_status_group",
+			"health_group",
+		},
+		"features": {"features_group"},
+		"help":     {"help_resources_group"},
+	}
+
+	items := Items()
+	if len(items) != len(want) {
+		t.Fatalf("Items() has %d pages, want %d", len(items), len(want))
+	}
+	for _, item := range items {
+		wantGroups, ok := want[item.Name]
+		if !ok {
+			t.Errorf("unexpected page metadata %q", item.Name)
+			continue
+		}
+		if !reflect.DeepEqual(item.Groups, wantGroups) {
+			t.Errorf("%s groups = %v, want %v", item.Name, item.Groups, wantGroups)
+		}
+	}
+}
+
+func TestVisiblePagesKeepEachBuilderBackedGroup(t *testing.T) {
+	for _, page := range Items() {
+		if page.AlwaysShow {
+			continue
+		}
+		for _, enabledGroup := range page.Groups {
+			t.Run(page.Name+"/"+enabledGroup, func(t *testing.T) {
+				got := VisibleItems(func(configPage, group string) bool {
+					return configPage == page.ConfigPage && group == enabledGroup
+				})
+				if !containsPage(got, page.Name) {
+					t.Fatalf("VisibleItems omitted %q when %q was enabled", page.Name, enabledGroup)
+				}
+			})
+		}
+	}
+}
+
+func TestVisiblePagesAlwaysKeepHelp(t *testing.T) {
+	got := VisibleItems(func(page, group string) bool { return false })
+	if len(got) != 1 || got[0].Name != "help" {
+		t.Fatalf("VisibleItems(all disabled) = %#v, want Help only", got)
+	}
+	if got[0].Accelerator != "<Alt>1" || got[0].Display != "Alt+1" {
+		t.Fatalf("Help shortcut = %q/%q, want compacted Alt+1", got[0].Accelerator, got[0].Display)
+	}
+}
+
+func TestVisiblePagesCompactShortcutsAndTransitions(t *testing.T) {
+	visible := VisibleItems(func(page, group string) bool {
+		return page == "updates_page" || page == "features_page"
+	})
+	wantNames := []string{"updates", "features", "help"}
+	if len(visible) != len(wantNames) {
+		t.Fatalf("VisibleItems selected %d pages, want %d: %#v", len(visible), len(wantNames), visible)
+	}
+	for index, wantName := range wantNames {
+		if visible[index].Name != wantName {
+			t.Fatalf("visible[%d].Name = %q, want %q", index, visible[index].Name, wantName)
+		}
+		wantAccelerator := "<Alt>" + strconv.Itoa(index+1)
+		if visible[index].Accelerator != wantAccelerator {
+			t.Errorf("visible[%d].Accelerator = %q, want %q", index, visible[index].Accelerator, wantAccelerator)
+		}
+		transition, ok := Resolve(wantName, visible, func(string) bool { return true })
+		if !ok {
+			t.Fatalf("Resolve(%q) rejected a visible page", wantName)
+		}
+		if transition.SelectedIndex != index {
+			t.Errorf("Resolve(%q).SelectedIndex = %d, want %d", wantName, transition.SelectedIndex, index)
+		}
+	}
+
+	shortcuts := Shortcuts(visible)
+	for index, item := range visible {
+		shortcut := shortcuts[index]
+		if shortcut.Action != "win.navigate-"+item.Name ||
+			shortcut.Accelerator != item.Accelerator ||
+			shortcut.Display != item.Display {
+			t.Errorf("shortcut[%d] = %#v, want compacted metadata for %#v", index, shortcut, item)
+		}
+	}
+
+	if transition, ok := Resolve("maintenance", visible, func(string) bool { return true }); ok {
+		t.Fatalf("Resolve accepted omitted Maintenance page: %#v", transition)
+	}
+
+	altBindings := make(map[string]string)
+	for _, binding := range Bindings(visible) {
+		if strings.HasPrefix(binding.Action, "win.navigate-") {
+			for _, accelerator := range binding.Accelerators {
+				if strings.HasPrefix(accelerator, "<Alt>") {
+					altBindings[accelerator] = binding.Action
+				}
+			}
+		}
+	}
+	if len(altBindings) != len(visible) {
+		t.Fatalf("Alt binding count = %d, want %d: %v", len(altBindings), len(visible), altBindings)
+	}
+	for _, item := range visible {
+		if got := altBindings[item.Accelerator]; got != "win.navigate-"+item.Name {
+			t.Errorf("%s is bound to %q, want navigate action for %q", item.Accelerator, got, item.Name)
+		}
 	}
 }
 
@@ -127,16 +287,18 @@ func TestWindowAndAppUseCanonicalNavigation(t *testing.T) {
 	checks := map[string][]string{
 		filepath.Join(repoRoot, "internal", "window", "window.go"): {
 			`w.navigateToPage(name)`,
-			`transition, ok := navigation.Resolve(pageName, func(name string) bool {`,
+			`w.navItems = navigation.VisibleItems(w.config.IsGroupEnabled)`,
+			`transition, ok := navigation.Resolve(pageName, w.navItems, func(name string) bool {`,
 			`w.sidebarList.GetRowAtIndex(int32(transition.SelectedIndex))`,
 			`w.contentStack.SetVisibleChildName(transition.VisibleChild)`,
 			`w.contentPage.SetTitle(transition.Title)`,
 			`w.splitView.SetShowContent(transition.ShowContent)`,
 			`action := gio.NewSimpleAction("navigate-"+itemName, nil)`,
-			`for _, shortcut := range navigation.Shortcuts()`,
+			`for _, shortcut := range navigation.Shortcuts(w.navItems)`,
 		},
 		filepath.Join(repoRoot, "internal", "app", "app.go"): {
-			`for _, binding := range navigation.Bindings()`,
+			`a.setupKeyboardShortcuts(win.NavigationItems())`,
+			`for _, binding := range navigation.Bindings(items)`,
 			`a.SetAccelsForAction(binding.Action, binding.Accelerators)`,
 		},
 	}
@@ -152,4 +314,13 @@ func TestWindowAndAppUseCanonicalNavigation(t *testing.T) {
 			}
 		}
 	}
+}
+
+func containsPage(items []Item, name string) bool {
+	for _, item := range items {
+		if item.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/window/window.go
+++ b/internal/window/window.go
@@ -41,6 +41,7 @@ type Window struct {
 	configError *config.LoadError
 	views       *views.UserHome
 	updateBadge *gtk.Button // Badge for updates count
+	navItems    []navigation.Item
 }
 
 func init() {
@@ -102,6 +103,8 @@ func New(app adw.Application) *Window {
 func (w *Window) buildUI() {
 	start := time.Now()
 
+	w.navItems = navigation.VisibleItems(w.config.IsGroupEnabled)
+
 	// Create views manager
 	w.views = views.New(w.config, w)
 	log.Printf("window: views built in %s", time.Since(start))
@@ -151,7 +154,7 @@ func (w *Window) buildSidebar() *adw.NavigationPage {
 	w.sidebarList.AddCssClass("navigation-sidebar")
 
 	// Add navigation items
-	for _, item := range navigation.Items() {
+	for _, item := range w.navItems {
 		row := w.createNavRow(item)
 		w.sidebarList.Append(&row.Widget)
 	}
@@ -208,7 +211,7 @@ func (w *Window) buildContentArea() *adw.NavigationPage {
 	w.contentStack.SetTransitionType(gtk.StackTransitionTypeCrossfadeValue)
 
 	// Add pages to the stack
-	items := navigation.Items()
+	items := w.navItems
 	for _, item := range items {
 		page := w.views.GetPage(item.Name)
 		if page != nil {
@@ -290,7 +293,7 @@ func (w *Window) setupActions() {
 	w.AddAction(aboutAction)
 
 	// Navigation actions
-	for _, item := range navigation.Items() {
+	for _, item := range w.navItems {
 		itemName := item.Name // Capture for closure
 		action := gio.NewSimpleAction("navigate-"+itemName, nil)
 		navActivateCb := func(action gio.SimpleAction, param uintptr) {
@@ -303,7 +306,7 @@ func (w *Window) setupActions() {
 
 // navigateToPage navigates to a specific page
 func (w *Window) navigateToPage(pageName string) {
-	transition, ok := navigation.Resolve(pageName, func(name string) bool {
+	transition, ok := navigation.Resolve(pageName, w.navItems, func(name string) bool {
 		_, exists := w.pages[name]
 		return exists
 	})
@@ -356,7 +359,7 @@ func (w *Window) onShowShortcuts() {
 	navGroup := adw.NewPreferencesGroup()
 	navGroup.SetTitle("Navigation")
 
-	for _, shortcut := range navigation.Shortcuts() {
+	for _, shortcut := range navigation.Shortcuts(w.navItems) {
 		if shortcut.Group != navigation.GroupNavigation {
 			continue
 		}
@@ -376,7 +379,7 @@ func (w *Window) onShowShortcuts() {
 	generalGroup := adw.NewPreferencesGroup()
 	generalGroup.SetTitle("General")
 
-	for _, shortcut := range navigation.Shortcuts() {
+	for _, shortcut := range navigation.Shortcuts(w.navItems) {
 		if shortcut.Group != navigation.GroupGeneral {
 			continue
 		}
@@ -398,6 +401,12 @@ func (w *Window) onShowShortcuts() {
 
 	dialog.SetContent(&toolbarView.Widget)
 	dialog.Present()
+}
+
+// NavigationItems returns the visible, compacted page inventory used by this
+// window. The application uses the same inventory to register accelerators.
+func (w *Window) NavigationItems() []navigation.Item {
+	return append([]navigation.Item(nil), w.navItems...)
 }
 
 // onShowAbout shows the about dialog

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -52,7 +52,9 @@ The `views.go` file defines the central `UserHome` struct that holds references 
 
 ### Pages
 
-The UI has six pages, each in its own file under `internal/views/`:
+The UI defines six pages, each in its own file under `internal/views/`. Static
+configuration may omit any functional page whose builder-backed groups are all
+disabled; Help is always retained:
 
 | Page | File | Purpose |
 |------|------|---------|
@@ -1041,28 +1043,35 @@ Configurable maintenance scripts (from `config.yml` `actions` entries) are execu
 
 `internal/navigation` is the single puregotk-free authority for sidebar page
 order, titles, icons, advertised shortcuts, registered accelerators, and the
-complete page-selection transition. `internal/app` registers
-`navigation.Bindings()`, while the custom shortcuts dialog in
-`internal/window` renders `navigation.Shortcuts()`; the two surfaces therefore
-cannot advertise and register different keys.
+complete page-selection transition. Its item metadata also maps every page to
+the groups that actually build content. `navigation.VisibleItems` filters that
+inventory using `Config.IsGroupEnabled`, always retains Help, and assigns
+compacted Alt+number keys. `internal/window` uses the result for its sidebar,
+stack, actions, initial selection, and shortcuts dialog. After construction,
+`internal/app` registers `navigation.Bindings(window.NavigationItems())`, so
+the registered and advertised keys use the exact same visible inventory.
 
-The canonical accelerators are:
+The accelerators are:
 
 - `Ctrl+Q` → quit
 - `Ctrl+?` → show shortcuts dialog
-- `Alt+1` through `Alt+6` → navigate to each page (Applications, Maintenance, Updates, System, Features, Help)
-- `F1` → navigate to Help (the same `win.navigate-help` action as `Alt+6`)
+- `Alt+1` through `Alt+N` → navigate to the first through Nth visible page in
+  canonical order, with omitted pages leaving no gaps
+- `F1` → navigate to Help (the same `win.navigate-help` action as Help's
+  current compacted Alt+number binding)
 
 Mouse row activation and keyboard navigation actions both call
-`Window.navigateToPage`. That method calls `navigation.Resolve`, rejects a
-page that was not constructed, then applies all four successful outcomes:
-select the canonical sidebar row, set the stack's visible child, update the
-content-page title, and set `NavigationSplitView.show-content` true so a
-collapsed layout reveals the destination. `internal/navigation` tests every
-canonical page's index/title/visible-child/reveal result, unavailable and
-unknown rejection, the complete advertised-to-registered shortcut inventory,
-the F1 Help binding, and static app/window wiring. No `_test.go` is added to
-the puregotk-importing `internal/window` or `internal/app` packages.
+`Window.navigateToPage`. That method calls `navigation.Resolve` against the
+visible inventory, rejects an omitted or unconstructed page, then applies all
+four successful outcomes: select the compacted sidebar row, set the stack's
+visible child, update the content-page title, and set
+`NavigationSplitView.show-content` true so a collapsed layout reveals the
+destination. `internal/navigation` tests every functional page with all of its
+groups disabled, each builder-backed group individually enabled, the Help-only
+fallback, compacted indices/accelerators, unavailable and unknown rejection,
+the complete advertised-to-registered shortcut inventory, the F1 Help
+binding, and static app/window wiring. No `_test.go` is added to the
+puregotk-importing `internal/window` or `internal/app` packages.
 
 Note: `GtkShortcutsWindow` is not available in puregotk, so a custom `adw.Window` with `adw.PreferencesGroup` rows is used for the shortcuts dialog.
 


### PR DESCRIPTION
## Summary

- derive the visible page inventory from static group configuration while always retaining Help
- use that same inventory for sidebar/stack construction, initial selection, window actions, compacted Alt+number bindings, and the shortcuts dialog
- cover every page's all-disabled case, every builder-backed group, Help-only fallback, omitted-page rejection, and compacted bindings in the puregotk-free navigation package
- update navigation and configuration documentation

`brew_bundles_group` is included in the Applications visibility decision because #8 has since added its real UI builder; this applies #63's builder-backed rule to the current source rather than the issue's now-stale pre-#8 example.

## Verification

- `go test ./internal/navigation -count=100`
- `make ci`

Closes #63
