### PR TITLE
docs: reconcile current behavior references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,10 @@ An agent must not break these:
 
 After any change to source code, update relevant documentation in `AGENTS.md`,
 `README.md`, and the `yeti/` folder. A task is not complete without reviewing
-and updating relevant documentation.
+and updating relevant documentation. For behavior, configuration, dependency,
+or install-layout changes, also follow
+`docs/documentation-consistency.md`; current-state claims must be checked
+against source/config/go.mod rather than copied from historical plans.
 
 **yeti/ directory** contains documentation written for AI consumption and
 context enhancement, not primarily for humans. Read `yeti/OVERVIEW.md` and

--- a/README-go-port.md
+++ b/README-go-port.md
@@ -1,5 +1,10 @@
 # ChairLift (Go/puregotk version)
 
+> **Historical document.** This file records the original Go-port proposal and
+> is not current build or installation guidance. ChairLift is now wholly Go
+> and puregotk-based. Use [README.md](README.md), [CONFIG.md](CONFIG.md), and
+> [docs/index.md](docs/index.md) for the maintained instructions.
+
 A modern GTK4/Libadwaita system management tool written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ remain test-binary-free because GTK libraries are unavailable on CI.
 ### Contributing
 
 Contributions are welcome! Please feel free to submit issues and pull requests.
+Changes that affect behavior, configuration, dependencies, or installation
+layout should also follow the
+[documentation consistency checklist](docs/documentation-consistency.md).
 
 ---
 

--- a/docs/documentation-consistency.md
+++ b/docs/documentation-consistency.md
@@ -1,0 +1,21 @@
+# Documentation Consistency Checklist
+
+Use this checklist whenever behavior, configuration, dependencies, or
+installation layout changes:
+
+- Compare documented page/group keys with `config.yml`, `Config`, and the
+  actual `IsGroupEnabled` guards. Run
+  `go test ./internal/config ./internal/navigation`.
+- Copy dependency versions from `go.mod`; do not retain a version claim from a
+  plan or release note.
+- Trace optional-tool visibility in the page builder and its async loader.
+  Distinguish static config-driven page omission from runtime group hiding,
+  unavailable placeholders, and visible error/status rows.
+- Check commands and installation destinations against `Makefile`,
+  `.goreleaser.yaml`, fixed helper constants, and PolicyKit annotations. Run a
+  `make -n install` dry run when installation text changes.
+- Treat `README-go-port.md` and files under `docs/plans/` and
+  `docs/superpowers/` as historical. Current-state claims belong in
+  `README.md`, `CONFIG.md`, `docs/index.md`, `docs/reference.md`, and `yeti/`.
+- Run `make ci`, then grep current-state documentation for the obsolete term,
+  key, version, or path that prompted the change.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,18 @@ always retained so the window always has a valid destination.
 
 ## Optional Dependencies
 
-ChairLift adapts to what is available on the system. Groups for unavailable tools are hidden automatically.
+Runtime visibility depends on the group:
+
+- bootc status/staging groups and unavailable Homebrew/Flatpak maintenance
+  groups are hidden when their tool-specific runtime gates fail;
+- the Homebrew untrusted-taps group stays hidden unless actionable taps exist;
+- Features replaces its main group with an explicit unavailable message when
+  Updex is not configured;
+- Applications and Updates groups for Homebrew and Flatpak remain visible and
+  report that the tool is unavailable.
+
+Page omission is separate and static: it depends only on which builder-backed
+groups configuration enables, not on runtime tool availability.
 
 | Tool | Used For |
 |------|----------|
@@ -65,7 +76,8 @@ Both are built with `CGO_ENABLED=0`.
 sudo make install
 ```
 
-Installs binaries, desktop file, icons, PolicyKit policies, and the updex helper to `PREFIX` (default `/usr/local`).
+Installs binaries, desktop file, icons, PolicyKit policies, and the updex helper
+to `PREFIX` (default `/usr`). PolicyKit integration requires that default.
 
 ### Development
 

--- a/internal/bootc/stage.go
+++ b/internal/bootc/stage.go
@@ -22,7 +22,6 @@ type EventType string
 
 const (
 	EventMessage  EventType = "message"
-	EventError    EventType = "error"
 	EventComplete EventType = "complete"
 )
 

--- a/internal/installcheck/documentation_test.go
+++ b/internal/installcheck/documentation_test.go
@@ -1,0 +1,101 @@
+package installcheck
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readRepoFile(t *testing.T, relative string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(RepoRoot(), relative))
+	if err != nil {
+		t.Fatalf("read %s: %v", relative, err)
+	}
+	return string(data)
+}
+
+func TestCurrentDocumentationMatchesSourceFacts(t *testing.T) {
+	t.Run("updex version comes from go.mod", func(t *testing.T) {
+		goMod := readRepoFile(t, "go.mod")
+		match := regexp.MustCompile(`(?m)^\s*github\.com/frostyard/updex\s+(v\S+)`).FindStringSubmatch(goMod)
+		if len(match) != 2 {
+			t.Fatal("go.mod does not contain a parseable github.com/frostyard/updex version")
+		}
+		overview := readRepoFile(t, filepath.Join("yeti", "OVERVIEW.md"))
+		want := "currently pinned to " + match[1] + " in go.mod"
+		if !strings.Contains(overview, want) {
+			t.Errorf("yeti/OVERVIEW.md does not contain %q", want)
+		}
+	})
+
+	t.Run("bootc event contract has no duplicate error event", func(t *testing.T) {
+		for _, path := range []string{
+			filepath.Join("internal", "bootc", "stage.go"),
+			filepath.Join("internal", "views", "updates_page.go"),
+			filepath.Join("yeti", "OVERVIEW.md"),
+			filepath.Join("yeti", "package-managers.md"),
+		} {
+			if strings.Contains(readRepoFile(t, path), "EventError") {
+				t.Errorf("%s still documents or implements removed EventError", path)
+			}
+		}
+	})
+
+	t.Run("historical port guide is marked", func(t *testing.T) {
+		if !strings.Contains(readRepoFile(t, "README-go-port.md"), "**Historical document.**") {
+			t.Error("README-go-port.md is not clearly marked historical")
+		}
+	})
+
+	t.Run("configuration fallback wording is consistent", func(t *testing.T) {
+		for _, path := range []string{
+			"README.md",
+			"CONFIG.md",
+			filepath.Join("docs", "reference.md"),
+		} {
+			document := readRepoFile(t, path)
+			for _, fact := range []string{
+				"beside the",
+				"executable",
+				"current working",
+				"development fallback",
+			} {
+				if !strings.Contains(document, fact) {
+					t.Errorf("%s does not describe %q", path, fact)
+				}
+			}
+		}
+	})
+
+	t.Run("optional visibility and install prefix are current", func(t *testing.T) {
+		index := readRepoFile(t, filepath.Join("docs", "index.md"))
+		if strings.Contains(index, "Groups for unavailable tools are hidden automatically") {
+			t.Error("docs/index.md retains the false uniform runtime-visibility claim")
+		}
+		if !strings.Contains(index, "default `/usr`") {
+			t.Error("docs/index.md does not document the /usr install default")
+		}
+	})
+
+	t.Run("known stale claims stay removed", func(t *testing.T) {
+		current := strings.Join([]string{
+			readRepoFile(t, "README.md"),
+			readRepoFile(t, "CONFIG.md"),
+			readRepoFile(t, filepath.Join("docs", "index.md")),
+			readRepoFile(t, filepath.Join("docs", "reference.md")),
+		}, "\n")
+		for _, stale := range []string{
+			"updates_status_group",
+			"Help page coming soon",
+			"Help is coming soon",
+			"Groups for unavailable tools are hidden automatically",
+		} {
+			if strings.Contains(current, stale) {
+				t.Errorf("current documentation still contains stale claim %q", stale)
+			}
+		}
+	})
+}

--- a/internal/views/updates_page.go
+++ b/internal/views/updates_page.go
@@ -607,14 +607,6 @@ func (uh *UserHome) onBootcStageClicked() {
 					msgRow.SetSubtitle(time.Now().Format("15:04:05"))
 					logExpander.AddRow(&msgRow.Widget)
 					activityRow.SetSubtitle(evt.Message)
-				case bootc.EventError:
-					errRow := adw.NewActionRow()
-					errRow.SetTitle(evt.Message)
-					errRow.SetSubtitle("Error")
-					errIcon := gtk.NewImageFromIconName("dialog-error-symbolic")
-					errRow.AddPrefix(&errIcon.Widget)
-					logExpander.AddRow(&errRow.Widget)
-					logExpander.SetExpanded(true)
 				case bootc.EventComplete:
 					activityRow.SetSubtitle("Complete")
 				}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -984,7 +984,10 @@ Each wrapper in `internal/` follows a consistent shape:
 `bootc.StageUpdate(ctx, progressCh)` runs `pkexec /usr/libexec/bootc-update-stage`, streaming combined stdout+stderr line-by-line to the caller's channel and closing it when done:
 1. Caller creates a `chan bootc.ProgressEvent` and passes it to `StageUpdate`
 2. Each non-empty output line becomes an `EventMessage`; the channel is closed after either an `EventComplete` (success) or the function returning an error
-3. Event types: `EventMessage`, `EventError`, `EventComplete` — deliberately simpler than a step/percent model because the stage script's own output is unstructured log lines, not a structured progress protocol
+3. Event types: `EventMessage` and `EventComplete` — deliberately simpler than
+   a step/percent model because the stage script's own output is unstructured
+   log lines, not a structured progress protocol. Failures return as errors;
+   they are not duplicated into the event stream.
 4. The view goroutine (`internal/views/updates_page.go`, `onBootcStageClicked`) reads events and dispatches UI updates to the main thread via `sgtk.RunOnMainThread`
 
 **Caller-visible outcomes.** Both context-taking bootc functions classify failures with `errors.Is` against the context sentinels (never `==` on `ctx.Err()`), and `bootc.Error` has an `Err error` field plus `Unwrap() error` so callers can tell them apart:
@@ -1000,7 +1003,7 @@ The deadline and cancellation messages differ in both functions, and neither eve
 
 ### bootc progress UI (updates page)
 
-`onBootcStageClicked()` (`internal/views/updates_page.go`) drives the "System Update" expander: it disables the button, spawns `bootc.StageUpdate` in a goroutine, and processes the `ProgressEvent` channel on a second goroutine — `EventMessage` lines are appended to a log expander with timestamps, `EventError` surfaces an error toast, and `EventComplete` re-queries `bootc.GetStatus` to refresh the staged/booted summary and re-enables the button. After `wg.Wait()` returns, the handler re-reads live `bootc.GetStatus()` and calls `uh.updateCounts.Set(badgestate.Bootc, 0|1)` plus `uh.updateBadgeCount()` unconditionally in both dry-run and live mode (this is a plain read, not a mutation, so it always reflects reality); it then sets `expander`'s subtitle from that same live read unconditionally as well, but shows `actionmsg.BootcStage(bootc.IsDryRun(), staged)` for the completion toast — an explicit preview string under dry-run rather than one of the "staged"/"up to date" strings that read as a verified completion claim about a click that, under dry-run, checked and changed nothing. The system page has a separate, simpler bootc path: `loadBootcStatus` (gated on `IsBootcBootedCached()`) calls `bootc.GetStatus` to show the booted/staged/rollback deployment images, versions, and digests, with no staging controls of its own — staging happens on the Updates page.
+`onBootcStageClicked()` (`internal/views/updates_page.go`) drives the "System Update" expander: it disables the button, spawns `bootc.StageUpdate` in a goroutine, and processes the `ProgressEvent` channel on a second goroutine — `EventMessage` lines are appended to a log expander with timestamps, and `EventComplete` marks the activity complete. A returned `stageErr` drives the error subtitle and toast after the stream closes; there is no duplicate error event. After `wg.Wait()` returns, the handler re-reads live `bootc.GetStatus()` and calls `uh.updateCounts.Set(badgestate.Bootc, 0|1)` plus `uh.updateBadgeCount()` unconditionally in both dry-run and live mode (this is a plain read, not a mutation, so it always reflects reality); it then sets `expander`'s subtitle from that same live read unconditionally as well, but shows `actionmsg.BootcStage(bootc.IsDryRun(), staged)` for the completion toast — an explicit preview string under dry-run rather than one of the "staged"/"up to date" strings that read as a verified completion claim about a click that, under dry-run, checked and changed nothing. The system page has a separate, simpler bootc path: `loadBootcStatus` (gated on `IsBootcBootedCached()`) calls `bootc.GetStatus` to show the booted/staged/rollback deployment images, versions, and digests, with no staging controls of its own — staging happens on the Updates page.
 
 ### Update badge tracking
 
@@ -1176,7 +1179,7 @@ page_name:
 |--------|---------|
 | `codeberg.org/puregotk/puregotk` | GTK4/Adwaita bindings (no CGO) |
 | `github.com/frostyard/snowkit` | GObject registration, main-thread dispatch |
-| `github.com/frostyard/updex` | Updex Go library for feature reads and helper binary (currently pinned to v1.2.3 in go.mod) |
+| `github.com/frostyard/updex` | Updex Go library for feature reads and helper binary (currently pinned to v1.3.0 in go.mod) |
 | `gopkg.in/yaml.v3` | YAML config parsing |
 | `golang.org/x/text` | Title-casing OS release info keys |
 

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -384,10 +384,12 @@ The deadline and cancellation messages differ, and neither surfaces as `signal: 
 ### Event types
 
 - `EventMessage` — one line of stage-script output
-- `EventError` — surfaced by the view layer when `StageUpdate` returns an error
 - `EventComplete` — sent once, after successful completion
 
-This is intentionally flatter than a step/percent progress model, because the stage script emits unstructured log lines, not a structured progress protocol.
+This is intentionally flatter than a step/percent progress model, because the
+stage script emits unstructured log lines, not a structured progress protocol.
+Failures are returned by `StageUpdate` and handled once by the view after the
+channel closes; there is no error event duplicating that path.
 
 ### Dry-run behavior
 
@@ -418,13 +420,12 @@ for event := range progressCh {
         switch evt.Type {
         case bootc.EventMessage:
             // append to log expander with timestamp
-        case bootc.EventError:
-            // show error toast
         case bootc.EventComplete:
-            // re-query GetStatus to refresh staged/booted summary
+            // mark streamed activity complete
         }
     })
 }
+// After the channel closes, handle the returned error or re-query GetStatus.
 ```
 
 ### Progress UI (`internal/views/updates_page.go`)


### PR DESCRIPTION
## Summary

- remove the unused `EventError` constant and unreachable view branch; bootc staging failures continue through the single returned-error path
- document actual per-group optional-tool visibility and the `/usr` installation default
- mark the obsolete Go-port guide as historical and update the pinned Updex version
- add a lightweight documentation-consistency checklist
- gate dependency versions, config fallback wording, historical labeling, runtime visibility, install prefix, known stale claims, and the bootc event contract

The previously listed `updates_status_group`, Help-page, and config-path contradictions were already corrected on current main; the new checks preserve those fixes.

## Verification

- affected packages repeated 100x
- `make ci`

Closes #74
