### PR TITLE
fix(packaging): install maintainer default config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -132,6 +132,9 @@ nfpms:
       # Desktop file
       - src: ./data/org.frostyard.ChairLift.desktop
         dst: /usr/share/applications/org.frostyard.ChairLift.desktop
+      # Package-maintainer defaults; never install into the administrator-owned /etc path
+      - src: ./config.yml
+        dst: /usr/share/chairlift/config.yml
       # Icons
       - src: ./data/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg
         dst: /usr/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,9 @@ The app builds pure-Go (`CGO_ENABLED=0`); the race detector needs CGO.
   the installed PolicyKit policy/rules files land where `polkitd` reads them
   (`/usr/share/polkit-1/{actions,rules.d}`) and the updex helper's installed
   path matches its fixed `pkexec` exec-path annotation (see the privilege
-  boundary invariant below).
+  boundary invariant below). It installs maintainer defaults at
+  `/usr/share/chairlift/config.yml` and must never install or overwrite the
+  administrator-owned `/etc/chairlift/config.yml`.
 
 CI (`.github/workflows/test.yml`) filters tests with `-run "^Test[^I]"
 -skip "Integration"`. That filter excludes *any* test whose name begins `TestI`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -7,12 +7,17 @@ ChairLift can be configured to show or hide specific feature groups, making it m
 ChairLift searches for the configuration file in the following locations (in order):
 
 1. `/etc/chairlift/config.yml` (system-wide configuration - highest priority)
-2. `/usr/share/chairlift/config.yml` (package maintainer defaults)
+2. `/usr/share/chairlift/config.yml` (package maintainer defaults installed by
+   source and nFPM packages)
 3. `config.yml` beside the ChairLift executable, or in the current working
    directory when no executable-relative file exists (development fallback)
 
 If no configuration file is found, all features default to enabled, except
 `maintenance_cleanup_group`, which defaults to disabled.
+
+Packages own and may replace the `/usr/share` defaults during an upgrade.
+Administrators should put local changes in `/etc/chairlift/config.yml`;
+ChairLift's install and packaging paths never create or overwrite that file.
 
 The first file that exists in this order is authoritative. ChairLift does not
 fall through to a lower-priority file when that file is unreadable, malformed,

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ BINDIR = $(PREFIX)/bin
 DATADIR = $(PREFIX)/share
 ICONSDIR = $(DATADIR)/icons
 APPLICATIONSDIR = $(DATADIR)/applications
+CONFIGDIR = $(DATADIR)/chairlift
 POLKITACTIONSDIR = $(DATADIR)/polkit-1/actions
 POLKITRULESDIR = $(DATADIR)/polkit-1/rules.d
 
@@ -101,6 +102,8 @@ install: build
 	install -Dm755 data/chairlift-wrapper.sh $(DESTDIR)$(BINDIR)/chairlift-wrapper
 	# Install desktop file
 	install -Dm644 data/org.frostyard.ChairLift.desktop $(DESTDIR)$(APPLICATIONSDIR)/org.frostyard.ChairLift.desktop
+	# Install package-maintainer defaults; /etc/chairlift/config.yml remains the administrator-owned override
+	install -Dm644 config.yml $(DESTDIR)$(CONFIGDIR)/config.yml
 	# Install icons
 	install -Dm644 data/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg $(DESTDIR)$(ICONSDIR)/hicolor/scalable/apps/org.frostyard.ChairLift.svg
 	install -Dm644 data/icons/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg $(DESTDIR)$(ICONSDIR)/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg
@@ -119,6 +122,7 @@ uninstall:
 	rm -f $(DESTDIR)$(BINDIR)/$(BINARY_NAME)
 	rm -f $(DESTDIR)$(BINDIR)/chairlift-wrapper
 	rm -f $(DESTDIR)$(APPLICATIONSDIR)/org.frostyard.ChairLift.desktop
+	rm -f $(DESTDIR)$(CONFIGDIR)/config.yml
 	rm -f $(DESTDIR)$(ICONSDIR)/hicolor/scalable/apps/org.frostyard.ChairLift.svg
 	rm -f $(DESTDIR)$(ICONSDIR)/hicolor/scalable/apps/org.frostyard.ChairLift-flower.svg
 	rm -f $(DESTDIR)$(ICONSDIR)/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ more restrictive, always-reprompting authentication rule). This also matches
 the layout used by ChairLift's own `.goreleaser.yaml` packages, so a source
 install and a packaged install end up identical.
 
+Both paths install package-maintainer configuration defaults at
+`/usr/share/chairlift/config.yml`. They never create or overwrite the
+administrator-owned `/etc/chairlift/config.yml` override.
+
 `PREFIX` can still be overridden (e.g. `make install PREFIX=$HOME/.local`)
 for a non-privileged, non-PolicyKit-integrated install — but the updex
 helper and bootc staging will not resolve to the fixed exec-path annotation

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,8 +76,12 @@ Both are built with `CGO_ENABLED=0`.
 sudo make install
 ```
 
-Installs binaries, desktop file, icons, PolicyKit policies, and the updex helper
-to `PREFIX` (default `/usr`). PolicyKit integration requires that default.
+Installs binaries, desktop file, icons, PolicyKit policies, the updex helper,
+and maintainer configuration defaults to `PREFIX` (default `/usr`). The
+maintainer configuration is installed at `/usr/share/chairlift/config.yml`;
+`/etc/chairlift/config.yml` is reserved for administrator overrides and is
+never created or overwritten by ChairLift's source or nFPM packages. PolicyKit
+integration requires the default prefix.
 
 ### Development
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -18,6 +18,12 @@ persistent toast with the path and cause. Fix the file and restart ChairLift.
 If no file is found, built-in defaults apply: all groups are enabled except
 `maintenance_cleanup_group`.
 
+Source and nFPM installs provide the repository's maintainer defaults at
+`/usr/share/chairlift/config.yml`. Package upgrades may replace that file.
+Administrators should put local changes in `/etc/chairlift/config.yml`, which
+has higher precedence and is never created or overwritten by ChairLift's
+packages.
+
 ## Format
 
 ```yaml

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -91,6 +91,7 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 		srcSuffix string
 		want      string
 	}{
+		{"maintainer config", "config.yml", "/usr/share/chairlift/config.yml"},
 		{"updex policy", "org.frostyard.ChairLift.updex.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy")},
 		{"updex rules", "org.frostyard.ChairLift.updex.rules", filepath.Join(polkitRulesDir, "org.frostyard.ChairLift.updex.rules")},
 		{"bootc policy", "org.frostyard.ChairLift.bootc.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy")},
@@ -107,9 +108,15 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 				t.Run(cc.name, func(t *testing.T) {
 					got := nfpmDst(t, nfpm, cc.srcSuffix)
 					if got != cc.want {
-						t.Errorf("nfpms[%d] contents dst for %s = %q, want %q (fixed PolicyKit read location)", i, cc.srcSuffix, got, cc.want)
+						t.Errorf("nfpms[%d] contents dst for %s = %q, want required package path %q", i, cc.srcSuffix, got, cc.want)
 					}
 				})
+			}
+
+			for _, content := range nfpm.Contents {
+				if content.Dst == "/etc/chairlift/config.yml" {
+					t.Errorf("nfpms[%d] packages administrator-owned /etc/chairlift/config.yml", i)
+				}
 			}
 		})
 	}

--- a/internal/installcheck/makefile_test.go
+++ b/internal/installcheck/makefile_test.go
@@ -42,13 +42,14 @@ func runMakeInstallDryRun(t *testing.T, destDir string, extraArgs ...string) str
 	return out.String()
 }
 
-// assertInstallsHelperAndPolicies checks that a `make -n install` dry-run's
+// assertInstallsPackageLayout checks that a `make -n install` dry-run's
 // output places the updex helper binary at DESTDIR+updex.HelperPath (cross-
 // referencing internal/updex.HelperPath as the single source of truth for
 // both the helper's installed directory and file name, per c1) and both
 // PolicyKit policy/rules pairs under DESTDIR + the fixed polkit-1
-// directories.
-func assertInstallsHelperAndPolicies(t *testing.T, output, destDir string) {
+// directories. It also requires the package-owned maintainer config under
+// /usr/share and rejects the administrator-owned /etc path.
+func assertInstallsPackageLayout(t *testing.T, output, destDir string) {
 	t.Helper()
 
 	wantHelper := filepath.Join("build", filepath.Base(updex.HelperPath)) +
@@ -65,8 +66,18 @@ func assertInstallsHelperAndPolicies(t *testing.T, output, destDir string) {
 	} {
 		want := filepath.Join(destDir, rel)
 		if !strings.Contains(output, want) {
-			t.Errorf("make -n install output does not target %q (fixed PolicyKit read location)\noutput:\n%s", want, output)
+			t.Errorf("make -n install output does not target required package path %q\noutput:\n%s", want, output)
 		}
+	}
+
+	maintainerConfig := filepath.Join(destDir, "/usr/share/chairlift/config.yml")
+	if want := "config.yml " + maintainerConfig; !strings.Contains(output, want) {
+		t.Errorf("make -n install output does not install config.yml at %q\nwant substring: %q\noutput:\n%s", maintainerConfig, want, output)
+	}
+
+	adminConfig := filepath.Join(destDir, "/etc/chairlift/config.yml")
+	if strings.Contains(output, adminConfig) {
+		t.Errorf("make install must not overwrite administrator config %q\noutput:\n%s", adminConfig, output)
 	}
 }
 
@@ -79,12 +90,12 @@ func TestMakefileInstallUsesUsrPrefix(t *testing.T) {
 	t.Run("default PREFIX", func(t *testing.T) {
 		destDir := t.TempDir()
 		out := runMakeInstallDryRun(t, destDir)
-		assertInstallsHelperAndPolicies(t, out, destDir)
+		assertInstallsPackageLayout(t, out, destDir)
 	})
 
 	t.Run("explicit PREFIX=/usr", func(t *testing.T) {
 		destDir := t.TempDir()
 		out := runMakeInstallDryRun(t, destDir, "PREFIX=/usr")
-		assertInstallsHelperAndPolicies(t, out, destDir)
+		assertInstallsPackageLayout(t, out, destDir)
 	})
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1101,7 +1101,8 @@ Help page links are opened via `xdg-open` using `exec.Command`. The process is s
 ### Config file search order
 
 1. `/etc/chairlift/config.yml` — system-wide (highest priority)
-2. `/usr/share/chairlift/config.yml` — package maintainer defaults
+2. `/usr/share/chairlift/config.yml` — package-maintainer defaults installed
+   by both source `make install` and nFPM packages
 3. `config.yml` — beside the executable when present, otherwise relative to
    the current working directory (development fallback)
 
@@ -1111,6 +1112,11 @@ group and produces both a high-signal log entry and a persistent toast. If no
 file is found, all features default to enabled except
 `maintenance_cleanup_group`, which defaults to disabled. See
 [CONFIG.md](../CONFIG.md) for the full reference.
+
+Both packaging paths own only the `/usr/share` candidate and may replace it on
+upgrade. Neither writes `/etc/chairlift/config.yml`; that higher-precedence
+path remains administrator-owned, so local policy is never overwritten by a
+ChairLift install or package update.
 
 ### Config structure
 

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -534,18 +534,21 @@ The Features page's per-feature switch (`onFeatureToggled`, `internal/views/feat
 
 ## Install-path consistency (`internal/installcheck`)
 
-Two installation paths ship this repository's privileged surface (the updex
-helper binary and both PolicyKit policy/rules pairs): a source `make install`
-(Makefile, `PREFIX` defaulting to `/usr`) and the packaged nFPM (deb/rpm/apk)
-layout goreleaser builds from `.goreleaser.yaml`. Both are hand-maintained
-text — a Makefile recipe and a YAML block — with no shared code path, so
-nothing stops them (or `internal/updex.HelperPath`, the fixed absolute path
-`pkexec` matches against the policy's `exec.path` annotation) from silently
-drifting apart again the way the Makefile's old `/usr/local` default drifted
-from the policy's `/usr/bin` in the bug this package now guards against.
+Two installation paths ship this repository's privileged surface and
+maintainer configuration: a source `make install` (Makefile, `PREFIX`
+defaulting to `/usr`) and the packaged nFPM (deb/rpm/apk) layout GoReleaser
+builds from `.goreleaser.yaml`. Both are hand-maintained text — a Makefile
+recipe and a YAML block — with no shared code path, so nothing stops them (or
+`internal/updex.HelperPath`, the fixed absolute path `pkexec` matches against
+the policy's `exec.path` annotation) from silently drifting apart.
 
-`internal/installcheck` holds five regression tests, not production code, that
-turn "verified by inspection" into a real, gated check. The first two guard the
+Both paths install the repository's `config.yml` as package-owned maintainer
+defaults at `/usr/share/chairlift/config.yml`. Neither path installs
+`/etc/chairlift/config.yml`: that higher-precedence path belongs to the
+administrator and must survive package installation and upgrades unchanged.
+
+`internal/installcheck` holds regression tests, not production code, that turn
+"verified by inspection" into real, gated checks. The first two guard the
 installed layout itself:
 
 - **`TestMakefileInstallUsesUsrPrefix`** runs `make -n install
@@ -554,7 +557,9 @@ installed layout itself:
   `PREFIX=/usr`, and asserts the printed `install -Dm...` lines place the
   updex helper at `DESTDIR` + `internal/updex.HelperPath` and both
   policy/rules pairs under `DESTDIR` + the fixed
-  `/usr/share/polkit-1/{actions,rules.d}` PolicyKit reads. It shells out to
+  `/usr/share/polkit-1/{actions,rules.d}` PolicyKit reads, installs maintainer
+  defaults at `DESTDIR/usr/share/chairlift/config.yml`, and never targets the
+  administrator-owned `/etc/chairlift/config.yml`. It shells out to
   the real `make` rather than parsing the Makefile textually because `make`
   itself is the authority on what a given `PREFIX`/`DESTDIR` combination
   actually resolves to (variable derivation, `$(DESTDIR)$(BINDIR)`
@@ -571,7 +576,10 @@ installed layout itself:
   `docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`),
   asserts each entry's `bindir` matches the directory of
   `internal/updex.HelperPath` and its updex/bootc policy+rules
-  `contents[].dst` entries equal those same fixed polkit-1 paths.
+  `contents[].dst` entries equal those same fixed polkit-1 paths. It also
+  requires every package to map the repository `config.yml` to
+  `/usr/share/chairlift/config.yml` and rejects any content entry targeting
+  `/etc/chairlift/config.yml`.
 
 Both tests fail — not skip — if `internal/updex.HelperPath`, the Makefile's
 `PREFIX` default, or `.goreleaser.yaml`'s `nfpms` block change independently


### PR DESCRIPTION
Closes #73

## Summary
- install package-owned defaults at `/usr/share/chairlift/config.yml` from both source and nFPM packages
- leave `/etc/chairlift/config.yml` exclusively administrator-owned
- gate both layouts and document ownership and precedence

## Validation
- `make ci`