### PR TITLE
feat(packaging): add system integration artifact

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -111,7 +111,12 @@ changelog:
       order: 9999
 
 nfpms:
-  - file_name_template: "{{ .ConventionalFileName }}"
+  # Self-contained system package: app plus privileged integration.
+  - id: chairlift
+    ids:
+      - chairlift
+      - chairlift-updex-helper
+    file_name_template: "{{ .ConventionalFileName }}"
     package_name: frostyard-chairlift
     # Both build ids' binaries (chairlift, chairlift-updex-helper) are
     # packaged automatically into bindir; do not add them as contents
@@ -121,6 +126,8 @@ nfpms:
       System management tool for bootc-based installations.
       Manage flatpaks, homebrew and system updates with a modern GTK4/Libadwaita interface.
     license: GPL-3.0-or-later
+    conflicts:
+      - frostyard-chairlift-system-integration
     contents:
       # Wrapper script
       - src: ./data/chairlift-wrapper.sh
@@ -133,6 +140,8 @@ nfpms:
       # Package-maintainer defaults; never install into the administrator-owned /etc path
       - src: ./config.yml
         dst: /usr/share/chairlift/config.yml
+        file_info:
+          mode: 0644
       # Icons
       - src: ./data/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg
         dst: /usr/share/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg
@@ -143,9 +152,47 @@ nfpms:
       # PolicyKit policy for bootc
       - src: ./data/org.frostyard.ChairLift.bootc.policy
         dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
+        file_info:
+          mode: 0644
       # PolicyKit policy for updex
       - src: ./data/org.frostyard.ChairLift.updex.policy
         dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.updex.policy
+        file_info:
+          mode: 0644
+    formats:
+      - deb
+      - rpm
+      - apk
+
+  # Root-owned companion for a user-scoped app installation such as the
+  # Homebrew cask. It intentionally retains ChairLift's fixed helper and
+  # PolicyKit paths. Distros enabling bootc staging must separately provide
+  # /usr/libexec/bootc-update-stage.
+  - id: chairlift-system-integration
+    ids:
+      - chairlift-updex-helper
+    file_name_template: "{{ .ConventionalFileName }}"
+    package_name: frostyard-chairlift-system-integration
+    bindir: /usr/bin
+    description: |-
+      System integration for a user-scoped ChairLift installation.
+      Installs the privileged updex helper, PolicyKit policies, and maintainer configuration defaults.
+    license: GPL-3.0-or-later
+    conflicts:
+      - frostyard-chairlift
+    contents:
+      - src: ./config.yml
+        dst: /usr/share/chairlift/config.yml
+        file_info:
+          mode: 0644
+      - src: ./data/org.frostyard.ChairLift.bootc.policy
+        dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy
+        file_info:
+          mode: 0644
+      - src: ./data/org.frostyard.ChairLift.updex.policy
+        dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.updex.policy
+        file_info:
+          mode: 0644
     formats:
       - deb
       - rpm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,11 @@ The app builds pure-Go (`CGO_ENABLED=0`); the race detector needs CGO.
   path matches its fixed `pkexec` exec-path annotation (see the privilege
   boundary invariant below). It installs maintainer defaults at
   `/usr/share/chairlift/config.yml` and must never install or overwrite the
-  administrator-owned `/etc/chairlift/config.yml`.
+  administrator-owned `/etc/chairlift/config.yml`. GoReleaser publishes both
+  the self-contained `frostyard-chairlift` package and the mutually exclusive
+  `frostyard-chairlift-system-integration` companion for user-scoped GUI
+  installs; every nFPM entry carrying policies must retain the same fixed
+  paths.
 
 CI (`.github/workflows/test.yml`) filters tests with `-run "^Test[^I]"
 -skip "Integration"`. That filter excludes *any* test whose name begins `TestI`
@@ -63,6 +67,14 @@ An agent must not break these:
   deliberately per-user and does **not** use pkexec. Do not add arbitrary
   privileged command execution, broaden what pkexec runs, or route new
   mutations around the fixed helper/policy pair.
+- **System-integration split.** The
+  `frostyard-chairlift-system-integration` nFPM package contains the fixed-path
+  updex helper, both PolicyKit policies, and package-maintainer config, but not
+  the GUI or a bootc staging implementation. Distributions pairing it with a
+  user-scoped ChairLift install must provide their trusted stage helper at
+  `/usr/libexec/bootc-update-stage` before enabling `bootc_updates_group`.
+  Do not make the privileged path configurable from ChairLift's user-writable
+  configuration.
 - **GTK main-thread safety.** All external tool calls run in goroutines; every
   UI update marshals back to the GTK main thread via
   `snowkit`'s `sgtk.RunOnMainThread(...)`. Never touch a widget directly from a

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -18,6 +18,8 @@ If no configuration file is found, all features default to enabled, except
 Packages own and may replace the `/usr/share` defaults during an upgrade.
 Administrators should put local changes in `/etc/chairlift/config.yml`;
 ChairLift's install and packaging paths never create or overwrite that file.
+The `frostyard-chairlift-system-integration` package also provides the
+`/usr/share` defaults for a user-scoped GUI installation.
 
 The first file that exists in this order is authoritative. ChairLift does not
 fall through to a lower-priority file when that file is unreadable, malformed,

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ against an `org.freedesktop.policykit.exec.argv1` annotation. Installing under
 any other prefix places those files where polkit never looks, so the privileged
 updex and bootc-staging features silently stop working (or fall back to a
 more restrictive, always-reprompting authentication rule). This also matches
-the layout used by ChairLift's own `.goreleaser.yaml` packages, so a source
-install and a packaged install end up identical.
+the layout used by ChairLift's full `frostyard-chairlift` nFPM package, so a
+source install and a full packaged install end up identical.
 
 ChairLift does not install passwordless PolicyKit rules. Bootc staging and
 updex writes use the policies' normal administrator-authentication defaults;
@@ -88,6 +88,20 @@ shape inside the privileged process.
 Both paths install package-maintainer configuration defaults at
 `/usr/share/chairlift/config.yml`. They never create or overwrite the
 administrator-owned `/etc/chairlift/config.yml` override.
+
+Releases also publish a small
+`frostyard-chairlift-system-integration` deb/rpm/apk for distributions that
+deliver the GUI through a user-scoped mechanism such as the Homebrew cask. It
+installs only the fixed `/usr/bin/chairlift-updex-helper`, both PolicyKit
+policies, and `/usr/share/chairlift/config.yml`; it does not install the GUI.
+The integration and full packages conflict intentionally because they own the
+same privileged files.
+
+The bootc policy deliberately retains the fixed
+`/usr/libexec/bootc-update-stage` path. A distribution must provide a trusted
+stage helper at exactly that path before enabling `bootc_updates_group`; the
+integration package does not provide a distro-specific staging implementation.
+ChairLift hides the group when the helper is absent.
 
 `PREFIX` can still be overridden (e.g. `make install PREFIX=$HOME/.local`)
 for a non-privileged, non-PolicyKit-integrated install — but the updex

--- a/config.bootc-example.yml
+++ b/config.bootc-example.yml
@@ -3,9 +3,11 @@
 # while keeping universal features enabled.
 #
 # To use this configuration:
-# 1. Copy this file to /etc/chairlift/config.yml
-# 2. Modify as needed for your distribution
-# 3. Restart ChairLift
+# 1. Install frostyard-chairlift-system-integration when the GUI is user-scoped
+# 2. Provide a trusted staging helper at /usr/libexec/bootc-update-stage
+# 3. Copy this file to /etc/chairlift/config.yml
+# 4. Modify as needed for your distribution
+# 5. Restart ChairLift
 
 system_page:
   system_info_group:
@@ -18,7 +20,7 @@ system_page:
 
 updates_page:
   bootc_updates_group:
-    enabled: true  # Show system updates
+    enabled: true  # Requires /usr/libexec/bootc-update-stage
   brew_updates_group:
     enabled: false  # Hide Homebrew updates (not typically used on other distros)
   brew_trust_group:
@@ -46,6 +48,10 @@ maintenance_page:
         sudo: true  # Whether the script requires administrator privileges
   maintenance_optimization_group:
     enabled: true  # Show optimization tools
+
+features_page:
+  features_group:
+    enabled: false  # Enable only when updex is configured for this distribution
 
 help_page:
   help_resources_group:

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,15 @@ maintainer configuration is installed at `/usr/share/chairlift/config.yml`;
 never created or overwritten by ChairLift's source or nFPM packages. PolicyKit
 integration requires the default prefix.
 
+For distributions that install the GUI through a user-scoped Homebrew cask,
+releases also provide a `frostyard-chairlift-system-integration` deb/rpm/apk.
+It installs the fixed-path updex helper, PolicyKit policies, and maintainer
+configuration without installing the GUI. It intentionally conflicts with the
+self-contained `frostyard-chairlift` package. Bootc staging additionally
+requires the distribution to provide its trusted implementation at
+`/usr/libexec/bootc-update-stage`; the integration package does not supply
+one.
+
 ### Development
 
 ```bash

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -60,7 +60,7 @@ order below. Help is always retained.
 
 | Group | Key | Description |
 |-------|-----|-------------|
-| bootc Updates | `bootc_updates_group` | Download and stage the next bootc system image update (applies on restart); shown only when bootc-booted and the `bootc-update-stage` script is present |
+| bootc Updates | `bootc_updates_group` | Download and stage the next bootc system image update (applies on restart); shown only when bootc-booted and the fixed `/usr/libexec/bootc-update-stage` helper is present. Non-Snow distributions must provide a trusted implementation there before enabling this group; ChairLift's system-integration package does not supply one. |
 | Flatpak Updates | `flatpak_updates_group` | Pending Flatpak application updates |
 | Homebrew Updates | `brew_updates_group` | Outdated Homebrew packages with upgrade buttons |
 | Untrusted Taps | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); trust a tap to resume its updates. Shown only when there is something to trust |

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -27,6 +28,11 @@ const wantSPDXLicense = "GPL-3.0-or-later"
 // edit here would silently redirect every generated release note.
 const wantHomepage = "https://github.com/frostyard/chairlift"
 
+const (
+	fullPackageName        = "frostyard-chairlift"
+	integrationPackageName = "frostyard-chairlift-system-integration"
+)
+
 // loadGoreleaserConfig parses the real, repo-root .goreleaser.yaml — not a
 // fixture or copy that could drift from the file goreleaser actually reads
 // — using the yaml.v3 dependency already vendored for internal/config.
@@ -46,18 +52,38 @@ func loadGoreleaserConfig(t *testing.T) GoreleaserConfig {
 	return cfg
 }
 
-// nfpmDst finds the contents[] entry whose src ends in srcSuffix and returns
-// its dst, failing the test if no such entry exists.
-func nfpmDst(t *testing.T, nfpm NfpmConfig, srcSuffix string) string {
+// nfpmContentBySuffix finds the contents[] entry whose src ends in srcSuffix,
+// failing the test if no such entry exists.
+func nfpmContentBySuffix(t *testing.T, nfpm NfpmConfig, srcSuffix string) NfpmContent {
 	t.Helper()
 
 	for _, c := range nfpm.Contents {
 		if strings.HasSuffix(c.Src, srcSuffix) {
-			return c.Dst
+			return c
 		}
 	}
 	t.Fatalf("no nfpm contents entry with src ending in %q", srcSuffix)
-	return ""
+	return NfpmContent{}
+}
+
+func nfpmDst(t *testing.T, nfpm NfpmConfig, srcSuffix string) string {
+	t.Helper()
+	return nfpmContentBySuffix(t, nfpm, srcSuffix).Dst
+}
+
+func nfpmByPackageName(t *testing.T, cfg GoreleaserConfig, packageName string) NfpmConfig {
+	t.Helper()
+
+	var matches []NfpmConfig
+	for _, nfpm := range cfg.Nfpms {
+		if nfpm.PackageName == packageName {
+			matches = append(matches, nfpm)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("nfpms entries with package_name %q = %d, want exactly 1", packageName, len(matches))
+	}
+	return matches[0]
 }
 
 // TestGoreleaserNfpmLayoutMatchesUsrPrefix parses the real .goreleaser.yaml
@@ -77,9 +103,9 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 		t.Fatal(".goreleaser.yaml has no nfpms entries")
 	}
 
-	// nFPM auto-packages both build ids' binaries (chairlift,
-	// chairlift-updex-helper) into bindir, so bindir alone determines where
-	// the packaged updex helper lands. It must match the directory of
+	// nFPM auto-packages each entry's selected build ids into bindir. Every
+	// current package selects chairlift-updex-helper, so bindir determines
+	// where its helper lands. It must match the directory of
 	// internal/updex.HelperPath — the fixed absolute path pkexec matches
 	// against the PolicyKit policy's exec.path annotation — not just a
 	// hardcoded "/usr/bin" literal, so this fails if either side changes
@@ -104,9 +130,12 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 
 			for _, cc := range contentChecks {
 				t.Run(cc.name, func(t *testing.T) {
-					got := nfpmDst(t, nfpm, cc.srcSuffix)
-					if got != cc.want {
-						t.Errorf("nfpms[%d] contents dst for %s = %q, want required package path %q", i, cc.srcSuffix, got, cc.want)
+					content := nfpmContentBySuffix(t, nfpm, cc.srcSuffix)
+					if content.Dst != cc.want {
+						t.Errorf("nfpms[%d] contents dst for %s = %q, want required package path %q", i, cc.srcSuffix, content.Dst, cc.want)
+					}
+					if content.FileInfo.Mode != 0o644 {
+						t.Errorf("nfpms[%d] contents mode for %s = %#o, want 0644", i, cc.srcSuffix, content.FileInfo.Mode)
 					}
 				})
 			}
@@ -120,6 +149,47 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGoreleaserPublishesSystemIntegrationPackage(t *testing.T) {
+	cfg := loadGoreleaserConfig(t)
+	full := nfpmByPackageName(t, cfg, fullPackageName)
+	integration := nfpmByPackageName(t, cfg, integrationPackageName)
+
+	if full.ID == "" || integration.ID == "" || full.ID == integration.ID {
+		t.Errorf("nFPM ids must be non-empty and unique: full=%q integration=%q", full.ID, integration.ID)
+	}
+	if want := []string{"chairlift", "chairlift-updex-helper"}; !reflect.DeepEqual(full.IDs, want) {
+		t.Errorf("%s ids = %v, want %v", fullPackageName, full.IDs, want)
+	}
+	if want := []string{"chairlift-updex-helper"}; !reflect.DeepEqual(integration.IDs, want) {
+		t.Errorf("%s ids = %v, want %v", integrationPackageName, integration.IDs, want)
+	}
+	if want := []string{integrationPackageName}; !reflect.DeepEqual(full.Conflicts, want) {
+		t.Errorf("%s conflicts = %v, want %v", fullPackageName, full.Conflicts, want)
+	}
+	if want := []string{fullPackageName}; !reflect.DeepEqual(integration.Conflicts, want) {
+		t.Errorf("%s conflicts = %v, want %v", integrationPackageName, integration.Conflicts, want)
+	}
+	for _, nfpm := range []NfpmConfig{full, integration} {
+		if want := []string{"deb", "rpm", "apk"}; !reflect.DeepEqual(nfpm.Formats, want) {
+			t.Errorf("%s formats = %v, want %v", nfpm.PackageName, nfpm.Formats, want)
+		}
+	}
+
+	wantIntegrationContents := map[string]string{
+		"config.yml":                           "/usr/share/chairlift/config.yml",
+		"org.frostyard.ChairLift.bootc.policy": filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy"),
+		"org.frostyard.ChairLift.updex.policy": filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy"),
+	}
+	if len(integration.Contents) != len(wantIntegrationContents) {
+		t.Errorf("%s contents has %d entries, want %d", integrationPackageName, len(integration.Contents), len(wantIntegrationContents))
+	}
+	for srcSuffix, wantDst := range wantIntegrationContents {
+		if got := nfpmDst(t, integration, srcSuffix); got != wantDst {
+			t.Errorf("%s contents dst for %s = %q, want %q", integrationPackageName, srcSuffix, got, wantDst)
+		}
 	}
 }
 

--- a/internal/installcheck/installcheck.go
+++ b/internal/installcheck/installcheck.go
@@ -64,19 +64,26 @@ type ReleaseConfig struct {
 	Footer string `yaml:"footer"`
 }
 
-// NfpmConfig is the subset of an nfpms[] entry relevant to install-location
-// and license consistency: where packaged binaries land (Bindir), where
-// explicitly listed files (policies, maintainer config, wrapper script,
-// icons, ...) land
-// (Contents), and the package's declared license (License).
+// NfpmConfig is the subset of an nfpms[] entry relevant to package identity,
+// build selection, conflicts, install locations, and license consistency.
 type NfpmConfig struct {
-	Bindir   string        `yaml:"bindir"`
-	License  string        `yaml:"license"`
-	Contents []NfpmContent `yaml:"contents"`
+	ID          string        `yaml:"id"`
+	PackageName string        `yaml:"package_name"`
+	IDs         []string      `yaml:"ids"`
+	Bindir      string        `yaml:"bindir"`
+	License     string        `yaml:"license"`
+	Conflicts   []string      `yaml:"conflicts"`
+	Contents    []NfpmContent `yaml:"contents"`
+	Formats     []string      `yaml:"formats"`
 }
 
 // NfpmContent is one nfpm contents[] entry's source/destination pair.
 type NfpmContent struct {
-	Src string `yaml:"src"`
-	Dst string `yaml:"dst"`
+	Src      string       `yaml:"src"`
+	Dst      string       `yaml:"dst"`
+	FileInfo NfpmFileInfo `yaml:"file_info"`
+}
+
+type NfpmFileInfo struct {
+	Mode uint32 `yaml:"mode"`
 }

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1052,6 +1052,24 @@ system facts, not values ChairLift decides; the Makefile and
 `internal/updex.HelperPath` exist to conform to them, matching the layout
 `.goreleaser.yaml`'s nFPM packages already use.
 
+**System-integration delivery:** GoReleaser publishes two mutually exclusive
+package shapes. `frostyard-chairlift` is the existing self-contained package
+with both application binaries, desktop assets, maintainer config, and
+policies. `frostyard-chairlift-system-integration` is the root-owned companion
+for a user-scoped GUI delivery such as the Homebrew cask: its build filter
+contains only `chairlift-updex-helper`, and its contents contain the two
+policies plus `/usr/share/chairlift/config.yml`. The packages declare conflicts
+because they intentionally own the same privileged files.
+
+The integration package does **not** ship `bootc-update-stage`. That operation
+is distro policy, so an image that enables `bootc_updates_group` must provide a
+trusted implementation at the existing fixed
+`/usr/libexec/bootc-update-stage` path. Keeping the path fixed preserves the
+PolicyKit executable boundary; making it a user-writable config value would
+allow the GUI configuration to redirect a root execution. The page already
+gates the group on `bootc.StageScriptAvailable`, so an absent distro helper
+hides the operation.
+
 ### Maintenance action execution
 
 Configurable maintenance scripts (from `config.yml` `actions` entries) are executed via `runMaintenanceAction()` in `internal/views/maintenance_page.go`. The pattern:

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -534,11 +534,11 @@ The Features page's per-feature switch (`onFeatureToggled`, `internal/views/feat
 
 ## Install-path consistency (`internal/installcheck`)
 
-Two installation paths ship this repository's privileged surface and
-maintainer configuration: a source `make install` (Makefile, `PREFIX`
-defaulting to `/usr`) and the packaged nFPM (deb/rpm/apk) layout GoReleaser
-builds from `.goreleaser.yaml`. Both are hand-maintained text — a Makefile
-recipe and a YAML block — with no shared code path, so nothing stops them (or
+The source `make install` path (Makefile, `PREFIX` defaulting to `/usr`) and
+the two packaged nFPM (deb/rpm/apk) layouts GoReleaser builds from
+`.goreleaser.yaml` ship this repository's privileged surface and maintainer
+configuration. They are hand-maintained text — a Makefile recipe and YAML
+blocks — with no shared code path, so nothing stops them (or
 `internal/updex.HelperPath`, the fixed absolute path `pkexec` matches against
 the policy's `exec.path` annotation) from silently drifting apart.
 
@@ -550,10 +550,19 @@ obsolete tracked files. Both policies now use normal administrator
 authentication, while the updex policy selects one action for each supported
 first argument and the helper validates the complete argv shape.
 
-Both paths install the repository's `config.yml` as package-owned maintainer
-defaults at `/usr/share/chairlift/config.yml`. Neither path installs
+All three layouts install the repository's `config.yml` as package-owned
+maintainer defaults at `/usr/share/chairlift/config.yml`. None installs
 `/etc/chairlift/config.yml`: that higher-precedence path belongs to the
 administrator and must survive package installation and upgrades unchanged.
+
+GoReleaser has two nFPM entries. `frostyard-chairlift` is self-contained and
+selects both `chairlift` and `chairlift-updex-helper` builds.
+`frostyard-chairlift-system-integration` selects only the helper and packages
+only maintainer config plus the bootc/updex policies, for pairing with a
+user-scoped app installation. The two package names conflict to prevent
+simultaneous ownership of the same fixed system files. The companion does not
+provide `/usr/libexec/bootc-update-stage`; a distro must bake its own trusted
+implementation at that exact policy-annotated path.
 
 `internal/installcheck` holds regression tests, not production code, that turn
 "verified by inspection" into real, gated checks. The first two guard the
@@ -585,10 +594,16 @@ installed layout itself:
   `docs/agents/skills/regression-tests-must-cover-every-collection-entry.md`),
   asserts each entry's `bindir` matches the directory of
   `internal/updex.HelperPath`, its updex/bootc policy `contents[].dst` entries
-  equal the fixed polkit-1 actions paths, and no `.rules` content remains. It also
-  requires every package to map the repository `config.yml` to
+  equal the fixed polkit-1 actions paths, their policy/config modes remain
+  `0644`, and no `.rules` content remains. It also requires every package to
+  map the repository `config.yml` to
   `/usr/share/chairlift/config.yml` and rejects any content entry targeting
   `/etc/chairlift/config.yml`.
+- **`TestGoreleaserPublishesSystemIntegrationPackage`** requires exactly one
+  full package and one integration package, verifies their build filters,
+  mutual conflicts, unique IDs, and the integration package's exact three
+  content mappings. This prevents the companion from accidentally acquiring
+  the GUI binary or losing one of the root-owned integration files.
 
 Both tests fail — not skip — if `internal/updex.HelperPath`, the Makefile's
 `PREFIX` default, or `.goreleaser.yaml`'s `nfpms` block change independently


### PR DESCRIPTION
Closes #54

## Summary
- publish a mutually exclusive `frostyard-chairlift-system-integration` deb/rpm/apk for user-scoped GUI installs
- retain fixed privileged paths while packaging only the updex helper, policies, and maintainer defaults
- document the distro-owned `/usr/libexec/bootc-update-stage` contract and gate artifact shape in CI

## Validation
- `make ci`
- GoReleaser Pro v2.17.1 `check`
- full GoReleaser Pro snapshot produced both package families for amd64/arm64 across deb/rpm/apk
- inspected integration deb contents, metadata, conflict, and file modes