### PR TITLE
feat(homebrew): add typed cask search and installs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,12 @@ An agent must not break these:
   changing rows or counts. A live package success removes its row, decrements
   the count/badge, and refreshes; a failed refresh preserves that last known
   row/count state instead of replacing it with an invented zero.
+- **Homebrew application actions are typed and refresh-safe.** Search queries
+  both formula and cask namespaces and carries the result kind into
+  `brew install [--cask]`. Search and installed-package refreshes use separate
+  `actionstate.RefreshGate` generations; stale workers must not replace newer
+  rows. Confirmed installs use an `actionstate.Gate`, restore controls on
+  failure/dry-run, and refresh installed rows only after a live success.
 - **Update badge counts have one state owner.** Bootc, Flatpak, and Homebrew
   counts live in the pure `internal/views/badgestate` package. Refreshes
   replace a provider's count, successful row removals decrement without going

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -66,7 +66,7 @@ valid page.
 - `flatpak_user_group`: User-installed Flatpak applications
 - `flatpak_system_group`: System-wide Flatpak applications
 - `brew_group`: Installed Homebrew formulae and casks
-- `brew_search_group`: Search and install Homebrew packages
+- `brew_search_group`: Search and install Homebrew formulae and casks
 - `brew_bundles_group`: Curated Homebrew package bundles
   - `bundles_paths`: Array of directories searched for immediate
     `*.Brewfile` entries (default: `['/usr/share/snow/bundles']`). Missing

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 ### 📦 Homebrew Package Management
 
 - **View Installed Packages**: Browse all installed formulae and casks in organized expandable lists
-- **Search & Install**: Search the Homebrew repository and install packages with one click
+- **Search & Install**: Search formulae and casks, confirm the selected package
+  type, and install with loading, error, refresh, and dry-run states
 - **Update & Upgrade**: Keep Homebrew up-to-date and upgrade outdated packages individually
 - **Pin Packages**: Pin packages to prevent accidental upgrades
 - **Curated Bundles**: Install pre-configured package bundles for common use cases

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -73,7 +73,7 @@ order below. Help is always retained.
 | User Flatpak | `flatpak_user_group` | User-installed Flatpak applications |
 | System Flatpak | `flatpak_system_group` | System-wide Flatpak applications |
 | Homebrew | `brew_group` | Installed Homebrew formulae and casks |
-| Brew Search | `brew_search_group` | Search and install Homebrew packages |
+| Brew Search | `brew_search_group` | Search and install Homebrew formulae and casks with an explicit package-type confirmation |
 | Brew Bundles | `brew_bundles_group` | Install packages from Brewfile bundles |
 
 `applications_installed_group` supports:

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -80,9 +80,25 @@ type Package struct {
 
 // SearchResult represents a search result
 type SearchResult struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Homepage    string `json:"homepage"`
+	Name string
+	Kind PackageKind
+}
+
+// PackageKind identifies which Homebrew install namespace a search result
+// belongs to. Formulae and casks can share a name, so the kind must travel
+// with the result all the way to the install command.
+type PackageKind string
+
+const (
+	Formula PackageKind = "formula"
+	Cask    PackageKind = "cask"
+)
+
+func (k PackageKind) DisplayName() string {
+	if k == Cask {
+		return "Cask"
+	}
+	return "Formula"
 }
 
 // stateChangingCommands are commands that modify system state
@@ -324,23 +340,53 @@ func ListOutdated() ([]Package, error) {
 	return packages, nil
 }
 
-// Search searches for formulae matching the query
+// Search searches both Homebrew namespaces and returns typed results.
 func Search(query string) ([]SearchResult, error) {
-	output, err := runBrewCommand("search", "--formula", query)
+	return searchWith(runBrewCommand, query)
+}
+
+func searchWith(run func(...string) (string, error), query string) ([]SearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+
+	formulae, err := searchKind(run, query, "--formula", Formula)
 	if err != nil {
 		return nil, err
 	}
+	casks, err := searchKind(run, query, "--cask", Cask)
+	if err != nil {
+		return nil, err
+	}
+	return append(formulae, casks...), nil
+}
 
+func searchKind(run func(...string) (string, error), query, flag string, kind PackageKind) ([]SearchResult, error) {
+	output, err := run("search", flag, query)
+	if err != nil {
+		// Homebrew exits 1 when one namespace has no matches, even if the
+		// other namespace may have results. Treat only that documented
+		// no-result diagnostic as an empty category.
+		if strings.Contains(err.Error(), "No formulae or casks found") {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return parseSearchOutput(output, kind), nil
+}
+
+func parseSearchOutput(output string, kind PackageKind) []SearchResult {
 	var results []SearchResult
 	lines := strings.Split(strings.TrimSpace(output), "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line != "" && !strings.HasPrefix(line, "==>") {
-			results = append(results, SearchResult{Name: line})
+			results = append(results, SearchResult{Name: line, Kind: kind})
 		}
 	}
-
-	return results, nil
+	return results
 }
 
 // Install installs a package

--- a/internal/homebrew/homebrew_test.go
+++ b/internal/homebrew/homebrew_test.go
@@ -1,6 +1,8 @@
 package homebrew
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -34,6 +36,112 @@ func TestCommandTimeout(t *testing.T) {
 				t.Errorf("commandTimeout(%v) = %v, want %v", tc.args, got, readTimeout)
 			}
 		})
+	}
+}
+
+func TestSearchWithReturnsTypedFormulaeAndCasks(t *testing.T) {
+	var calls [][]string
+	run := func(args ...string) (string, error) {
+		calls = append(calls, append([]string(nil), args...))
+		switch args[1] {
+		case "--formula":
+			return "ripgrep\nripgrep-all\n", nil
+		case "--cask":
+			return "font-ripgrep\n", nil
+		default:
+			t.Fatalf("unexpected search flag in args %v", args)
+			return "", nil
+		}
+	}
+
+	got, err := searchWith(run, "  ripgrep  ")
+	if err != nil {
+		t.Fatalf("searchWith: %v", err)
+	}
+	want := []SearchResult{
+		{Name: "ripgrep", Kind: Formula},
+		{Name: "ripgrep-all", Kind: Formula},
+		{Name: "font-ripgrep", Kind: Cask},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("searchWith results = %#v, want %#v", got, want)
+	}
+
+	wantCalls := [][]string{
+		{"search", "--formula", "ripgrep"},
+		{"search", "--cask", "ripgrep"},
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Errorf("searchWith calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+func TestSearchWithTreatsNoMatchesAsEmptyCategory(t *testing.T) {
+	noMatches := &Error{Message: `Brew command failed: Error: No formulae or casks found for "demo".`}
+	run := func(args ...string) (string, error) {
+		if args[1] == "--formula" {
+			return "", noMatches
+		}
+		return "demo-app\n", nil
+	}
+
+	got, err := searchWith(run, "demo")
+	if err != nil {
+		t.Fatalf("searchWith: %v", err)
+	}
+	want := []SearchResult{{Name: "demo-app", Kind: Cask}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("searchWith results = %#v, want %#v", got, want)
+	}
+}
+
+func TestSearchWithPropagatesOperationalErrors(t *testing.T) {
+	wantErr := errors.New("brew unavailable")
+	calls := 0
+	run := func(args ...string) (string, error) {
+		calls++
+		return "", wantErr
+	}
+
+	if _, err := searchWith(run, "demo"); !errors.Is(err, wantErr) {
+		t.Fatalf("searchWith error = %v, want %v", err, wantErr)
+	}
+	if calls != 1 {
+		t.Errorf("searchWith calls = %d, want 1 after formula search failure", calls)
+	}
+}
+
+func TestSearchWithEmptyQueryDoesNotRunBrew(t *testing.T) {
+	run := func(args ...string) (string, error) {
+		t.Fatalf("unexpected brew call: %v", args)
+		return "", nil
+	}
+	got, err := searchWith(run, " \t ")
+	if err != nil {
+		t.Fatalf("searchWith: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("searchWith empty query = %#v, want no results", got)
+	}
+}
+
+func TestParseSearchOutputFiltersHeadersAndBlankLines(t *testing.T) {
+	got := parseSearchOutput("\n==> Formulae\nalpha\n\nbeta\n", Formula)
+	want := []SearchResult{
+		{Name: "alpha", Kind: Formula},
+		{Name: "beta", Kind: Formula},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseSearchOutput = %#v, want %#v", got, want)
+	}
+}
+
+func TestPackageKindDisplayName(t *testing.T) {
+	if got := Formula.DisplayName(); got != "Formula" {
+		t.Errorf("Formula.DisplayName() = %q, want Formula", got)
+	}
+	if got := Cask.DisplayName(); got != "Cask" {
+		t.Errorf("Cask.DisplayName() = %q, want Cask", got)
 	}
 }
 

--- a/internal/views/actionstate/actionstate.go
+++ b/internal/views/actionstate/actionstate.go
@@ -1,6 +1,7 @@
 // Package actionstate owns the pure state transitions used by asynchronous
-// update-page actions. It has no GTK or puregotk dependency, so command
-// completion and repeated-click behavior can be tested headlessly.
+// Applications- and Updates-page actions. It has no GTK or puregotk
+// dependency, so command completion, refresh ordering, and repeated-click
+// behavior can be tested headlessly.
 package actionstate
 
 import (
@@ -55,9 +56,10 @@ func (g *Gate) Complete() {
 
 // Decision describes the UI work following one command attempt.
 type Decision struct {
-	Refresh        bool
-	RemoveRow      bool
-	RestoreControl bool
+	Refresh         bool
+	RemoveRow       bool
+	RestoreControl  bool
+	CompleteControl bool
 }
 
 // RefreshDecision describes whether a completed outdated-package query has
@@ -105,6 +107,21 @@ func PackageUpgrade(succeeded, dryRun bool) Decision {
 		return Decision{RestoreControl: true}
 	default:
 		return Decision{Refresh: true, RemoveRow: true}
+	}
+}
+
+// PackageInstall distinguishes a command failure, a successful dry-run
+// preview, and a successful live install from a search result. Only the live
+// install permanently completes the row control and refreshes installed
+// packages.
+func PackageInstall(succeeded, dryRun bool) Decision {
+	switch {
+	case !succeeded:
+		return Decision{RestoreControl: true}
+	case dryRun:
+		return Decision{RestoreControl: true}
+	default:
+		return Decision{Refresh: true, CompleteControl: true}
 	}
 }
 

--- a/internal/views/actionstate/actionstate_test.go
+++ b/internal/views/actionstate/actionstate_test.go
@@ -40,6 +40,40 @@ func TestPackageUpgradeEnumeratesEveryOutcome(t *testing.T) {
 	}
 }
 
+func TestPackageInstallEnumeratesEveryOutcome(t *testing.T) {
+	tests := []struct {
+		name      string
+		succeeded bool
+		dryRun    bool
+		want      Decision
+	}{
+		{
+			name: "failure restores the install control",
+			want: Decision{RestoreControl: true},
+		},
+		{
+			name:      "dry-run success restores the install control",
+			succeeded: true,
+			dryRun:    true,
+			want:      Decision{RestoreControl: true},
+		},
+		{
+			name:      "live success completes the control and refreshes installed packages",
+			succeeded: true,
+			want:      Decision{Refresh: true, CompleteControl: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PackageInstall(tt.succeeded, tt.dryRun)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("PackageInstall(%v, %v) = %#v, want %#v", tt.succeeded, tt.dryRun, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMetadataUpdateEnumeratesEveryOutcome(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/views/actionstate/applications_wiring_test.go
+++ b/internal/views/actionstate/applications_wiring_test.go
@@ -1,0 +1,48 @@
+package actionstate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestApplicationsPageWiresTypedSearchInstallState(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller could not locate applications_wiring_test.go")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", ".."))
+	path := filepath.Join(repoRoot, "internal", "views", "applications_page.go")
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	text := string(source)
+
+	for _, required := range []string{
+		`Search for and install Homebrew formulae and casks`,
+		`generation := uh.brewPackagesRefresh.Begin()`,
+		`if !uh.brewPackagesRefresh.IsCurrent(generation)`,
+		`generation := uh.searchRefresh.Begin()`,
+		`if !uh.searchRefresh.IsCurrent(generation)`,
+		`uh.searchResultRows.Clear(func(row *adw.ActionRow)`,
+		`row.SetSubtitle(result.Kind.DisplayName())`,
+		`if !gate.TryStart()`,
+		`uh.confirmHomebrewInstall(result, button, gate)`,
+		`dialog.AddResponse("install", "Install")`,
+		`button.SetLabel("Installing...")`,
+		`homebrew.Install(result.Name, result.Kind == homebrew.Cask)`,
+		`actionstate.PackageInstall(err == nil, dryRun)`,
+		`if decision.RestoreControl`,
+		`if decision.CompleteControl`,
+		`go uh.loadHomebrewPackages()`,
+		`uh.formulaeRows.Clear(func(row *adw.ActionRow)`,
+		`uh.caskRows.Clear(func(row *adw.ActionRow)`,
+	} {
+		if !strings.Contains(text, required) {
+			t.Errorf("applications-page wiring does not contain %q", required)
+		}
+	}
+}

--- a/internal/views/applications_page.go
+++ b/internal/views/applications_page.go
@@ -5,10 +5,12 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/frostyard/chairlift/internal/flatpak"
 	"github.com/frostyard/chairlift/internal/homebrew"
 	"github.com/frostyard/chairlift/internal/views/actionmsg"
+	"github.com/frostyard/chairlift/internal/views/actionstate"
 	"github.com/frostyard/chairlift/internal/views/bundleview"
 
 	sgtk "github.com/frostyard/snowkit/gtk"
@@ -131,7 +133,7 @@ func (uh *UserHome) buildApplicationsPage() {
 	if uh.config.IsGroupEnabled("applications_page", "brew_search_group") {
 		group := adw.NewPreferencesGroup()
 		group.SetTitle("Search Homebrew")
-		group.SetDescription("Search for and install Homebrew formulae")
+		group.SetDescription("Search for and install Homebrew formulae and casks")
 
 		// Search entry row
 		searchRow := adw.NewActionRow()
@@ -267,48 +269,82 @@ func (uh *UserHome) loadBrewBundles(paths []string) {
 
 // loadHomebrewPackages loads installed Homebrew packages asynchronously
 func (uh *UserHome) loadHomebrewPackages() {
+	generation := uh.brewPackagesRefresh.Begin()
 	if !homebrew.IsInstalledCached() {
 		sgtk.RunOnMainThread(func() {
-			uh.formulaeExpander.SetSubtitle("Homebrew not installed")
-			uh.casksExpander.SetSubtitle("Homebrew not installed")
+			if !uh.brewPackagesRefresh.IsCurrent(generation) {
+				return
+			}
+			if uh.formulaeExpander != nil {
+				uh.formulaeExpander.SetSubtitle("Homebrew not installed")
+			}
+			if uh.casksExpander != nil {
+				uh.casksExpander.SetSubtitle("Homebrew not installed")
+			}
 		})
 		return
 	}
 
 	// Load formulae
-	formulae, err := homebrew.ListInstalledFormulae()
-	if err != nil {
-		sgtk.RunOnMainThread(func() {
-			uh.formulaeExpander.SetSubtitle(fmt.Sprintf("Error: %v", err))
-		})
-	} else {
-		sgtk.RunOnMainThread(func() {
-			uh.formulaeExpander.SetSubtitle(fmt.Sprintf("%d installed", len(formulae)))
-			for _, pkg := range formulae {
-				row := adw.NewActionRow()
-				row.SetTitle(pkg.Name)
-				row.SetSubtitle(pkg.Version)
-				uh.formulaeExpander.AddRow(&row.Widget)
-			}
-		})
+	if uh.formulaeExpander != nil {
+		formulae, err := homebrew.ListInstalledFormulae()
+		if err != nil {
+			sgtk.RunOnMainThread(func() {
+				if !uh.brewPackagesRefresh.IsCurrent(generation) {
+					return
+				}
+				uh.formulaeExpander.SetSubtitle(fmt.Sprintf("Error: %v", err))
+			})
+		} else {
+			sgtk.RunOnMainThread(func() {
+				if !uh.brewPackagesRefresh.IsCurrent(generation) {
+					return
+				}
+				uh.formulaeRows.Clear(func(row *adw.ActionRow) {
+					uh.formulaeExpander.Remove(&row.Widget)
+				})
+				uh.formulaeExpander.SetSubtitle(fmt.Sprintf("%d installed", len(formulae)))
+				uh.formulaeExpander.SetEnableExpansion(len(formulae) > 0)
+				for _, pkg := range formulae {
+					row := adw.NewActionRow()
+					row.SetTitle(pkg.Name)
+					row.SetSubtitle(pkg.Version)
+					uh.formulaeExpander.AddRow(&row.Widget)
+					uh.formulaeRows.Add(row)
+				}
+			})
+		}
 	}
 
 	// Load casks
-	casks, err := homebrew.ListInstalledCasks()
-	if err != nil {
-		sgtk.RunOnMainThread(func() {
-			uh.casksExpander.SetSubtitle(fmt.Sprintf("Error: %v", err))
-		})
-	} else {
-		sgtk.RunOnMainThread(func() {
-			uh.casksExpander.SetSubtitle(fmt.Sprintf("%d installed", len(casks)))
-			for _, pkg := range casks {
-				row := adw.NewActionRow()
-				row.SetTitle(pkg.Name)
-				row.SetSubtitle(pkg.Version)
-				uh.casksExpander.AddRow(&row.Widget)
-			}
-		})
+	if uh.casksExpander != nil {
+		casks, err := homebrew.ListInstalledCasks()
+		if err != nil {
+			sgtk.RunOnMainThread(func() {
+				if !uh.brewPackagesRefresh.IsCurrent(generation) {
+					return
+				}
+				uh.casksExpander.SetSubtitle(fmt.Sprintf("Error: %v", err))
+			})
+		} else {
+			sgtk.RunOnMainThread(func() {
+				if !uh.brewPackagesRefresh.IsCurrent(generation) {
+					return
+				}
+				uh.caskRows.Clear(func(row *adw.ActionRow) {
+					uh.casksExpander.Remove(&row.Widget)
+				})
+				uh.casksExpander.SetSubtitle(fmt.Sprintf("%d installed", len(casks)))
+				uh.casksExpander.SetEnableExpansion(len(casks) > 0)
+				for _, pkg := range casks {
+					row := adw.NewActionRow()
+					row.SetTitle(pkg.Name)
+					row.SetSubtitle(pkg.Version)
+					uh.casksExpander.AddRow(&row.Widget)
+					uh.caskRows.Add(row)
+				}
+			})
+		}
 	}
 }
 
@@ -443,11 +479,12 @@ func (uh *UserHome) loadFlatpakApplications() {
 
 // onHomebrewSearch handles the Homebrew search action
 func (uh *UserHome) onHomebrewSearch() {
-	query := uh.searchEntry.GetText()
+	query := strings.TrimSpace(uh.searchEntry.GetText())
 	if query == "" {
 		return
 	}
 
+	generation := uh.searchRefresh.Begin()
 	uh.searchResultsExpander.SetSubtitle("Searching...")
 	uh.searchResultsExpander.SetEnableExpansion(false)
 
@@ -455,17 +492,22 @@ func (uh *UserHome) onHomebrewSearch() {
 		results, err := homebrew.Search(query)
 		if err != nil {
 			sgtk.RunOnMainThread(func() {
+				if !uh.searchRefresh.IsCurrent(generation) {
+					return
+				}
 				uh.searchResultsExpander.SetSubtitle(fmt.Sprintf("Error: %v", err))
 			})
 			return
 		}
 
 		sgtk.RunOnMainThread(func() {
-			// Clear previous search results
-			for _, row := range uh.searchResultRows {
-				uh.searchResultsExpander.Remove(&row.Widget)
+			if !uh.searchRefresh.IsCurrent(generation) {
+				return
 			}
-			uh.searchResultRows = nil
+			// Clear previous search results
+			uh.searchResultRows.Clear(func(row *adw.ActionRow) {
+				uh.searchResultsExpander.Remove(&row.Widget)
+			})
 
 			uh.searchResultsExpander.SetSubtitle(fmt.Sprintf("%d results", len(results)))
 			uh.searchResultsExpander.SetEnableExpansion(len(results) > 0)
@@ -474,33 +516,79 @@ func (uh *UserHome) onHomebrewSearch() {
 			for _, result := range results {
 				row := adw.NewActionRow()
 				row.SetTitle(result.Name)
+				row.SetSubtitle(result.Kind.DisplayName())
 
 				installBtn := gtk.NewButtonWithLabel("Install")
 				installBtn.SetValign(gtk.AlignCenterValue)
 				installBtn.AddCssClass("suggested-action")
 
-				pkgName := result.Name
-				clickedCb := func(btn gtk.Button) {
-					go func() {
-						if err := homebrew.Install(pkgName, false); err != nil {
-							sgtk.RunOnMainThread(func() {
-								uh.toastAdder.ShowErrorToast(fmt.Sprintf("Install failed: %v", err))
-							})
-							return
-						}
-						sgtk.RunOnMainThread(func() {
-							uh.toastAdder.ShowToast(actionmsg.Install(homebrew.IsDryRun(), pkgName))
-						})
-					}()
+				result := result
+				gate := &actionstate.Gate{}
+				button := installBtn
+				clickedCb := func(_ gtk.Button) {
+					if !gate.TryStart() {
+						return
+					}
+					uh.confirmHomebrewInstall(result, button, gate)
 				}
 				installBtn.ConnectClicked(&clickedCb)
 
 				row.AddSuffix(&installBtn.Widget)
 				uh.searchResultsExpander.AddRow(&row.Widget)
-				uh.searchResultRows = append(uh.searchResultRows, row)
+				uh.searchResultRows.Add(row)
 			}
 		})
 	}()
+}
+
+func (uh *UserHome) confirmHomebrewInstall(result homebrew.SearchResult, button *gtk.Button, gate *actionstate.Gate) {
+	kind := strings.ToLower(result.Kind.DisplayName())
+	dialog := adw.NewAlertDialog(
+		fmt.Sprintf("Install %s?", result.Name),
+		fmt.Sprintf("Homebrew will install the %s %s and run its package-defined installation steps.", kind, result.Name),
+	)
+	dialog.AddResponse("cancel", "Cancel")
+	dialog.AddResponse("install", "Install")
+	dialog.SetResponseAppearance("install", adw.ResponseSuggestedValue)
+
+	responseCb := func(_ adw.AlertDialog, response string) {
+		if response != "install" {
+			gate.Reset()
+			return
+		}
+		button.SetSensitive(false)
+		button.SetLabel("Installing...")
+		go uh.installHomebrewSearchResult(result, button, gate)
+	}
+	dialog.ConnectResponse(&responseCb)
+	dialog.Present(&uh.applicationsPrefsPage.Widget)
+}
+
+func (uh *UserHome) installHomebrewSearchResult(result homebrew.SearchResult, button *gtk.Button, gate *actionstate.Gate) {
+	err := homebrew.Install(result.Name, result.Kind == homebrew.Cask)
+	dryRun := homebrew.IsDryRun()
+	decision := actionstate.PackageInstall(err == nil, dryRun)
+
+	sgtk.RunOnMainThread(func() {
+		if decision.RestoreControl {
+			gate.Reset()
+			button.SetSensitive(true)
+			button.SetLabel("Install")
+		}
+		if err != nil {
+			uh.toastAdder.ShowErrorToast(fmt.Sprintf("Install failed: %v", err))
+			return
+		}
+		if decision.CompleteControl {
+			gate.Complete()
+			button.SetLabel("Installed")
+			button.SetSensitive(false)
+		}
+		uh.toastAdder.ShowToast(actionmsg.Install(dryRun, result.Name))
+		if decision.Refresh {
+			go uh.loadHomebrewPackages()
+		}
+	})
 }
 
 // launchApp launches a desktop application by its application ID

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -56,7 +56,9 @@ type UserHome struct {
 	flatpakUpdateRows      []*adw.ActionRow               // Store references for cleanup
 	flatpakUserRows        rowset.Tracker[*adw.ActionRow] // Store references for cleanup
 	flatpakSystemRows      rowset.Tracker[*adw.ActionRow] // Store references for cleanup
-	searchResultRows       []*adw.ActionRow               // Store references for cleanup
+	formulaeRows           rowset.Tracker[*adw.ActionRow]
+	caskRows               rowset.Tracker[*adw.ActionRow]
+	searchResultRows       rowset.Tracker[*adw.ActionRow]
 	brewBundlesGroup       *adw.PreferencesGroup
 	brewTrustGroup         *adw.PreferencesGroup
 	brewTrustRows          map[string]*adw.ActionRow
@@ -79,7 +81,10 @@ type UserHome struct {
 
 	// Update badge tracking
 	updateCounts badgestate.Counts
-	brewRefresh  actionstate.RefreshGate
+
+	brewRefresh         actionstate.RefreshGate
+	searchRefresh       actionstate.RefreshGate
+	brewPackagesRefresh actionstate.RefreshGate
 }
 
 // New creates a new UserHome views manager

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -1172,7 +1172,7 @@ page_name:
 | `applications_page` | `flatpak_user_group` | User Flatpak applications |
 | `applications_page` | `flatpak_system_group` | System Flatpak applications |
 | `applications_page` | `brew_group` | Homebrew formulae and casks |
-| `applications_page` | `brew_search_group` | Homebrew package search |
+| `applications_page` | `brew_search_group` | Typed Homebrew formula/cask search and confirmed install |
 | `applications_page` | `brew_bundles_group` | Curated `*.Brewfile` bundles discovered from every configured `bundles_paths` directory, with guarded install actions |
 | `applications_page` | `applications_installed_group` | Installed apps launcher (configurable `app_id`, default: Bazaar) |
 | `maintenance_page` | `maintenance_cleanup_group` | Custom cleanup scripts (5min timeout, pkexec for sudo); **disabled by default** |

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -9,7 +9,9 @@ Wraps the `brew` CLI. Uses JSON output (`--json=v2`) for structured data where a
 ### Key types
 
 - **`Package`** — name, version, pinned status, outdated flag, `InstalledOnRequest` bool, `Dependencies` string slice (struct field exists but not populated by current parsing)
-- **`SearchResult`** — name, description, homepage (only `Name` is populated by `Search()` — description and homepage fields exist but are always empty since search parses text output)
+- **`SearchResult`** — name plus a required `PackageKind` (`Formula` or
+  `Cask`). The kind is not cosmetic: it selects whether installation adds
+  `--cask`.
 
 ### Operations
 
@@ -18,7 +20,7 @@ Wraps the `brew` CLI. Uses JSON output (`--json=v2`) for structured data where a
 | `ListInstalledFormulae()` | `brew info --installed --json=v2 --formula` | 30s | JSON parsed |
 | `ListInstalledCasks()` | `brew info --installed --json=v2 --cask` | 30s | JSON parsed |
 | `ListOutdated()` | `brew outdated --json=v2` | 30s | JSON parsed; returns both formulae and casks |
-| `Search(query)` | `brew search --formula <query>` | 30s | Text output parsed; formula-only search |
+| `Search(query)` | `brew search --formula <query>`, then `brew search --cask <query>` | 30s each | Text output parsed into typed formula/cask results; one namespace's normal no-match exit is treated as empty |
 | `Install(name, isCask)` | `brew install [--cask] <name>` | 30m | State-changing, dry-run aware |
 | `Uninstall(name, isCask)` | `brew uninstall [--cask] <name>` | 30m | State-changing |
 | `Upgrade(name)` | `brew upgrade [<name>]` | 30m | State-changing; empty name upgrades all |
@@ -70,6 +72,31 @@ expanders. A successful live `BundleInstall` leaves the clicked row labelled
 and restores the action because nothing was installed. Each row owns a
 `bundleview.InstallGate`, so a second callback cannot overlap a running
 install even if invoked independently of GTK's insensitive-button guard.
+
+### Typed search and install
+
+`Search` trims the query and delegates to the pure injected seam
+`searchWith(run, query)`. It queries formulae and casks separately because
+Homebrew's combined human-readable search output does not reliably label every
+result, while `--formula` and `--cask` make the namespace unambiguous. Homebrew
+exits non-zero when one namespace has no matches; only its specific
+`No formulae or casks found` diagnostic becomes an empty category. Other
+errors remain failures. `homebrew_test.go` drives a fake runner to assert both
+argv sequences, type preservation, empty-category handling, error
+propagation, blank-query behavior, and header filtering.
+
+`onHomebrewSearch` assigns each query a `searchRefresh` generation so an older
+slow query cannot replace newer results. Rows display `Formula` or `Cask`, and
+the confirmation callback carries that type into
+`homebrew.Install(result.Name, result.Kind == homebrew.Cask)`. Each result owns
+an `actionstate.Gate`: cancel resets it, confirmation changes the button to
+`Installing...`, failure and dry-run restore it, and a live success completes
+it as `Installed`. `actionstate.PackageInstall` is the tested authority for
+restore/complete/refresh decisions. Live success starts
+`loadHomebrewPackages`; that loader has its own `brewPackagesRefresh`
+generation, nil-guards the independently configurable installed-package
+group, and clear-then-repopulates separate formula/cask `rowset.Tracker`
+values.
 
 ### Error handling
 
@@ -467,7 +494,19 @@ the full decision table is tested without constructing GTK widgets.
 
 A small standalone binary that accepts commands (`enable-feature`, `disable-feature`, `update`) and uses the updex Go library to perform privileged operations. It supports `--dry-run` for all three subcommands — `enable-feature`, `disable-feature`, and `update` — passing it through to the corresponding `updex.*Options.DryRun` field. Outputs JSON to stdout. Invoked via pkexec so that the main chairlift process does not need root.
 
-`main.go` itself is thin argv dispatch only: parsing `os.Args` and building each subcommand's `Options` struct live in `internal/updexhelper` (`internal/updexhelper/updexhelper.go`), a package with no puregotk import — only stdlib plus `github.com/frostyard/updex/updex`. That's what makes the logic testable at all: neither `gates_chunk` nor `make ci` ever runs `go test ./...`, both are scoped to `go test ./internal/...`, so a `_test.go` under `cmd/chairlift-updex-helper` would never execute under any gate this repo actually runs (see `docs/agents/skills/gtk-headless-tests.md` for the same "extract to a testable `internal/` package" pattern applied to GTK code). `internal/updexhelper` exports `HasDryRunFlag(args []string) bool` (pure — takes an args slice instead of reading `os.Args` directly) plus `EnableOptions`, `DisableOptions`, and `UpdateOptions`, each `func(dryRun bool) updex.*Options` setting `DryRun` to exactly the argument passed. `internal/updexhelper/updexhelper_test.go` table-tests all four functions, including the previously-dropped `update` case (see "Cross-cutting: dry-run" below).
+`main.go` itself is thin dispatch only: strict `os.Args` parsing and each
+subcommand's `Options` struct live in `internal/updexhelper`
+(`internal/updexhelper/updexhelper.go`), a package with no puregotk import —
+only stdlib plus `github.com/frostyard/updex/updex`. That's what makes the
+logic testable at all: neither `gates_chunk` nor `make ci` ever runs `go test
+./...`, both are scoped to `go test ./internal/...`, so a `_test.go` under
+`cmd/chairlift-updex-helper` would never execute under any gate this repo
+actually runs. `ParseInvocation` accepts only `enable-feature <name>
+[--dry-run]`, `disable-feature <name> [--dry-run]`, and `update [--dry-run]`;
+`SupportedCommands` is the complete first-argument surface matched by the
+PolicyKit actions. `EnableOptions`, `DisableOptions`, and `UpdateOptions` set
+`DryRun` exactly. Tests cover every accepted/rejected argv shape, the immutable
+command inventory, and all three option builders.
 
 ## Cross-cutting: dry-run
 
@@ -495,7 +534,24 @@ gate and button without showing a success/preview toast. `TryStart` and
 `SetSensitive(false)` both happen before the worker goroutine starts, so
 repeated callbacks cannot overlap an install.
 
-The Applications page's per-result Homebrew install button (`onHomebrewSearch`, `internal/views/applications_page.go`) and per-app Flatpak uninstall buttons (`loadFlatpakApplications`, both the user- and system-installation branches) show toasts built by `actionmsg.Install(homebrew.IsDryRun(), pkgName)` and `actionmsg.Uninstall(flatpak.IsDryRun(), appID)` respectively, rather than an unconditional "installed"/"uninstalled" string — the wrapper's own dry-run skip already makes `Install`/`Uninstall` a no-op, so the toast must say "would be installed/uninstalled" instead of claiming it happened. The list refresh after uninstall (`go uh.loadFlatpakApplications()`) stays unconditional since it re-queries live state either way. That refresh does not append to whatever is already on screen: each success branch of `loadFlatpakApplications` first clears the rows the previous load recorded — `uh.flatpakUserRows.Clear(...)` / `uh.flatpakSystemRows.Clear(...)`, two `rowset.Tracker[*adw.ActionRow]` values, each removing its rows from its own expander — and then rebuilds and re-adds them, all inside *one* `sgtk.RunOnMainThread` closure per expander (the two expanders keep separate closures and separate trackers). Keeping the clear and the repopulate in a single closure is what makes overlapping reloads safe without any locking: `RunOnMainThread` serializes closures FIFO on glib's idle queue, so two concurrent reloads run as clear+add, then clear+add, and cannot interleave into clear/clear/add/add. There is deliberately no mutex, generation counter, or in-flight flag. Each success branch also calls `SetEnableExpansion(len(apps) > 0)`, matching `onHomebrewSearch`; the not-installed and error branches only change the subtitle and deliberately leave the existing rows in place. Caveat: the Applications page's Homebrew formulae and casks expanders (`loadHomebrewPackages`) still have no clear-before-repopulate bookkeeping; issue #64 concerns the separate Updates-page outdated list and does not change those expanders.
+The Applications page's per-result Homebrew install button
+(`onHomebrewSearch`, `internal/views/applications_page.go`) and per-app Flatpak
+uninstall buttons (`loadFlatpakApplications`, both user and system branches)
+show toasts built by `actionmsg.Install(homebrew.IsDryRun(), result.Name)` and
+`actionmsg.Uninstall(flatpak.IsDryRun(), appID)`, rather than unconditional
+completion claims. The Homebrew path restores its install control after a
+dry-run and does not refresh, because nothing changed; only a live success
+completes the control and starts the generation-guarded installed-package
+refresh described above.
+
+The Flatpak list refresh after uninstall remains unconditional because it
+re-queries live state either way. Each successful loader branch first clears
+the prior `flatpakUserRows` or `flatpakSystemRows` tracker and then rebuilds it
+inside one main-thread closure. Homebrew's installed formula/cask loader now
+uses the same separate-tracker clear-before-repopulate pattern, with an
+additional refresh generation because multiple Homebrew actions can request
+overlapping reloads. Not-installed and error branches change the subtitle and
+preserve the last known rows.
 
 The Updates page's per-package Homebrew upgrade button, per-app Flatpak update button, and the "Update Homebrew" self-update button (`internal/views/updates_page.go`) follow the same toast pattern: `actionmsg.Upgrade(dryRun, pkgName)`, `actionmsg.Update(flatpak.IsDryRun(), appID)`, and `actionmsg.SelfUpdate(dryRun, "Homebrew")` replace what were unconditional "upgraded"/"updated"/"updated successfully" toasts, since `upgrade` and `update` are both in their wrappers' `stateChangingCommands` and no-op under dry-run. The Flatpak update button's list refresh (`go uh.loadFlatpakUpdates()`) stays unconditional, same reasoning as the uninstall refresh above.
 


### PR DESCRIPTION
Part of #65

## Summary
- search Homebrew formula and cask namespaces separately and preserve package type
- confirm installs, show loading/error/dry-run/completed states, and refresh installed rows after live success
- prevent stale search and installed-package refreshes from replacing newer results

## Validation
- `make ci`
- manually verified Homebrew 6 formula/cask search command behavior