### PR TITLE
Manage installed Homebrew packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,10 @@ An agent must not break these:
   `actionstate.RefreshGate` generations; stale workers must not replace newer
   rows. Confirmed installs use an `actionstate.Gate`, restore controls on
   failure/dry-run, and refresh installed rows only after a live success.
+  Installed formula/cask rows likewise confirm uninstall, formula rows confirm
+  pin/unpin, and every row shares one gate across its mutation controls so
+  actions cannot overlap. A live success completes the old controls and starts
+  a generation-guarded inventory refresh; failure or dry-run restores them.
 - **Update badge counts have one state owner.** Bootc, Flatpak, and Homebrew
   counts live in the pure `internal/views/badgestate` package. Refreshes
   replace a provider's count, successful row removals decrement without going

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -61,11 +61,14 @@ valid page.
 
 ### Applications Page (`applications_page`)
 
-- `applications_installed_group`: Flatpak application management link
+- `applications_installed_group`: External Flatpak manager link for discovering
+  and installing new applications; ChairLift itself lists and uninstalls
+  installed Flatpaks but does not directly install them
   - `app_id`: Application ID for the Flatpak manager (default: `io.github.kolunmi.Bazaar`)
-- `flatpak_user_group`: User-installed Flatpak applications
-- `flatpak_system_group`: System-wide Flatpak applications
-- `brew_group`: Installed Homebrew formulae and casks
+- `flatpak_user_group`: User-installed Flatpak applications with uninstall actions
+- `flatpak_system_group`: System-wide Flatpak applications with uninstall actions
+- `brew_group`: Installed Homebrew formulae/casks with uninstall actions and
+  formula pin/unpin actions
 - `brew_search_group`: Search and install Homebrew formulae and casks
 - `brew_bundles_group`: Curated Homebrew package bundles
   - `bundles_paths`: Array of directories searched for immediate

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
 
 ### 📦 Homebrew Package Management
 
-- **View Installed Packages**: Browse all installed formulae and casks in organized expandable lists
+- **Manage Installed Packages**: Browse installed formulae and casks, uninstall
+  either type, and pin or unpin formulae with confirmed, refresh-safe actions
 - **Search & Install**: Search formulae and casks, confirm the selected package
   type, and install with loading, error, refresh, and dry-run states
 - **Update & Upgrade**: Keep Homebrew up-to-date and upgrade outdated packages individually
-- **Pin Packages**: Pin packages to prevent accidental upgrades
 - **Curated Bundles**: Install pre-configured package bundles for common use cases
 - **Tap Trust Management**: Homebrew 6's per-tap trust model hides packages installed from untrusted taps; ChairLift detects them and lets you trust a tap (and resume its updates) with one click, without requiring root
 
@@ -141,7 +141,9 @@ chairlift
 
 ### Main Sections
 
-1. **Applications**: View installed packages, search for new ones, and install curated bundles
+1. **Applications**: Manage installed Homebrew packages, search for formulae
+   and casks, install curated bundles, and launch the configured external
+   Flatpak manager
 2. **Maintenance**: System cleanup and maintenance tools (Homebrew, Flatpak, custom scripts)
 3. **Updates**: Stage bootc system updates, manage Homebrew updates and outdated packages, apply Flatpak updates, and trust Homebrew taps
 4. **System**: Monitor deployment, health, and performance information
@@ -166,9 +168,15 @@ sidebar row and page title.
 - **Browse Installed**: Navigate to Applications → Brew Packages to see all installed formulae and casks
 - **Search**: Use the search box to find packages by name or keyword
 - **Install**: Click the install button next to search results or bundle items
-- **Pin/Unpin**: Click the pin icon to lock/unlock a package version
-- **Remove**: Click the trash icon to uninstall a package
+- **Pin/Unpin**: Use the formula row's Pin or Unpin action and confirm the change
+- **Remove**: Use an installed formula or cask row's Uninstall action and
+  confirm the removal
 - **Upgrade**: Click upgrade button next to outdated packages
+
+ChairLift lists and uninstalls installed user and system Flatpak applications,
+but delegates discovery and installation of new Flatpaks to the external
+manager configured by
+`applications_page.applications_installed_group.app_id` (Bazaar by default).
 
 ### Bundle Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ ChairLift provides six configurable pages:
 
 | Page | Description |
 |------|-------------|
-| **Applications** | Browse, search, install, and uninstall Flatpak (user and system) and Homebrew packages. Install curated Brewfile bundles. |
+| **Applications** | Search/install Homebrew formulae and casks; uninstall installed formulae/casks; pin/unpin formulae; install curated Brewfile bundles. List/uninstall Flatpaks and launch the configured external manager for Flatpak discovery and installation. |
 | **Maintenance** | Run cleanup tasks for Homebrew and Flatpak, and execute custom maintenance scripts. |
 | **Updates** | Stage bootc system updates, apply Flatpak updates, upgrade Homebrew packages, and trust Homebrew taps. |
 | **System** | View OS information, bootc deployment status, and launch a system health monitor. |
@@ -53,7 +53,7 @@ groups configuration enables, not on runtime tool availability.
 | Tool | Used For |
 |------|----------|
 | Homebrew | Package management (formulae, casks, bundles) |
-| Flatpak | Application management and updates |
+| Flatpak | Installed-application listing/uninstall and updates; new installs are delegated to the configured external manager |
 | bootc + `/usr/libexec/bootc-update-stage` | Staged bootc system updates |
 | Updex | System feature toggles |
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -69,16 +69,19 @@ order below. Help is always retained.
 
 | Group | Key | Description |
 |-------|-----|-------------|
-| Installed Apps | `applications_installed_group` | Launcher for a Flatpak manager |
-| User Flatpak | `flatpak_user_group` | User-installed Flatpak applications |
-| System Flatpak | `flatpak_system_group` | System-wide Flatpak applications |
-| Homebrew | `brew_group` | Installed Homebrew formulae and casks |
+| Installed Apps | `applications_installed_group` | Launcher for the external Flatpak manager used for discovery and installation |
+| User Flatpak | `flatpak_user_group` | User-installed Flatpak applications with uninstall actions |
+| System Flatpak | `flatpak_system_group` | System-wide Flatpak applications with uninstall actions |
+| Homebrew | `brew_group` | Installed Homebrew formulae/casks with uninstall actions and formula pin/unpin actions |
 | Brew Search | `brew_search_group` | Search and install Homebrew formulae and casks with an explicit package-type confirmation |
 | Brew Bundles | `brew_bundles_group` | Install packages from Brewfile bundles |
 
 `applications_installed_group` supports:
 
 - `app_id` — Flatpak application ID to launch (default: `io.github.kolunmi.Bazaar`)
+
+ChairLift does not directly discover or install new Flatpak applications.
+Those operations belong to the configured external manager.
 
 `brew_bundles_group` supports:
 

--- a/internal/views/actionmsg/actionmsg.go
+++ b/internal/views/actionmsg/actionmsg.go
@@ -2,9 +2,9 @@
 // gated by dry-run, the execution decision) for maintenance-page,
 // applications-page, updates-page, and features-page actions: Homebrew
 // Brewfile dumps and installs, Homebrew/Flatpak cleanup, Homebrew package
-// installs/upgrades/self-updates, Flatpak application uninstalls/updates,
-// Homebrew tap trust, bootc system update staging, configured custom
-// maintenance scripts, and system feature toggles/updates.
+// installs/uninstalls/pins/upgrades/self-updates, Flatpak application
+// uninstalls/updates, Homebrew tap trust, bootc system update staging,
+// configured custom maintenance scripts, and system feature toggles/updates.
 //
 // It is deliberately free of any puregotk/GTK import, following the
 // internal/views/trustmsg pattern, so its logic can be unit-tested on a
@@ -14,10 +14,11 @@
 // packages. See docs/agents/skills/gtk-headless-tests.md.
 //
 // Functions whose result only selects display text (BundleDump, Cleanup,
-// Install, Uninstall, Upgrade, Update, SelfUpdate, BootcStage, FeatureUpdate)
-// return a plain string: the state-changing/no-op decision for those actions
-// is already made and already tested inside their wrapper package
-// (internal/homebrew, internal/flatpak, internal/bootc, internal/updex).
+// Install, Uninstall, Pin, Upgrade, Update, SelfUpdate, BootcStage,
+// FeatureUpdate) return a plain string: the state-changing/no-op decision for
+// those actions is already made and already tested inside their wrapper
+// package (internal/homebrew, internal/flatpak, internal/bootc,
+// internal/updex).
 // Functions whose result gates a further decision return a decision struct,
 // precisely so the gated decision — not just the wording of the toast that
 // follows it — is what a table-driven test in actionmsg_test.go asserts.
@@ -96,16 +97,26 @@ func Install(dryRun bool, pkgName string) string {
 	return fmt.Sprintf("%s installed", pkgName)
 }
 
-// Uninstall returns the toast text for a Flatpak application uninstall. The
-// wrapper package (internal/flatpak) already skips the state-changing
-// `flatpak uninstall` command under dry-run, so this function only selects
-// which string to show: a preview when dryRun is true, or a fixed completion
-// message when the uninstall actually ran.
-func Uninstall(dryRun bool, appID string) string {
+// Uninstall returns toast text for a Homebrew package or Flatpak application
+// uninstall. Both wrappers skip their state-changing uninstall command under
+// dry-run.
+func Uninstall(dryRun bool, name string) string {
 	if dryRun {
-		return fmt.Sprintf("[DRY-RUN] Preview: %s would be uninstalled — no changes made", appID)
+		return fmt.Sprintf("[DRY-RUN] Preview: %s would be uninstalled — no changes made", name)
 	}
-	return fmt.Sprintf("%s uninstalled", appID)
+	return fmt.Sprintf("%s uninstalled", name)
+}
+
+// Pin returns toast text for a formula pin or unpin.
+func Pin(dryRun bool, name string, pin bool) string {
+	action := "unpinned"
+	if pin {
+		action = "pinned"
+	}
+	if dryRun {
+		return fmt.Sprintf("[DRY-RUN] Preview: %s would be %s — no changes made", name, action)
+	}
+	return fmt.Sprintf("%s %s", name, action)
 }
 
 // Upgrade returns the toast text for a per-package Homebrew upgrade. The

--- a/internal/views/actionmsg/actionmsg_test.go
+++ b/internal/views/actionmsg/actionmsg_test.go
@@ -175,8 +175,8 @@ func TestPackageInstallMessage(t *testing.T) {
 	}
 }
 
-// TestUninstall covers both dry-run states for the Flatpak
-// application-uninstall toast text.
+// TestUninstall covers both dry-run states for shared Homebrew/Flatpak
+// uninstall toast text.
 func TestUninstall(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -210,6 +210,44 @@ func TestUninstall(t *testing.T) {
 				if !strings.Contains(got, want) {
 					t.Errorf("Uninstall(%v, %q) = %q, want it to contain %q", tt.dryRun, tt.appID, got, want)
 				}
+			}
+		})
+	}
+}
+
+func TestPin(t *testing.T) {
+	tests := []struct {
+		name      string
+		dryRun    bool
+		pin       bool
+		wantExact string
+	}{
+		{
+			name:      "live pin",
+			pin:       true,
+			wantExact: "ripgrep pinned",
+		},
+		{
+			name:      "live unpin",
+			wantExact: "ripgrep unpinned",
+		},
+		{
+			name:      "dry-run pin",
+			dryRun:    true,
+			pin:       true,
+			wantExact: "[DRY-RUN] Preview: ripgrep would be pinned — no changes made",
+		},
+		{
+			name:      "dry-run unpin",
+			dryRun:    true,
+			wantExact: "[DRY-RUN] Preview: ripgrep would be unpinned — no changes made",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Pin(tt.dryRun, "ripgrep", tt.pin); got != tt.wantExact {
+				t.Errorf("Pin(%v, %q, %v) = %q, want %q", tt.dryRun, "ripgrep", tt.pin, got, tt.wantExact)
 			}
 		})
 	}

--- a/internal/views/actionstate/actionstate.go
+++ b/internal/views/actionstate/actionstate.go
@@ -115,6 +115,22 @@ func PackageUpgrade(succeeded, dryRun bool) Decision {
 // install permanently completes the row control and refreshes installed
 // packages.
 func PackageInstall(succeeded, dryRun bool) Decision {
+	return completedPackageMutation(succeeded, dryRun)
+}
+
+// PackageUninstall decides whether an installed-package uninstall control
+// resets or completes and whether the installed inventory must refresh.
+func PackageUninstall(succeeded, dryRun bool) Decision {
+	return completedPackageMutation(succeeded, dryRun)
+}
+
+// PackagePin decides whether a formula pin/unpin control resets or completes
+// and whether the installed inventory must refresh.
+func PackagePin(succeeded, dryRun bool) Decision {
+	return completedPackageMutation(succeeded, dryRun)
+}
+
+func completedPackageMutation(succeeded, dryRun bool) Decision {
 	switch {
 	case !succeeded:
 		return Decision{RestoreControl: true}

--- a/internal/views/actionstate/actionstate_test.go
+++ b/internal/views/actionstate/actionstate_test.go
@@ -74,6 +74,48 @@ func TestPackageInstallEnumeratesEveryOutcome(t *testing.T) {
 	}
 }
 
+func TestPackageMutationsEnumerateEveryInstalledOutcome(t *testing.T) {
+	operations := map[string]func(bool, bool) Decision{
+		"uninstall": PackageUninstall,
+		"pin":       PackagePin,
+	}
+	tests := []struct {
+		name      string
+		succeeded bool
+		dryRun    bool
+		want      Decision
+	}{
+		{
+			name: "failure restores controls",
+			want: Decision{RestoreControl: true},
+		},
+		{
+			name:      "dry-run success restores controls",
+			succeeded: true,
+			dryRun:    true,
+			want:      Decision{RestoreControl: true},
+		},
+		{
+			name:      "live success completes controls and refreshes inventory",
+			succeeded: true,
+			want:      Decision{Refresh: true, CompleteControl: true},
+		},
+	}
+
+	for operation, decide := range operations {
+		t.Run(operation, func(t *testing.T) {
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					got := decide(tt.succeeded, tt.dryRun)
+					if !reflect.DeepEqual(got, tt.want) {
+						t.Fatalf("%s decision(%v, %v) = %#v, want %#v", operation, tt.succeeded, tt.dryRun, got, tt.want)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestMetadataUpdateEnumeratesEveryOutcome(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/views/actionstate/applications_wiring_test.go
+++ b/internal/views/actionstate/applications_wiring_test.go
@@ -40,6 +40,18 @@ func TestApplicationsPageWiresTypedSearchInstallState(t *testing.T) {
 		`go uh.loadHomebrewPackages()`,
 		`uh.formulaeRows.Clear(func(row *adw.ActionRow)`,
 		`uh.caskRows.Clear(func(row *adw.ActionRow)`,
+		`uh.confirmHomebrewPin(pkg.Name, !pkg.Pinned, pinBtn, controls, gate)`,
+		`uh.confirmHomebrewUninstall(pkg.Name, homebrew.Formula, uninstallBtn, controls, gate)`,
+		`uh.confirmHomebrewUninstall(pkg.Name, homebrew.Cask, uninstallBtn, controls, gate)`,
+		`dialog.SetResponseAppearance("uninstall", adw.ResponseDestructiveValue)`,
+		`primary.SetLabel("Uninstalling...")`,
+		`homebrew.Uninstall(name, kind == homebrew.Cask)`,
+		`actionstate.PackageUninstall(err == nil, dryRun)`,
+		`homebrew.Pin(name)`,
+		`homebrew.Unpin(name)`,
+		`actionstate.PackagePin(err == nil, dryRun)`,
+		`setHomebrewControlsSensitive(controls, false)`,
+		`uh.finishHomebrewPackageMutation(`,
 	} {
 		if !strings.Contains(text, required) {
 			t.Errorf("applications-page wiring does not contain %q", required)

--- a/internal/views/applications_page.go
+++ b/internal/views/applications_page.go
@@ -306,9 +306,48 @@ func (uh *UserHome) loadHomebrewPackages() {
 				uh.formulaeExpander.SetSubtitle(fmt.Sprintf("%d installed", len(formulae)))
 				uh.formulaeExpander.SetEnableExpansion(len(formulae) > 0)
 				for _, pkg := range formulae {
+					pkg := pkg
 					row := adw.NewActionRow()
 					row.SetTitle(pkg.Name)
-					row.SetSubtitle(pkg.Version)
+					subtitle := pkg.Version
+					if pkg.Pinned {
+						subtitle += " • Pinned"
+					}
+					row.SetSubtitle(subtitle)
+
+					pinLabel := "Pin"
+					if pkg.Pinned {
+						pinLabel = "Unpin"
+					}
+					pinBtn := gtk.NewButtonWithLabel(pinLabel)
+					pinBtn.SetValign(gtk.AlignCenterValue)
+					pinBtn.SetTooltipText(pinLabel + " formula")
+
+					uninstallBtn := gtk.NewButtonWithLabel("Uninstall")
+					uninstallBtn.SetValign(gtk.AlignCenterValue)
+					uninstallBtn.AddCssClass("destructive-action")
+					uninstallBtn.SetTooltipText("Uninstall formula")
+
+					gate := &actionstate.Gate{}
+					controls := []*gtk.Button{pinBtn, uninstallBtn}
+					pinClickedCb := func(_ gtk.Button) {
+						if !gate.TryStart() {
+							return
+						}
+						uh.confirmHomebrewPin(pkg.Name, !pkg.Pinned, pinBtn, controls, gate)
+					}
+					pinBtn.ConnectClicked(&pinClickedCb)
+
+					uninstallClickedCb := func(_ gtk.Button) {
+						if !gate.TryStart() {
+							return
+						}
+						uh.confirmHomebrewUninstall(pkg.Name, homebrew.Formula, uninstallBtn, controls, gate)
+					}
+					uninstallBtn.ConnectClicked(&uninstallClickedCb)
+
+					row.AddSuffix(&pinBtn.Widget)
+					row.AddSuffix(&uninstallBtn.Widget)
 					uh.formulaeExpander.AddRow(&row.Widget)
 					uh.formulaeRows.Add(row)
 				}
@@ -337,14 +376,191 @@ func (uh *UserHome) loadHomebrewPackages() {
 				uh.casksExpander.SetSubtitle(fmt.Sprintf("%d installed", len(casks)))
 				uh.casksExpander.SetEnableExpansion(len(casks) > 0)
 				for _, pkg := range casks {
+					pkg := pkg
 					row := adw.NewActionRow()
 					row.SetTitle(pkg.Name)
 					row.SetSubtitle(pkg.Version)
+
+					uninstallBtn := gtk.NewButtonWithLabel("Uninstall")
+					uninstallBtn.SetValign(gtk.AlignCenterValue)
+					uninstallBtn.AddCssClass("destructive-action")
+					uninstallBtn.SetTooltipText("Uninstall cask")
+
+					gate := &actionstate.Gate{}
+					controls := []*gtk.Button{uninstallBtn}
+					uninstallClickedCb := func(_ gtk.Button) {
+						if !gate.TryStart() {
+							return
+						}
+						uh.confirmHomebrewUninstall(pkg.Name, homebrew.Cask, uninstallBtn, controls, gate)
+					}
+					uninstallBtn.ConnectClicked(&uninstallClickedCb)
+
+					row.AddSuffix(&uninstallBtn.Widget)
 					uh.casksExpander.AddRow(&row.Widget)
 					uh.caskRows.Add(row)
 				}
 			})
 		}
+	}
+}
+
+func (uh *UserHome) confirmHomebrewPin(
+	name string,
+	pin bool,
+	primary *gtk.Button,
+	controls []*gtk.Button,
+	gate *actionstate.Gate,
+) {
+	action := "Unpin"
+	description := "Unpinned formulae resume receiving upgrades."
+	if pin {
+		action = "Pin"
+		description = "Pinned formulae are skipped by Homebrew upgrades until they are unpinned."
+	}
+
+	dialog := adw.NewAlertDialog(fmt.Sprintf("%s %s?", action, name), description)
+	dialog.AddResponse("cancel", "Cancel")
+	dialog.AddResponse("confirm", action)
+	dialog.SetResponseAppearance("confirm", adw.ResponseSuggestedValue)
+
+	responseCb := func(_ adw.AlertDialog, response string) {
+		if response != "confirm" {
+			gate.Reset()
+			return
+		}
+		setHomebrewControlsSensitive(controls, false)
+		primary.SetLabel(action + "ning...")
+		go uh.runHomebrewPin(name, pin, primary, controls, gate)
+	}
+	dialog.ConnectResponse(&responseCb)
+	dialog.Present(&uh.applicationsPrefsPage.Widget)
+}
+
+func (uh *UserHome) runHomebrewPin(
+	name string,
+	pin bool,
+	primary *gtk.Button,
+	controls []*gtk.Button,
+	gate *actionstate.Gate,
+) {
+	var err error
+	if pin {
+		err = homebrew.Pin(name)
+	} else {
+		err = homebrew.Unpin(name)
+	}
+	dryRun := homebrew.IsDryRun()
+	decision := actionstate.PackagePin(err == nil, dryRun)
+
+	idleLabel := "Unpin"
+	completeLabel := "Unpinned"
+	errorPrefix := "Unpin failed"
+	if pin {
+		idleLabel = "Pin"
+		completeLabel = "Pinned"
+		errorPrefix = "Pin failed"
+	}
+	uh.finishHomebrewPackageMutation(
+		decision,
+		err,
+		errorPrefix,
+		actionmsg.Pin(dryRun, name, pin),
+		idleLabel,
+		completeLabel,
+		primary,
+		controls,
+		gate,
+	)
+}
+
+func (uh *UserHome) confirmHomebrewUninstall(
+	name string,
+	kind homebrew.PackageKind,
+	primary *gtk.Button,
+	controls []*gtk.Button,
+	gate *actionstate.Gate,
+) {
+	dialog := adw.NewAlertDialog(
+		fmt.Sprintf("Uninstall %s?", name),
+		fmt.Sprintf("Homebrew will remove the %s %s and its package-managed files.", strings.ToLower(kind.DisplayName()), name),
+	)
+	dialog.AddResponse("cancel", "Cancel")
+	dialog.AddResponse("uninstall", "Uninstall")
+	dialog.SetResponseAppearance("uninstall", adw.ResponseDestructiveValue)
+
+	responseCb := func(_ adw.AlertDialog, response string) {
+		if response != "uninstall" {
+			gate.Reset()
+			return
+		}
+		setHomebrewControlsSensitive(controls, false)
+		primary.SetLabel("Uninstalling...")
+		go uh.runHomebrewUninstall(name, kind, primary, controls, gate)
+	}
+	dialog.ConnectResponse(&responseCb)
+	dialog.Present(&uh.applicationsPrefsPage.Widget)
+}
+
+func (uh *UserHome) runHomebrewUninstall(
+	name string,
+	kind homebrew.PackageKind,
+	primary *gtk.Button,
+	controls []*gtk.Button,
+	gate *actionstate.Gate,
+) {
+	err := homebrew.Uninstall(name, kind == homebrew.Cask)
+	dryRun := homebrew.IsDryRun()
+	decision := actionstate.PackageUninstall(err == nil, dryRun)
+	uh.finishHomebrewPackageMutation(
+		decision,
+		err,
+		"Uninstall failed",
+		actionmsg.Uninstall(dryRun, name),
+		"Uninstall",
+		"Uninstalled",
+		primary,
+		controls,
+		gate,
+	)
+}
+
+func (uh *UserHome) finishHomebrewPackageMutation(
+	decision actionstate.Decision,
+	err error,
+	errorPrefix string,
+	toast string,
+	idleLabel string,
+	completeLabel string,
+	primary *gtk.Button,
+	controls []*gtk.Button,
+	gate *actionstate.Gate,
+) {
+	sgtk.RunOnMainThread(func() {
+		if decision.RestoreControl {
+			gate.Reset()
+			primary.SetLabel(idleLabel)
+			setHomebrewControlsSensitive(controls, true)
+		}
+		if err != nil {
+			uh.toastAdder.ShowErrorToast(fmt.Sprintf("%s: %v", errorPrefix, err))
+			return
+		}
+		if decision.CompleteControl {
+			gate.Complete()
+			primary.SetLabel(completeLabel)
+			setHomebrewControlsSensitive(controls, false)
+		}
+		uh.toastAdder.ShowToast(toast)
+		if decision.Refresh {
+			go uh.loadHomebrewPackages()
+		}
+	})
+}
+
+func setHomebrewControlsSensitive(controls []*gtk.Button, sensitive bool) {
+	for _, button := range controls {
+		button.SetSensitive(sensitive)
 	}
 }
 

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -59,7 +59,7 @@ disabled; Help is always retained:
 
 | Page | File | Purpose |
 |------|------|---------|
-| Applications | `applications_page.go` | Browse/install Flatpak (user+system) and Homebrew packages |
+| Applications | `applications_page.go` | Manage Homebrew formulae/casks and installed Flatpaks; launch an external manager for new Flatpak installs |
 | Maintenance | `maintenance_page.go` | Homebrew/Flatpak cleanup, configurable maintenance scripts (executed via `exec.Command`/`pkexec`) |
 | Updates | `updates_page.go` | bootc staged system updates, Flatpak updates, Homebrew outdated packages, untrusted-tap trust prompts |
 | System | `system_page.go` | OS info (`/etc/os-release`), bootc deployment status, health monitor launch |
@@ -110,13 +110,13 @@ bootc-related UI groups (system page's `bootc_status_group` and updates page's `
 
 The `--dry-run` / `-d` flag is propagated to wrapper packages via `SetDryRun(true)`, set once at startup in `app.New()` for homebrew, flatpak, bootc, updex, and `internal/views` itself (`internal/views/dryrun.go` — for configured custom maintenance scripts, which have no wrapper package of their own).
 
-**The general rule, applied uniformly:** every state-changing view handler branches on the relevant wrapper's `IsDryRun()` (or `views.IsDryRun()` for custom scripts) to show an explicit preview toast instead of a completed/saved/installed message. Anywhere that same handler would *also* mutate a row, a group's visibility, or a switch on success, that mutation decision is pulled out of the view and expressed as a small struct — `ScriptDecision.Execute`, `BundleInstallDecision.Complete`, `TapTrustDecision.MutateUI`, `FeatureToggleDecision.Confirm` — returned by the same `internal/views/actionmsg` function that produces the toast. The view computes `IsDryRun()` exactly once, builds the decision, and branches solely on its bool for both the mutation *and* the toast, so a table-driven test asserting the bool also proves the mutation gate, and the toast and the gate can never drift apart (see [package-managers.md](./package-managers.md#view-layer-toast-and-decision-helpers-internalviewsactionmsg-internalviewstrustmsg) for the full function/type list). Sites with no second UI mutation to gate (package install/uninstall/upgrade/update/self-update, cleanup, Brewfile dump, bootc stage, and feature-update toasts) get a plain string function instead — there's nothing beyond the toast for a bool to gate there, so adding one would be dead weight.
+**The general rule, applied uniformly:** every state-changing view handler branches on the relevant wrapper's `IsDryRun()` (or `views.IsDryRun()` for custom scripts) to show an explicit preview toast instead of a completed/saved/installed message. Anywhere that same handler would *also* mutate a row, a group's visibility, or a switch on success, that mutation decision is pulled out of the view and expressed as a small struct or an `actionstate.Decision` — `ScriptDecision.Execute`, `BundleInstallDecision.Complete`, `TapTrustDecision.MutateUI`, `FeatureToggleDecision.Confirm`, `PackageInstall`, `PackageUninstall`, or `PackagePin`. The view computes `IsDryRun()` exactly once, builds the decision, and branches solely on it for both the mutation *and* the toast, so a table-driven test proves the mutation gate and the toast cannot drift from it (see [package-managers.md](./package-managers.md#view-layer-toast-and-decision-helpers-internalviewsactionmsg-internalviewstrustmsg) for the full function/type list). Sites with no second UI mutation to gate (package upgrade/update/self-update, Flatpak uninstall, cleanup, Brewfile dump, bootc stage, and feature-update toasts) get a plain string function instead.
 
 **Intentional exception:** bootc staging's completion **toast** is dry-run-aware (`actionmsg.BootcStage`), but its expander **subtitle** deliberately is not. The subtitle is a persistent status readout of live `bootc.GetStatus()` — what deployment is actually staged/booted right now — not a per-click completion claim, so it stays accurate and unchanged in both dry-run and live mode. Only the toast, which inherently answers "what did this click just do," needed dry-run-specific wording; there is no mutation left to gate once the subtitle is deliberately excluded, which is why `BootcStage` is string-only rather than a decision struct.
 
 Per-wrapper mechanics:
 
-- **Homebrew/Flatpak**: state-changing commands are skipped entirely at the wrapper layer (return mock/empty results); ordinary package-action toasts use the plain `actionmsg` string functions (`Install`, `Uninstall`, `Upgrade`, `Update`, `SelfUpdate`, `BundleDump`, `Cleanup`). Brew bundle installation uses `BundleInstallDecision`: a live success completes and permanently disables its row action, while a dry-run success resets the action after showing a preview.
+- **Homebrew/Flatpak**: state-changing commands are skipped entirely at the wrapper layer (return mock/empty results); ordinary package-action toasts use the plain `actionmsg` string functions (`Install`, `Uninstall`, `Pin`, `Upgrade`, `Update`, `SelfUpdate`, `BundleDump`, `Cleanup`). Homebrew search installs and installed-package uninstall/pin actions pair that text with `actionstate` decisions: live success completes the old row controls and refreshes the installed inventory, while failure or dry-run restores the controls. Brew bundle installation uses `BundleInstallDecision` with the same live-complete/dry-run-reset distinction.
 - **Updex**: `EnableFeature`/`DisableFeature`/`UpdateFeatures` skip their `pkexec` call entirely under dry-run and return empty/nil results; the helper binary itself (`cmd/chairlift-updex-helper`, dispatch logic in `internal/updexhelper`) also honors `--dry-run` for `update`, matching `enable-feature`/`disable-feature`, as defense-in-depth even though it's unreachable from the wrapper today.
 - **bootc**: `StageUpdate` short-circuits before invoking pkexec: it logs the would-be command, emits a synthetic `EventMessage` + `EventComplete` pair on the progress channel, and returns — the stage script is never actually run (see the exception above for the toast/subtitle split).
 - **Homebrew tap trust**: `trustTap` (`internal/views/updates_page.go`) computes `decision := actionmsg.TapTrust(homebrew.IsDryRun(), tap.Name)` once, after a successful `homebrew.TrustPackages` call, and gates removing the tap's row, hiding the group, and refreshing outdated packages on `decision.MutateUI`.
@@ -1169,12 +1169,12 @@ page_name:
 | `updates_page` | `flatpak_updates_group` | Flatpak pending updates |
 | `updates_page` | `brew_updates_group` | Homebrew outdated packages |
 | `updates_page` | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); hidden unless there is something to trust |
-| `applications_page` | `flatpak_user_group` | User Flatpak applications |
-| `applications_page` | `flatpak_system_group` | System Flatpak applications |
-| `applications_page` | `brew_group` | Homebrew formulae and casks |
+| `applications_page` | `flatpak_user_group` | User Flatpak applications with uninstall actions |
+| `applications_page` | `flatpak_system_group` | System Flatpak applications with uninstall actions |
+| `applications_page` | `brew_group` | Installed Homebrew formulae/casks with uninstall and formula pin/unpin actions |
 | `applications_page` | `brew_search_group` | Typed Homebrew formula/cask search and confirmed install |
 | `applications_page` | `brew_bundles_group` | Curated `*.Brewfile` bundles discovered from every configured `bundles_paths` directory, with guarded install actions |
-| `applications_page` | `applications_installed_group` | Installed apps launcher (configurable `app_id`, default: Bazaar) |
+| `applications_page` | `applications_installed_group` | External Flatpak-manager launcher for discovery/install (configurable `app_id`, default: Bazaar); ChairLift has no direct Flatpak-install UI |
 | `maintenance_page` | `maintenance_cleanup_group` | Custom cleanup scripts (5min timeout, pkexec for sudo); **disabled by default** |
 | `maintenance_page` | `maintenance_brew_group` | Homebrew cleanup (deferred visibility) |
 | `maintenance_page` | `maintenance_flatpak_group` | Flatpak unused cleanup (deferred visibility) |

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -22,13 +22,13 @@ Wraps the `brew` CLI. Uses JSON output (`--json=v2`) for structured data where a
 | `ListOutdated()` | `brew outdated --json=v2` | 30s | JSON parsed; returns both formulae and casks |
 | `Search(query)` | `brew search --formula <query>`, then `brew search --cask <query>` | 30s each | Text output parsed into typed formula/cask results; one namespace's normal no-match exit is treated as empty |
 | `Install(name, isCask)` | `brew install [--cask] <name>` | 30m | State-changing, dry-run aware |
-| `Uninstall(name, isCask)` | `brew uninstall [--cask] <name>` | 30m | State-changing |
+| `Uninstall(name, isCask)` | `brew uninstall [--cask] <name>` | 30m | State-changing, dry-run aware |
 | `Upgrade(name)` | `brew upgrade [<name>]` | 30m | State-changing; empty name upgrades all |
 | `Update()` | `brew update` | 30m | State-changing |
-| `Pin(name)` / `Unpin(name)` | `brew pin/unpin <name>` | 30m | State-changing |
+| `Pin(name)` / `Unpin(name)` | `brew pin/unpin <name>` | 30m | State-changing, dry-run aware |
 | `Cleanup()` | `brew cleanup` | 30m | State-changing; returns output string |
 | `BundleDump(path, force)` | `brew bundle dump [--file=<path>] [--force]` | 30m | State-changing; writes to file path |
-| `BundleInstall(path)` | `brew bundle install [--file=<path>]` | 30m | State-changing |
+| `BundleInstall(path)` | `brew bundle install [--file=<path>]` | 30m | State-changing, dry-run aware |
 | `AvailableBundles(paths)` | none | — | Discovers immediate `*.Brewfile` entries from every configured directory |
 
 ### State-changing commands
@@ -98,6 +98,26 @@ generation, nil-guards the independently configurable installed-package
 group, and clear-then-repopulates separate formula/cask `rowset.Tracker`
 values.
 
+### Installed Homebrew actions
+
+Each installed formula row has Pin/Unpin and Uninstall controls; each cask row
+has Uninstall. A formula's pinned state is visible in both its subtitle and
+the Pin/Unpin label. The row shares one `actionstate.Gate` across all of its
+controls, so a pin and uninstall cannot overlap. Every action requires an
+Adwaita confirmation: pin/unpin is suggested, while uninstall is destructive
+and identifies whether the target is a formula or cask.
+
+After confirmation, all controls on the row become insensitive and the
+primary control shows `Pinning...`, `Unpinning...`, or `Uninstalling...`;
+only then does a worker goroutine call `homebrew.Pin`, `Unpin`, or
+`Uninstall(name, isCask)`. `actionstate.PackagePin` and
+`PackageUninstall` enumerate the outcomes. Failure restores the original
+controls and reports the error, and dry-run success restores them with an
+explicit preview toast. Live success completes the old controls and starts
+the generation-guarded `loadHomebrewPackages` refresh. The refresh, rather
+than the action callback, owns row replacement, so overlapping loads cannot
+publish stale installed state.
+
 ### Error handling
 
 `runBrewCommand` is a thin wrapper: it applies the dry-run skip (before any `exec.Cmd` exists), builds a context from `commandTimeout(args)`, and delegates to the unexported `runBrewCommandAt(ctx context.Context, exe string, args ...string) (string, error)`, always passing `"brew"`. The executable path and context are parameters purely so `runner_test.go` can drive a `#!/bin/sh` script from `t.TempDir()` and control the deadline — the same seam `runStageStreaming` gives `internal/bootc`. No exported function takes a `context.Context`: callers get deadlines, not cancellation.
@@ -148,7 +168,8 @@ Two of the eight small, puregotk-free packages under `internal/views/` (the othe
   - `BundleInstallDecision{Complete bool; Toast string}` + `BundleInstall(dryRun bool, name string) BundleInstallDecision` — completes a successfully installed bundle row in live mode, or resets it after a dry-run preview (issue #8)
   - `Cleanup(dryRun bool, tool, output string) string` — Homebrew/Flatpak cleanup toast (c1)
   - `Install(dryRun bool, pkgName string) string` — Homebrew install toast (c2)
-  - `Uninstall(dryRun bool, appID string) string` — Flatpak uninstall toast (c2)
+  - `Uninstall(dryRun bool, name string) string` — Homebrew or Flatpak uninstall toast (c2)
+  - `Pin(dryRun bool, name string, pin bool) string` — Homebrew formula pin/unpin toast (c2)
   - `Upgrade(dryRun bool, pkgName string) string` — Homebrew per-package upgrade toast (c3)
   - `Update(dryRun bool, appID string) string` — Flatpak per-app update toast (c3)
   - `SelfUpdate(dryRun bool, tool string) string` — Homebrew self-update ("Update Homebrew" button) toast (c3)
@@ -157,13 +178,13 @@ Two of the eight small, puregotk-free packages under `internal/views/` (the othe
   - `FeatureToggleDecision{Confirm bool; Toast string}` + `FeatureToggle(dryRun, enable bool, name string) FeatureToggleDecision` — gates whether `onFeatureToggled`'s switch confirms the flip or reverts it (c5)
   - `FeatureUpdate(dryRun bool) string` — Features page "Update" button toast (c5)
 
-  The plain-`string` functions (`BundleDump`, `Cleanup`, `Install`, `Uninstall`, `Upgrade`, `Update`, `SelfUpdate`, `BootcStage`, `FeatureUpdate`) are correct as-is because the state-changing/no-op decision for those actions is already made and already tested one layer down, in the relevant wrapper package (`internal/homebrew`, `internal/flatpak`, `internal/bootc`, `internal/updex`) — there is nothing left for the view to gate beyond the toast wording. The four decision-struct functions exist because their call sites have no such wrapper-layer gate for the *second*, UI-side effect: script execution has no wrapper package; a bundle row must distinguish a real completion from a dry-run wrapper success; tap-trust row removal and switch confirmation are view-local state that the wrapper's own dry-run skip does not touch.
+  The plain-`string` functions (`BundleDump`, `Cleanup`, `Install`, `Uninstall`, `Pin`, `Upgrade`, `Update`, `SelfUpdate`, `BootcStage`, `FeatureUpdate`) select toast wording only. Where an application action also changes row controls or requests an inventory refresh, the separate tested `actionstate` decision owns that UI-side effect. The four decision-struct functions in `actionmsg` exist because their call sites have no wrapper- or `actionstate`-level gate for the *second* effect: script execution has no wrapper package; a bundle row must distinguish a real completion from a dry-run wrapper success; tap-trust row removal and switch confirmation are view-local state that the wrapper's own dry-run skip does not touch.
 
 ### View-layer update action state (`internal/views/actionstate`)
 
 `internal/views/actionstate` is one of the eight puregotk-free leaf packages
 under `internal/views`. It owns the state machines and complete outcome tables
-for the Updates page's Homebrew mutation controls:
+for the Applications and Updates pages' Homebrew mutation controls:
 
 - `Gate.TryStart` atomically moves idle to running and rejects every repeated
   callback while running; `Reset` makes a failed, previewed, or fully-refreshed
@@ -175,6 +196,10 @@ for the Updates page's Homebrew mutation controls:
   restores the control without changing rows; dry-run success also restores
   it without a refresh; live success requests both immediate row removal and
   a full outdated-metadata refresh.
+- `PackageInstall`, `PackageUninstall`, and `PackagePin` share the installed
+  inventory mutation outcomes: failure and dry-run success restore the row
+  controls without a refresh; live success completes the old controls and
+  requests a generation-guarded installed-package refresh.
 - `MetadataUpdate(succeeded, dryRun)` returns exactly three outcomes: failure
   and dry-run success restore the top-level control without refreshing; live
   success requests a refresh and deliberately does not restore the control
@@ -190,9 +215,9 @@ for the Updates page's Homebrew mutation controls:
 `actionstate_test.go` table-tests every outcome, races 64 callers against one
 action gate (requiring exactly one acquisition), and proves 64 concurrent
 refresh requests receive unique generations with exactly one current.
-`wiring_test.go` statically checks the
-puregotk-importing `updates_page.go` uses those decisions, progress labels,
-gates, row removal, count decrement, versioned refresh callbacks, and
+`wiring_test.go` and `applications_wiring_test.go` statically check the
+puregotk-importing views use those decisions, confirmation/progress states,
+shared gates, row removal, count decrement, versioned refresh callbacks, and
 clear/add bookkeeping; no `_test.go` is added to `internal/views`.
 
 ### View-layer update badge state (`internal/views/badgestate`)
@@ -543,6 +568,15 @@ completion claims. The Homebrew path restores its install control after a
 dry-run and does not refresh, because nothing changed; only a live success
 completes the control and starts the generation-guarded installed-package
 refresh described above.
+
+Installed Homebrew formula/cask rows follow the same decision path for
+uninstall, and formula rows add pin/unpin. They confirm before starting,
+disable every mutation control on the row while the worker runs, use
+`actionmsg.Uninstall`/`actionmsg.Pin` for live versus preview wording, restore
+on failure or dry-run, and refresh the installed inventory only after live
+success. New Flatpak discovery and install deliberately remain in the
+configured external manager; ChairLift's direct Flatpak UI lists and
+uninstalls installed applications.
 
 The Flatpak list refresh after uninstall remains unconditional because it
 re-queries live state either way. Each successful loader branch first clears


### PR DESCRIPTION
## Summary
- add confirmed uninstall actions for installed Homebrew formulae and casks
- add confirmed formula pin/unpin actions with shared row gates, loading/error/dry-run states, and generation-guarded refreshes
- document the selected package-management boundary: ChairLift owns Homebrew actions while new Flatpak installs stay in the configured external manager
- add headless decision/message tests and GTK wiring checks

## Validation
- `make ci`
- two adversarial review passes (interaction state/concurrency and acceptance/docs/test-filter coverage)

Closes #65