### PR TITLE
Apply current gofmt output

### DIFF
--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -121,7 +121,7 @@ func TestResolveEffectiveOutputHasNoAnchorsOrAliases(t *testing.T) {
 			scalarNode("second-key"), anchoredValue,
 			aliasKey, scalarNode("via-alias-key"),
 			scalarNode("third-key"), aliasValue,
-			scalarNode("seq"), &yaml.Node{Kind: yaml.SequenceNode, Content: []*yaml.Node{aliasValue, scalarNode("plain")}},
+			scalarNode("seq"), {Kind: yaml.SequenceNode, Content: []*yaml.Node{aliasValue, scalarNode("plain")}},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- apply the formatter output required by `make bump`
- unblock the release target clean-tree guard

## Validation
- `make ci`