### PR TITLE
fix: correct Snow Linux repository URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS
 
 ChairLift is a GTK4/Libadwaita system-management GUI for
-[Snow Linux](https://github.com/frostyard/snow), written in idiomatic Go using
+[Snow Linux](https://github.com/frostyard/snosi), written in idiomatic Go using
 [puregotk](https://codeberg.org/puregotk/puregotk) bindings — **no CGO**. GTK,
 Libadwaita, and GLib shared libraries are loaded at runtime via `dlopen`. The UI
 is YAML-configuration-driven; feature groups toggle on and off per host.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <img src="data/icons/hicolor/scalable/apps/org.frostyard.ChairLift.svg">
     <h1>ChairLift</h1>
-    <p>A modern system management tool for <a href="https://github.com/frostyard/snow">Snow Linux</a></p>
+    <p>A modern system management tool for <a href="https://github.com/frostyard/snosi">Snow Linux</a></p>
     <p>Manage your Homebrew packages, monitor system health, and maintain your system with ease.</p>
 </div>
 

--- a/config.yml
+++ b/config.yml
@@ -60,6 +60,6 @@ features_page:
 help_page:
   help_resources_group:
     enabled: true
-    website: https://github.com/frostyard/snow
-    issues: https://github.com/frostyard/snow/issues
-    chat: https://github.com/frostyard/snow/discussions
+    website: https://github.com/frostyard/snosi
+    issues: https://github.com/frostyard/snosi/issues
+    chat: https://github.com/frostyard/snosi/discussions

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # ChairLift
 
-ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snow), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, bootc system updates, system features (via updex), and maintenance tasks.
+ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snosi), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, bootc system updates, system features (via updex), and maintenance tasks.
 
 The UI is YAML-configuration-driven, making it portable to other Linux distributions by toggling feature groups on or off.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,9 +278,9 @@ func defaultConfig() *Config {
 		HelpPage: PageConfig{
 			"help_resources_group": GroupConfig{
 				Enabled: true,
-				Website: "https://github.com/frostyard/snow",
-				Issues:  "https://github.com/frostyard/snow/issues",
-				Chat:    "https://github.com/frostyard/snow/discussions",
+				Website: "https://github.com/frostyard/snosi",
+				Issues:  "https://github.com/frostyard/snosi/issues",
+				Chat:    "https://github.com/frostyard/snosi/discussions",
 			},
 		},
 	}

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snow), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, bootc system updates (staged via the snow `bootc-update-stage` script), system features (via updex), and maintenance tasks. The UI is YAML-configuration-driven, making it portable to other Linux distributions by toggling feature groups on/off.
+ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snosi), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, bootc system updates (staged via the snow `bootc-update-stage` script), system features (via updex), and maintenance tasks. The UI is YAML-configuration-driven, making it portable to other Linux distributions by toggling feature groups on/off.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- update Snow Linux links to the canonical `frostyard/snosi` repository
- correct website, issue, and discussion URLs in runtime defaults and maintainer config
- keep README, docs, AGENTS, and yeti references consistent

## Testing
- `make test`
- `git diff --check`