### PR TITLE
docs: add agent prompts catalog

### DIFF
--- a/docs/prompts/implement-issue.md
+++ b/docs/prompts/implement-issue.md
@@ -1,0 +1,28 @@
+# Implement an issue
+
+Use this prompt for a scoped ChairLift feature, fix, or maintenance issue.
+
+```text
+Implement [ISSUE OR TASK] in ChairLift.
+
+Before editing:
+1. Read AGENTS.md, every file in docs/agents/skills/, and the relevant current-state documentation.
+2. Inspect the existing implementation and tests; do not infer behavior from historical plans.
+3. State the intended change and identify affected repository invariants.
+
+While implementing:
+- Keep the GTK main thread free of external tool calls and marshal UI updates through sgtk.RunOnMainThread.
+- Preserve the fixed PolicyKit/helper privilege boundary; do not introduce arbitrary privileged execution.
+- Respect config-driven group visibility and nil-guard cross-group widgets.
+- Put non-UI logic in a pure package where it can be tested headlessly.
+- Add regression tests that exercise the actual failure mode and all affected collection entries.
+- Update current-state documentation when behavior, configuration, dependencies, or install layout changes.
+
+Before finishing:
+1. Run focused tests while iterating.
+2. Run make ci.
+3. Review git diff and git status for accidental or missing files.
+4. Summarize behavior changed, tests run, and any remaining limitation.
+
+Do not weaken tests or repository invariants to make the change pass.
+```

--- a/docs/prompts/index.md
+++ b/docs/prompts/index.md
@@ -1,0 +1,22 @@
+# Agent prompt catalog
+
+These reusable prompts give coding agents a consistent starting point for
+common ChairLift tasks. Copy a prompt, replace its bracketed placeholders, and
+include the relevant issue or diff.
+
+The prompts supplement rather than replace repository instructions. Agents
+must read and follow `AGENTS.md` and the files under `docs/agents/skills/`
+before changing code. When a prompt conflicts with repository instructions,
+the repository instructions take precedence.
+
+## Catalog
+
+| Prompt | Use it for |
+|---|---|
+| [Implement an issue](implement-issue.md) | Planning, coding, testing, and documenting a scoped issue |
+| [Review a change](review-change.md) | Risk-focused review of a branch or pull request |
+| [Reconcile documentation](reconcile-documentation.md) | Checking current-state docs against source and configuration |
+
+All implementation work should finish with `make ci`. If the environment
+cannot run a gate, report the exact command and reason instead of claiming it
+passed.

--- a/docs/prompts/reconcile-documentation.md
+++ b/docs/prompts/reconcile-documentation.md
@@ -1,0 +1,18 @@
+# Reconcile documentation
+
+Use this prompt when behavior or configuration changed, or when documentation
+may have drifted.
+
+```text
+Reconcile ChairLift's current-state documentation for [TOPIC].
+
+Read AGENTS.md, docs/documentation-consistency.md, and every file in docs/agents/skills/. Treat README-go-port.md and docs/plans/ as historical, not as sources of current behavior.
+
+Trace the topic to its live sources:
+- config.yml and internal/config for page/group keys and defaults;
+- internal/navigation and page builders for visibility and shortcuts;
+- go.mod for dependency versions;
+- Makefile, .goreleaser.yaml, helper constants, and PolicyKit files for commands and install paths.
+
+Update every current-state restatement in README.md, CONFIG.md, docs/, and yeti/ that is relevant. Search for old terms and contradictory claims rather than only adding a new paragraph. Run the focused tests named by docs/documentation-consistency.md when applicable, then run make ci. Report the files reconciled and the source used to verify each factual claim.
+```

--- a/docs/prompts/review-change.md
+++ b/docs/prompts/review-change.md
@@ -1,0 +1,21 @@
+# Review a change
+
+Use this prompt for a branch or pull-request review.
+
+```text
+Review [BRANCH, COMMIT, OR DIFF] for correctness and regressions in ChairLift.
+
+Read AGENTS.md and every file in docs/agents/skills/ first. Inspect surrounding code and tests, not only the diff. Prioritize findings over summary.
+
+Check specifically for:
+- privileged mutations bypassing the fixed pkexec helper and PolicyKit policy;
+- external commands or widget updates running on the wrong thread;
+- stale async workers replacing newer state;
+- disabled configuration groups leaving nil widgets that later code dereferences;
+- package actions losing known rows/counts on failure or dry-run;
+- navigation, page visibility, and shortcut inventories drifting apart;
+- tests skipped by the repository's TestI/Integration CI name filter;
+- current-state documentation contradicting source, config, go.mod, or install files.
+
+For each finding, give the file and line, explain the concrete failure mode, and suggest the smallest safe correction. Distinguish blocking defects from optional improvements. If there are no findings, say so and identify any testing gap that still limits confidence.
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,3 +3,8 @@ site_name: tools/chairlift
 nav:
   - Home: "index.md"
   - Reference: "reference.md"
+  - Agent prompts:
+      - Catalog: "prompts/index.md"
+      - Implement an issue: "prompts/implement-issue.md"
+      - Review a change: "prompts/review-change.md"
+      - Reconcile documentation: "prompts/reconcile-documentation.md"


### PR DESCRIPTION
## Summary
- add a `docs/prompts/` catalog for issue implementation, change review, and documentation reconciliation
- ground prompts in ChairLift's repository invariants and required validation workflow
- expose the catalog in MkDocs navigation

## Validation
- `make ci`
- prompt catalog link check
- `git diff --check`

Closes #114