### PR TITLE
chore: add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{go,mod}]
+indent_style = tab
+indent_size = tab
+
+[Makefile]
+indent_style = tab
+indent_size = tab
+
+[*.sh]
+indent_size = 4
+
+[*.{md,mdc}]
+trim_trailing_whitespace = false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,9 @@ make build
 3. Add or update tests for changed behavior.
 4. Update relevant documentation when behavior, configuration, dependencies,
    or installation changes.
-5. Format Go changes with `make fmt`.
+5. Use an EditorConfig-compatible editor so new text follows the repository's
+   line-ending, indentation, final-newline, and whitespace conventions.
+6. Format Go changes with `make fmt`.
 
 Tests for packages that import puregotk cannot run on headless systems because
 GTK libraries are loaded during package initialization. Extract testable logic


### PR DESCRIPTION
## Summary

- add a root EditorConfig for UTF-8, LF endings, final newlines, and trailing-whitespace handling
- encode gofmt/`go.mod` tabs, Make recipe tabs, two-space repository defaults, and four-space shell indentation
- preserve intentional Markdown hard-break whitespace and document EditorConfig use for contributors

## Validation

- `make ci`
- line-ending, final-newline, and trailing-whitespace checks for the changed files

Closes #115