### PR TITLE
chore: add agent correction capture

### DIFF
--- a/.memory/README.md
+++ b/.memory/README.md
@@ -1,0 +1,32 @@
+# `.memory/` - agent correction capture
+
+This directory is ChairLift's durable, version-controlled store for learning
+artifacts produced by AI-assisted work. Read it before changing the repository
+so verified corrections and session findings carry forward instead of being
+rediscovered.
+
+Use this directory for deltas between what an agent believed and what the
+repository, a command, or a maintainer established as true. General
+architecture and operating rules still belong in `AGENTS.md`,
+`docs/agents/skills/`, or `yeti/`; promote a correction there once it becomes a
+stable rule.
+
+## Corrections
+
+Store corrections in `corrections.jsonl`, creating it when the first
+correction is recorded. Keep it append-only, with one JSON object per line:
+
+```json
+{"date":"YYYY-MM-DD","scope":"repo-relative path or subsystem","correction":"the prior belief and verified reality","evidence":"file:line, command output, issue, or PR","promoted_to":null}
+```
+
+- `date` is the date the correction was established.
+- `scope` identifies where the correction applies.
+- `correction` states both the mistaken belief and the verified reality.
+- `evidence` identifies how the correction was verified; do not use
+  unsupported impressions.
+- `promoted_to` names the durable documentation containing the rule, or is
+  `null` until promotion.
+
+Do not record secrets, credentials, personal data, or unverified speculation
+in this directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,13 @@ before working. Write content there to be maximally useful to an AI agent
 understanding the codebase — detailed architecture and rationale rather than
 user-facing guides.
 
+**.memory/ directory** is the repository's committed correction store for AI
+agents. Read `.memory/README.md` and any learning artifacts in that directory
+before working. Record verified corrections there when a session establishes
+that a prior belief about ChairLift was wrong, and promote stable rules into
+this file, `docs/agents/skills/`, or `yeti/` as appropriate. Never record
+secrets or personal data because the directory is version-controlled.
+
 ## Learned agent skills
 
 **docs/agents/skills/** Read every file in `docs/agents/skills/` before


### PR DESCRIPTION
## Summary

- add a tracked `.memory/` store for durable agent corrections and learning artifacts
- document the append-only JSONL correction format and privacy constraints
- direct future agents to read and maintain the correction store from `AGENTS.md`

## Validation

- `git diff --check`
- verified `.memory/README.md` is tracked and present

Closes #117
