### PR TITLE
chore: add Claude mechanical enforcement

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "ask": [
+      "Bash(gh issue close *)",
+      "Bash(gh pr close *)",
+      "Bash(gh pr merge *)",
+      "Bash(git commit *)",
+      "Bash(git push *)",
+      "Bash(rm *)"
+    ],
+    "deny": [
+      "Bash(git clean *)",
+      "Bash(git push *--force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard*)",
+      "Bash(sudo *)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./**/.env)",
+      "Read(./**/.env.*)"
+    ],
+    "disableBypassPermissionsMode": "disable"
+  }
+}


### PR DESCRIPTION
## Summary

- add shared Claude Code project settings with the official JSON schema
- require confirmation for repository publication, closure, merge, and deletion operations
- deny destructive Git and privileged commands, force pushes, and reads of environment-secret files
- disable bypass-permissions mode for the project

## Validation

- `jq empty .claude/settings.json`
- `git diff --check`
- `claude doctor`

Closes #122
