### PR TITLE
chore: add structural agent stop gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,17 @@
       "Bash(git reset --hard:*)",
       "Bash(git clean:*)"
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "git diff HEAD --check >&2"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -41,6 +41,12 @@ gate documented in `AGENTS.md`.
 make ci
 ```
 
+Claude Code sessions have an additional structural stop gate in
+`.claude/settings.json`. Before an agent stops, it runs
+`git diff HEAD --check` and blocks completion when staged or unstaged tracked
+changes contain whitespace errors. This fast check complements rather than
+replaces the full `make ci` gate.
+
 To inspect the same coverage scope locally without relying on the external
 upload, run:
 


### PR DESCRIPTION
## Summary
- add a Claude Code `Stop` hook that runs `git diff HEAD --check`
- block agent completion when tracked changes contain whitespace errors
- document how the fast structural gate complements `make ci`

The required `.claude/settings.json` landed while this issue was open; this change makes that settings file enforce a concrete structural gate rather than duplicating it.

## Validation
- `jq empty .claude/settings.json`
- `claude --settings .claude/settings.json --version`
- verified the configured command rejects a trailing-whitespace fixture
- `make ci`

Closes #124