### PR TITLE
docs: add Claude session summary artifact

### DIFF
--- a/.claude/session-summary.md
+++ b/.claude/session-summary.md
@@ -1,0 +1,30 @@
+# Session summary
+
+This file is the latest Claude Code handoff for ChairLift. Read it at the
+start of a session and update it before ending work that another session must
+continue. Replace the prior handoff instead of accumulating a session log, and
+record only verified repository context. Durable corrections belong in
+`.memory/corrections.jsonl`; stable guidance belongs in `AGENTS.md`,
+`docs/agents/skills/`, or `yeti/`.
+
+Do not record credentials, personal data, or other secrets.
+
+## Objective
+
+None. There is no active handoff.
+
+## Completed work
+
+None.
+
+## Validation
+
+None.
+
+## Remaining work
+
+None.
+
+## Handoff context
+
+None.

--- a/.claude/skills/chairlift/SKILL.md
+++ b/.claude/skills/chairlift/SKILL.md
@@ -4,4 +4,7 @@ description: Repository guidance for working on ChairLift
 ---
 
 Before changing ChairLift, read and follow `AGENTS.md`, every file in
-`docs/agents/skills/`, and the relevant architecture documentation in `yeti/`.
+`docs/agents/skills/`, the latest `.claude/session-summary.md` handoff, and the
+relevant architecture documentation in `yeti/`. Before handing unfinished
+work to another session, update the session summary with the objective,
+completed work, validation, remaining work, and relevant repository context.


### PR DESCRIPTION
## Summary

- add the `.claude/session-summary.md` handoff artifact
- define focused fields for objectives, completed work, validation, remaining work, and context
- teach the ChairLift Claude skill to read and maintain the latest handoff

## Testing

- `git diff --check`

Closes #123