### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!-- Explain what changed and why. Keep the pull request focused on one concern. -->
+
+-
+
+## Related issue
+
+<!-- Use a closing keyword when this pull request fully resolves the issue. -->
+
+Closes #
+
+## Validation
+
+<!-- List exact commands and results. Explain any check that could not run. -->
+
+- [ ] `make ci`
+- [ ] Additional relevant checks (including `make e2e` when applicable):
+
+## Tests and documentation
+
+<!-- Describe regression coverage for changed behavior, or explain why it is not needed. -->
+
+- Tests:
+- Documentation:
+
+## Review readiness
+
+- [ ] The diff contains no unrelated refactors or generated artifacts.
+- [ ] Changed behavior has CI-enforced regression coverage, or this change does
+      not alter behavior.
+- [ ] Relevant repository invariants in `AGENTS.md` remain intact.
+- [ ] I reviewed the change against `docs/review-rubric.md`.


### PR DESCRIPTION
## Summary

- add a default pull request template covering scope, issue linkage, validation, tests, documentation, and review readiness
- align author prompts with `CONTRIBUTING.md`, `AGENTS.md`, and the review rubric

## Related issue

Closes #108

## Validation

- [x] `make ci`
- [x] Verified the accepted `.github/pull_request_template.md` path and required sections

## Tests and documentation

- Tests: not applicable; this change adds repository metadata only
- Documentation: the template itself documents pull request submission expectations

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] This change does not alter application behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.