### PR TITLE
docs: expand contributor workflow guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,28 +10,59 @@ Thank you for helping improve ChairLift.
 - Review [AGENTS.md](AGENTS.md) for repository invariants and development
   guidance.
 
-## Development setup
+## Local setup
 
-ChairLift requires Go and builds without CGO. Runtime dependencies and
-installation details are listed in the [README](README.md).
+ChairLift requires Git, Make, the Go version declared in
+[`go.mod`](go.mod), and `golangci-lint` for the complete local quality gate.
+The application builds without CGO, but the race-detector gate requires a
+working CGO toolchain. GTK4 and Libadwaita are runtime dependencies and are
+needed for E2E testing, not ordinary builds.
+
+Fork the repository, clone your fork, and register the upstream repository:
 
 ```sh
-git clone https://github.com/frostyard/chairlift.git
+git clone git@github.com:YOUR-USER/chairlift.git
 cd chairlift
+git remote add upstream https://github.com/frostyard/chairlift.git
+git fetch upstream
 make deps
 make build
 ```
 
-## Making changes
+Installation details and optional runtime dependencies are listed in the
+[README](README.md).
 
-1. Create a focused branch from the current default branch.
-2. Keep changes small and limited to one concern.
-3. Add or update tests for changed behavior.
-4. Update relevant documentation when behavior, configuration, dependencies,
-   or installation changes.
-5. Use an EditorConfig-compatible editor so new text follows the repository's
-   line-ending, indentation, final-newline, and whitespace conventions.
-6. Format Go changes with `make fmt`.
+## Development workflow
+
+1. Start a focused branch from the current upstream default branch:
+
+   ```sh
+   git fetch upstream
+   git switch -c TYPE/ISSUE-DESCRIPTION upstream/main
+   ```
+
+2. Keep the change limited to one issue and avoid unrelated refactors or
+   generated artifacts.
+3. Add or update regression tests for changed behavior. Use `make test` and
+   `make lint` for a quick local iteration loop, and format Go changes with
+   `make fmt`.
+4. Update the relevant current-state documentation. Changes to behavior,
+   configuration, dependencies, or installation layout must follow the
+   [documentation consistency checklist](docs/documentation-consistency.md).
+5. Run `make ci` before pushing. Rebase onto the latest `upstream/main`, rerun
+   the gate, then push the branch to your fork:
+
+   ```sh
+   git fetch upstream
+   git rebase upstream/main
+   make ci
+   git push --set-upstream origin HEAD
+   ```
+
+Use an EditorConfig-compatible editor so new text follows the repository's
+line-ending, indentation, final-newline, and whitespace conventions.
+
+## Testing constraints
 
 Tests for packages that import puregotk cannot run on headless systems because
 GTK libraries are loaded during package initialization. Extract testable logic
@@ -39,26 +70,45 @@ into a pure-Go package under `internal/` rather than adding tests to those
 packages. Name ordinary unit tests so they do not begin with `TestI` or contain
 `Integration`; CI reserves those names for tests requiring a real environment.
 
-## Validation
+The enforced unit and race gates run tests under `internal/...`. Logic moved
+outside that tree needs a separately enforced test path; do not rely on an
+ad-hoc local test that CI never executes.
 
-Run the same checks used by CI before submitting:
+Run `make e2e` when a change affects application startup, GTK integration,
+installation staging, command-line behavior, or the privileged helper. This
+target requires GTK4, Libadwaita, `dbus-run-session`, GNU `timeout`, and Xvfb.
 
-```sh
-make ci
-```
+## Quality gates
 
-For a quicker iteration loop, use `make test` and `make lint`, then run
-`make ci` before opening or updating a pull request.
+`make ci` is required before opening or updating a pull request. It mirrors the
+host-independent checks in the repository's `Tests` workflow:
+
+| Gate | What it checks |
+|---|---|
+| Verify | `go.mod`/`go.sum` remain tidy, `go vet` passes, and Go files are formatted |
+| Lint | `golangci-lint` reports no violations |
+| Unit tests | Headless tests under `internal/...` pass with the CI name filters |
+| Race detection | The same internal test scope passes with the race detector |
+| Build | Linux amd64, Linux arm64, and the native binaries compile |
+
+The hosted workflow additionally runs `make e2e` with its runtime dependencies.
+Codecov reports the same internal test scope and rejects project coverage
+regressions greater than one percentage point; that remote signal is not
+reproduced by `make ci`. See the [quality dashboard](docs/quality.md) for the
+canonical description of every signal.
 
 ## Pull requests
 
-- Link the relevant issue.
-- Explain what changed and why.
-- Describe how the change was tested.
+- Target `main` from the branch on your fork and use a closing keyword for an
+  issue the pull request fully resolves.
+- Complete every section of the pull request template: explain what changed
+  and why, list exact validation commands and results, and describe regression
+  coverage and documentation changes.
+- Keep the commit history and changed-files list focused on the issue.
+- Ensure every required GitHub check passes, and inspect a failed job's logs
+  rather than relying on the aggregate status.
 - Review proposed changes against the
   [pull request review rubric](docs/review-rubric.md).
-- Keep unrelated refactors out of the pull request.
-- Ensure all CI checks pass.
 
 By contributing, you agree that your contributions are licensed under the
 project's [GPL-3.0-or-later license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -288,10 +288,9 @@ suite tests them only by executing the already-built application.
 
 ### Contributing
 
-Contributions are welcome! Please feel free to submit issues and pull requests.
-Changes that affect behavior, configuration, dependencies, or installation
-layout should also follow the
-[documentation consistency checklist](docs/documentation-consistency.md).
+Contributions are welcome. See the [contributor guide](CONTRIBUTING.md) for
+local setup, the fork and pull-request workflow, testing constraints,
+documentation expectations, and required quality gates.
 
 ---
 


### PR DESCRIPTION
## Summary

- expand the contributor guide with fork setup and a focused branch workflow
- document testing constraints, `make ci` gates, E2E expectations, and hosted coverage signals
- define PR preparation and review expectations and link the guide from the README

## Related issue

Closes #145

## Validation

- [x] `make ci`
- [x] `git diff --check`

## Tests and documentation

- Tests: no behavior changed; the existing suite passed through `make ci`
- Documentation: expanded `CONTRIBUTING.md` and linked it from `README.md`

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.