### PR TITLE
docs: refresh architecture for bootc era

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,151 +1,225 @@
 # Architecture
 
-**Analysis Date:** 2026-01-26
+**Analysis Date:** 2026-08-09
 
 ## Pattern Overview
 
-**Overall:** Layered GTK4/Libadwaita Desktop Application
+**Overall:** Layered GTK4/Libadwaita desktop application with dedicated
+system-tool adapters.
 
 **Key Characteristics:**
 - Pure Go implementation using puregotk bindings (no CGO required)
-- Clean separation between UI, business logic, and external tool wrappers
-- YAML-driven configuration for page/feature enablement
-- Dry-run mode propagated through all state-changing operations
-- Async operations with GTK main-thread callback pattern
+- GObject-registered application and window types backed by snowkit
+- Configuration-driven page and feature-group visibility
+- Dedicated Homebrew, Flatpak, bootc, and Updex integrations
+- Asynchronous external work with GTK main-thread UI updates
+- Dry-run mode propagated across every state-changing path
+
+## Runtime Package Layout
+
+```text
+cmd/chairlift/main.go
+    -> internal/app
+        -> internal/window
+            -> internal/config
+            -> internal/navigation
+            -> internal/views
+                -> internal/{bootc,flatpak,homebrew,updex}
+                -> internal/views/{actionmsg,actionstate,badgestate,bundleview,
+                                   featurestatus,flatpakstatus,rowset,trustmsg}
+        -> internal/{bootc,flatpak,homebrew,updex,views} (dry-run setup)
+
+cmd/chairlift-updex-helper/main.go
+    -> internal/updexhelper
+    -> github.com/frostyard/updex/updex
+```
+
+`internal/version` stores build metadata used by the main binary and window.
+`internal/installcheck` is a test-only package that verifies documentation,
+PolicyKit, Makefile, and release-package contracts.
 
 ## Layers
 
-**Entry Point (cmd):**
-- Purpose: Application bootstrap and version injection
-- Location: `cmd/chairlift/`
-- Contains: `main.go` - build version setup, app initialization
-- Depends on: `internal/app`, `internal/version`
-- Used by: N/A (entry point)
+### Entry Points (`cmd`)
 
-**Application Layer (app):**
-- Purpose: GTK Application lifecycle, keyboard shortcuts, activation
-- Location: `internal/app/`
-- Contains: `app.go` - Application struct wrapping adw.Application
-- Depends on: `internal/window`, `internal/nbc`, `internal/updex`, `internal/pm`
-- Used by: `cmd/chairlift/main.go`
+ChairLift builds two binaries:
 
-**Window Layer (window):**
-- Purpose: Main window UI composition, navigation, dialogs
-- Location: `internal/window/`
-- Contains: `window.go` - NavigationSplitView layout, sidebar, content stack
-- Depends on: `internal/views`, `internal/config`, `internal/version`
-- Used by: `internal/app`
+- `cmd/chairlift` injects build metadata, creates `internal/app.Application`,
+  and starts the GTK run loop.
+- `cmd/chairlift-updex-helper` is the narrowly scoped privileged executable
+  for Updex writes. It parses a fixed command grammar through
+  `internal/updexhelper` before calling the Updex Go API.
 
-**Views Layer (views):**
-- Purpose: Page content, UI actions, async data loading
-- Location: `internal/views/`
-- Contains: `userhome.go` - All page builders and event handlers
-- Depends on: `internal/config`, `internal/nbc`, `internal/updex`, `internal/pm`
-- Used by: `internal/window`
+### Application (`internal/app`)
 
-**Configuration Layer (config):**
-- Purpose: YAML config loading, feature enablement
-- Location: `internal/config/`
-- Contains: `config.go` - Config struct, loading, defaults
-- Depends on: None (uses gopkg.in/yaml.v3)
-- Used by: `internal/window`, `internal/views`
+`Application` is a registered `adw.Application` subtype. It owns the
+application lifecycle, detects `--dry-run`, propagates dry-run state to the
+integration and view packages, reuses the existing window on repeated
+activation, and registers keyboard accelerators from the window's visible
+navigation inventory.
 
-**External Tool Wrappers:**
-- Purpose: Interface with system tools (nbc, updex, brew, flatpak, snap)
-- Location: `internal/nbc/`, `internal/updex/`, `internal/pm/`
-- Contains: Command execution, JSON parsing, dry-run support
-- Depends on: External CLI tools via exec
-- Used by: `internal/views`
+### Window and Navigation (`internal/window`, `internal/navigation`)
 
-**Version Package:**
-- Purpose: Build-time version info storage
-- Location: `internal/version/`
-- Contains: `version.go` - Version/Commit/Date vars
-- Depends on: None
-- Used by: `cmd/chairlift`, `internal/window`
+`Window` is a registered `adw.ApplicationWindow` subtype. It loads
+configuration, creates `views.UserHome`, and composes an
+`adw.NavigationSplitView` from a sidebar and a `gtk.Stack`. It also implements
+the views' `ToastAdder` interface for success/error messages and update badges.
 
-## Data Flow
+`internal/navigation` is the single widget-free authority for page order,
+titles, icons, configuration groups, shortcuts, and page-selection
+transitions. `navigation.VisibleItems` removes functional pages whose groups
+are all statically disabled, always retains Help, and compacts Alt+number
+shortcuts. Both mouse and keyboard navigation call `Window.navigateToPage`,
+which applies the transition returned by `navigation.Resolve` to the sidebar,
+content stack, title, and collapsed split-view state.
 
-**Application Startup:**
+### Views (`internal/views`)
 
-1. `main.go` sets version info and creates Application via `app.New()`
-2. `app.New()` initializes package managers (Flatpak, Snap, Homebrew) and checks dry-run flag
-3. On activate signal, `window.New()` creates main window with navigation split view
-4. Window creates `views.UserHome` which asynchronously builds page content
-5. Each page loads data via goroutines, updating UI via `runOnMainThread()`
+`views.UserHome` coordinates six pages: Applications, Maintenance, Updates,
+System, Features, and Help. Shared widget references and page lookup live in
+`views.go`; each page's builders and handlers live in its own
+`*_page.go` file.
 
-**User Action Flow:**
+View handlers start external work in goroutines and marshal widget changes
+through `snowkit/gtk.RunOnMainThread`. Pure decision and bookkeeping logic is
+kept in the GTK-free packages below `internal/views` so it can be unit tested
+without loading native GTK libraries.
 
-1. User clicks button (e.g., "Update" on NBC)
-2. Button handler disables widget, shows progress state
-3. Goroutine executes operation via wrapper package (e.g., `nbc.Update()`)
-4. Progress events stream through channel, marshaled to main thread
-5. On completion, UI updated via `runOnMainThread()` with success/error toast
+### Configuration (`internal/config`)
 
-**State Management:**
-- No global state store; UI state is local to widgets
-- Config loaded once at window creation, stored in `UserHome.config`
-- Package manager instances are module-level singletons with mutex protection
-- Dry-run mode is a module-level flag propagated to all wrappers
+The configuration layer loads YAML, merges an authoritative file over built-in
+defaults, validates the result, and answers page/group enablement queries.
+The first existing candidate is authoritative. An unreadable, malformed, or
+invalid file returns a fail-closed configuration with all groups disabled;
+the window reports the retained `LoadError` through a persistent toast.
 
-## Key Abstractions
+Static group configuration determines the page inventory. Some enabled groups
+also apply runtime availability gates for optional tools, including the bootc
+host and stage-script checks.
 
-**ToastAdder Interface:**
-- Purpose: Decouple views from window for toast notifications
-- Examples: `internal/views/userhome.go:57-62`
-- Pattern: Dependency injection via constructor
+### System Integrations
 
-**Package Manager Wrapper Pattern:**
-- Purpose: Consistent interface to diverse package managers
-- Examples: `internal/pm/wrapper.go` wraps `github.com/frostyard/pm`
-- Pattern: Facade with dry-run support, availability caching
+- `internal/homebrew` wraps Homebrew listing, search, package actions,
+  bundles, updates, and tap trust.
+- `internal/flatpak` wraps installed applications, updates, uninstall, and
+  cleanup operations.
+- `internal/bootc` reads `bootc status --format json` and streams staged OS
+  update progress from the distribution-provided stage helper.
+- `internal/updex` uses the Updex Go API directly for reads and delegates
+  writes to the installed ChairLift helper.
+- `internal/updexhelper` validates the privileged helper's accepted argv and
+  constructs the corresponding Updex options.
 
-**Progress Event Channels:**
-- Purpose: Stream async operation progress to UI
-- Examples: `internal/nbc/nbc.go:247` (runNbcCommandStreaming), `internal/views/userhome.go:1529`
-- Pattern: Goroutine produces, main thread consumes via channel
+## Core Flows
 
-**Configuration Groups:**
-- Purpose: Feature flags for page sections
-- Examples: `internal/config/config.go:22-34`
-- Pattern: Hierarchical map lookup with defaults
+### Application Startup
 
-## Entry Points
+1. `cmd/chairlift/main.go` sets `internal/version` fields and calls
+   `app.New()`.
+2. `app.New()` registers command-line options and propagates dry-run mode.
+3. GTK activation calls `window.New()`. The window loads configuration and
+   builds the views.
+4. `navigation.VisibleItems` derives the sidebar and stack inventory from
+   static group configuration.
+5. The window builds sidebar rows, adds the corresponding view pages to the
+   content stack, selects the first visible page, and exposes the inventory to
+   the application.
+6. The application registers accelerators from the exact visible navigation
+   inventory and presents the window.
 
-**Binary Entry:**
-- Location: `cmd/chairlift/main.go`
-- Triggers: OS process launch
-- Responsibilities: Version injection, app creation, GTK run loop
+### Ordinary User Action
 
-**GTK Activate:**
-- Location: `internal/app/app.go:82` (onActivate)
-- Triggers: GTK application activate signal
-- Responsibilities: Window creation, present to user
+1. A per-page handler disables or marks the initiating widget as busy.
+2. The handler invokes the appropriate integration from a goroutine.
+3. Results are dispatched to the GTK main thread.
+4. The view updates rows and badges and reports success or failure through
+   `ToastAdder`.
 
-**Page Builders:**
-- Location: `internal/views/userhome.go` (buildSystemPage, buildUpdatesPage, etc.)
-- Triggers: Called from goroutine in `views.New()`
-- Responsibilities: Construct page UI, initiate async data loading
+State-changing handlers derive dry-run-aware text and UI mutation decisions
+from the GTK-free view subpackages. The integration packages also enforce
+dry-run behavior so preview mode does not execute the underlying mutation.
+
+### bootc Status and Staged Updates
+
+bootc status reads are unprivileged. `internal/bootc.GetStatus` executes
+`bootc status --format json` and parses booted, staged, and rollback
+deployments. `IsBootcBootedCached` gates bootc UI on a non-null booted
+deployment rather than a sentinel file or command exit status.
+
+The System page only displays deployment status. The Updates page owns
+staging:
+
+1. The group is shown only when the host is bootc-booted and
+   `/usr/libexec/bootc-update-stage` exists.
+2. The view calls `bootc.StageUpdate` and consumes `ProgressEvent` messages.
+3. `StageUpdate` runs `pkexec /usr/libexec/bootc-update-stage`; it does not run
+   `bootc upgrade` or implement image pull/switch policy inside ChairLift.
+4. The distribution-owned helper checks, downloads, and stages the next image.
+   The staged deployment is applied on restart.
+5. After completion, the view re-reads bootc status so its subtitle and update
+   badge reflect the actual deployment state.
+
+The progress channel carries message and completion events. Failures are
+returned as errors rather than duplicated as error events.
+
+## Privileged Boundary
+
+ChairLift has two fixed privileged update paths:
+
+| Operation | Unprivileged caller | PolicyKit executable |
+|-----------|---------------------|----------------------|
+| Stage a bootc OS image | `internal/bootc` | `/usr/libexec/bootc-update-stage` |
+| Enable, disable, or update Updex features | `internal/updex` | `/usr/bin/chairlift-updex-helper` |
+
+The executable paths are fixed in code and must exactly match the annotations
+in `data/org.frostyard.ChairLift.bootc.policy` and
+`data/org.frostyard.ChairLift.updex.policy`. The Updex policy additionally
+selects the permitted operation by the helper's first argument, while
+`internal/updexhelper` rejects unsupported or extra arguments before any
+write.
+
+ChairLift does not ship the bootc stage helper: staging mechanics are
+distribution policy, and an image enabling `bootc_updates_group` must provide
+the trusted helper at the fixed path. ChairLift does ship its Updex helper,
+because that executable is the application's validation boundary around
+Updex writes.
+
+Configured maintenance actions may separately request `pkexec` with
+`sudo: true`; they are explicit administrator-provided scripts rather than
+part of either update integration.
+
+## State and Concurrency
+
+- Widget and page state is owned by `Window` and `views.UserHome`; there is no
+  application-wide state store.
+- Integration dry-run flags and cached availability checks are package-level.
+- Update counts are held in the mutex-backed
+  `internal/views/badgestate.Counts`.
+- Refresh-generation gates prevent older asynchronous Homebrew queries from
+  overwriting newer results.
+- GTK objects are changed only on the main thread.
 
 ## Error Handling
 
-**Strategy:** Return errors up, display via toast notifications
+- Integration packages return errors, including custom typed errors where the
+  caller needs to distinguish missing tools, command failures, timeouts, or
+  cancellation.
+- View goroutines convert failures into error toasts and restore affected UI
+  controls on the main thread.
+- Configuration failures retain the source path and cause, disable all
+  configurable groups, and produce both a high-signal log message and a
+  persistent startup toast.
+- External command output is surfaced where useful, but errors are not
+  swallowed or represented as successful completion.
 
-**Patterns:**
-- Wrapper packages return custom Error types (e.g., `nbc.Error`, `nbc.NotFoundError`)
-- Views catch errors in goroutine callbacks and show via `toastAdder.ShowErrorToast()`
-- Progress streams include EventTypeError for inline error display
+## External Dependencies
 
-## Cross-Cutting Concerns
-
-**Logging:** Go standard library `log` package with `log.SetFlags(log.LstdFlags | log.Lshortfile)`
-
-**Validation:** Minimal; relies on config YAML schema and external tool validation
-
-**Authentication:** None internal; privileged operations use pkexec for PolicyKit auth
-
-**Thread Safety:** Mutex-protected singletons; `runOnMainThread()` for GTK thread marshaling
+- `codeberg.org/puregotk/puregotk`: GTK4 and Libadwaita bindings
+- `github.com/frostyard/snowkit`: GObject registration and GTK main-thread
+  dispatch
+- `github.com/frostyard/updex`: feature reads and privileged helper operations
+- `gopkg.in/yaml.v3`: configuration parsing
 
 ---
 
-*Architecture analysis: 2026-01-26*
+*Architecture analysis: 2026-08-09*


### PR DESCRIPTION
## Summary

- Replaces the stale NBC/shared-wrapper architecture map with the current bootc-era package layout.
- Documents canonical navigation ownership, per-page views, async UI flow, and configuration behavior.
- Clarifies the fixed PolicyKit boundaries for bootc staging and Updex writes.

## Related issue

Closes #144

## Validation

- [x] `make ci`
- [x] `go test ./internal/installcheck`
- [x] Grepped the architecture guide for removed package, file, and event-model claims.

## Tests and documentation

- Tests: No new regression test is needed because this is a documentation-only correction.
- Documentation: Rewrote `.planning/codebase/ARCHITECTURE.md` against the current source tree, README, and `yeti/OVERVIEW.md`.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.