### PR TITLE
ci: apply Copilot review feedback automatically

### DIFF
--- a/.github/workflows/copilot-review-apply.yml
+++ b/.github/workflows/copilot-review-apply.yml
@@ -1,0 +1,72 @@
+name: Apply Copilot review feedback
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: copilot-review-apply-${{ github.event.pull_request.number }}-${{ github.event.review.id }}
+  cancel-in-progress: false
+
+jobs:
+  request-fixes:
+    name: Request fixes for Copilot findings
+    if: >-
+      github.event.pull_request.state == 'open' &&
+      !github.event.pull_request.draft &&
+      contains(fromJSON('["copilot-pull-request-reviewer", "copilot-pull-request-reviewer[bot]"]'), github.event.review.user.login) &&
+      contains(fromJSON('["commented", "changes_requested"]'), github.event.review.state)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask Copilot to apply actionable review findings
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const review = context.payload.review;
+            const marker = `<!-- copilot-review-apply:${review.id} -->`;
+
+            // A COMMENTED review with no inline findings needs no fix cycle.
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listCommentsForReview,
+              {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                review_id: review.id,
+                per_page: 100,
+              },
+            );
+            if (reviewComments.length === 0) {
+              core.notice(`Copilot review ${review.id} has no inline findings.`);
+              return;
+            }
+
+            // Delivery can be retried; dispatch at most once for each review.
+            const issueComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pullNumber, per_page: 100 },
+            );
+            if (issueComments.some((comment) => comment.body?.includes(marker))) {
+              core.notice(`Review ${review.id} was already dispatched.`);
+              return;
+            }
+
+            const reviewURL = review.html_url;
+            const body = [
+              marker,
+              `@copilot Please address every actionable finding in [Copilot review ${review.id}](${reviewURL}). Follow \`AGENTS.md\` and the repository review rubric, keep the change within the pull request's existing scope, and run the relevant quality gates. If a finding should not be applied, explain why in the pull request instead of silently ignoring it.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pullNumber,
+              body,
+            });

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -77,6 +77,21 @@ For an agent-authored pull request, audit the signals in this order:
    repository invariants and learned skills, then record concrete findings on
    the pull request.
 
+## Automated Copilot feedback
+
+`.github/workflows/copilot-review-apply.yml` closes the feedback loop for
+Copilot pull request reviews. When the trusted Copilot reviewer submits a
+commented or changes-requested review with inline findings on an open,
+non-draft pull request, the workflow posts one deduplicated `@copilot` fix
+request linked to that review. A review without inline findings does not start
+a fix cycle.
+
+The workflow has read-only contents access and pull-request comment access. It
+does not check out or execute pull request code, interpolate review text into a
+shell, approve, merge, or bypass required checks. Copilot's resulting changes
+must still pass the ordinary quality gates and human review; findings that
+should not be applied must be explained on the pull request.
+
 Reusable implementation and review prompts are available in the
 [agent prompt catalog](prompts/index.md). They are aids only; repository
 instructions and human review remain authoritative.


### PR DESCRIPTION
## Summary

- react to submitted Copilot reviews that contain inline findings
- post one deduplicated `@copilot` fix request per review
- use minimal token permissions, a commit-pinned action, and no untrusted checkout or execution
- document the automated feedback loop and its human-review boundaries

## Related issue

Closes #150

## Validation

- [x] `make ci`
- [x] `actionlint .github/workflows/copilot-review-apply.yml`
- [x] `yq eval` YAML validation
- [x] `node --check` on the wrapped `github-script` body

## Tests and documentation

- Tests: static workflow and JavaScript syntax validation; live dispatch requires a submitted Copilot review after merge
- Documentation: added the automated Copilot feedback behavior and security boundaries to `docs/quality.md`

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] This workflow never checks out or executes pull request code.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.