### PR TITLE
ci: add nightly compliance suite

### DIFF
--- a/.github/workflows/nightly-compliance.yml
+++ b/.github/workflows/nightly-compliance.yml
@@ -1,0 +1,55 @@
+name: Nightly compliance
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-compliance
+  cancel-in-progress: false
+
+jobs:
+  compliance:
+    name: Full compliance suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install compliance tools
+        run: |
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+
+      - name: Install E2E runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            dbus-x11 \
+            libadwaita-1-0 \
+            libgtk-4-1 \
+            xauth \
+            xvfb
+
+      - name: Run host-independent compliance gates
+        run: make ci
+
+      - name: Run end-to-end compliance gates
+        run: make e2e
+
+      - name: Scan Go code and dependencies for known vulnerabilities
+        run: govulncheck ./...

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -12,6 +12,7 @@ that would immediately become stale.
 | Signal | What it reports | Source |
 |---|---|---|
 | Tests workflow | Latest lint, unit-test, race-detection, verification, and cross-architecture build results | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/test.yml) |
+| Nightly compliance | Daily full CI, E2E, and known-vulnerability scan results for the default branch | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/nightly-compliance.yml) |
 | Pull request checks | Gate results attached to each proposed change, including reruns and logs | Open a pull request and select its **Checks** tab |
 | PR acceptance | Accepted and closed pull request counts over a rolling 90-day cohort | [Metric definition and reproducible query](metrics.md) |
 | Coverage | Line coverage produced by tests under `internal/...` | [Codecov](https://app.codecov.io/gh/frostyard/chairlift) |
@@ -61,6 +62,21 @@ The test-name filters are significant: ordinary unit tests must not begin with
 `TestI` or contain `Integration`, because the gated command excludes them.
 Tests for packages that import puregotk also cannot run headlessly; decidable
 logic belongs in a pure package under `internal/`, as required by `AGENTS.md`.
+
+## Nightly compliance
+
+The `Nightly compliance` workflow runs every day at 04:17 UTC and can also be
+started manually. It checks out the current default branch, runs the complete
+host-independent `make ci` gate, installs the same GTK/Xvfb runtime used by the
+hosted E2E job and runs `make e2e`, then runs `govulncheck ./...` against the
+current Go vulnerability database. This catches dependency disclosures and
+environment drift even when no pull request is active.
+
+The workflow has read-only repository permission, persists no checkout
+credentials, consumes no repository secrets, and publishes nothing. Its
+third-party actions are pinned to commits and its Go compliance tools are
+installed at explicit versions. A nightly failure is an investigation signal;
+it does not replace pull-request checks or authorize an automatic merge.
 
 ## Reviewing agent changes
 


### PR DESCRIPTION
## Summary

- add a daily and manually dispatchable compliance workflow for the default branch
- run `make ci`, the GTK/Xvfb E2E suite, and `govulncheck ./...`
- use read-only permissions, no secrets, non-persisted checkout credentials, commit-pinned actions, and version-pinned tools
- document the nightly signal and its security boundaries in the quality dashboard

## Related issue

Closes #149

## Validation

- [x] `make ci`
- [x] `actionlint .github/workflows/nightly-compliance.yml`
- [x] `yq eval` YAML validation
- [x] `govulncheck ./...` using the workflow-pinned v1.6.0 — no reachable vulnerabilities
- [ ] `make e2e` — application-help and installed-helper checks passed, but GTK startup could not run because `xvfb-run` is absent; installing it locally failed because `/var/lib/dpkg` is read-only. The workflow installs Xvfb on the hosted runner before this gate.

## Tests and documentation

- Tests: static workflow validation plus local CI and vulnerability scan; full E2E remains enforced by the existing hosted Tests workflow and the new nightly job
- Documentation: added the nightly signal, schedule, checks, and security model to `docs/quality.md`

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] The workflow always checks out the default branch without persisted credentials.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.