### PR TITLE
ci: add AI fix request workflow

### DIFF
--- a/.github/workflows/ai-fix-requested.yml
+++ b/.github/workflows/ai-fix-requested.yml
@@ -1,0 +1,52 @@
+name: Request Copilot issue fixes
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ai-fix-requested-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  request-fix:
+    name: Request Copilot implementation
+    if: >-
+      github.event.issue.state == 'open' &&
+      github.event.label.name == 'ai-fix-requested'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask Copilot to implement the issue
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue.number;
+            const issueURL = context.payload.issue.html_url;
+            const marker = `<!-- ai-fix-requested:${issueNumber} -->`;
+
+            // Label deliveries can be retried or the label can be reapplied.
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: issueNumber, per_page: 100 },
+            );
+            if (comments.some((comment) => comment.body?.includes(marker))) {
+              core.notice(`Issue ${issueNumber} was already dispatched.`);
+              return;
+            }
+
+            const body = [
+              marker,
+              `@copilot Please implement [issue #${issueNumber}](${issueURL}). Follow \`AGENTS.md\` and the repository review rubric, keep the change within the issue's scope, and run the relevant quality gates. Open a pull request for human review; do not merge it.`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -102,11 +102,18 @@ non-draft pull request, the workflow posts one deduplicated `@copilot` fix
 request linked to that review. A review without inline findings does not start
 a fix cycle.
 
-The workflow has read-only contents access and pull-request comment access. It
-does not check out or execute pull request code, interpolate review text into a
-shell, approve, merge, or bypass required checks. Copilot's resulting changes
-must still pass the ordinary quality gates and human review; findings that
-should not be applied must be explained on the pull request.
+`.github/workflows/ai-fix-requested.yml` handles explicit implementation
+requests on issues. When the `ai-fix-requested` label is applied to an open
+issue, it posts one deduplicated `@copilot` request linked to that issue.
+Reapplying the label does not start a duplicate fix cycle.
+
+The review workflow receives read-only contents and pull-requests write
+permissions; the issue workflow receives only issues write permission. Each
+uses its write permission only to create the request comment. Neither workflow
+checks out or executes repository code, interpolates review or issue text into
+a shell, approves, merges, or bypasses required checks. Copilot's resulting
+changes must still pass the ordinary quality gates and human review; review
+findings that should not be applied must be explained on the pull request.
 
 Reusable implementation and review prompts are available in the
 [agent prompt catalog](prompts/index.md). They are aids only; repository

--- a/internal/installcheck/documentation_test.go
+++ b/internal/installcheck/documentation_test.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func readRepoFile(t *testing.T, relative string) string {
@@ -98,4 +100,50 @@ func TestCurrentDocumentationMatchesSourceFacts(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestAIFixRequestedWorkflowIsLabelScoped(t *testing.T) {
+	path := filepath.Join(".github", "workflows", "ai-fix-requested.yml")
+	workflow := readRepoFile(t, path)
+
+	var document yaml.Node
+	if err := yaml.Unmarshal([]byte(workflow), &document); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	for _, required := range []string{
+		"issues:",
+		"types: [labeled]",
+		"issues: write",
+		"github.event.issue.state == 'open'",
+		"github.event.label.name == 'ai-fix-requested'",
+		"actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
+		"<!-- ai-fix-requested:${issueNumber} -->",
+		"comments.some((comment) => comment.body?.includes(marker))",
+		"@copilot Please implement",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Errorf("%s does not contain required contract %q", path, required)
+		}
+	}
+
+	for _, unsafe := range []string{
+		"pull_request_target:",
+		"actions/checkout@",
+		"github.event.issue.body",
+		"github.event.issue.title",
+		"context.payload.issue.body",
+		"context.payload.issue.title",
+		"contents: write",
+		"\n        run:",
+	} {
+		if strings.Contains(workflow, unsafe) {
+			t.Errorf("%s contains unsafe or unnecessary workflow surface %q", path, unsafe)
+		}
+	}
+
+	quality := readRepoFile(t, filepath.Join("docs", "quality.md"))
+	if !strings.Contains(quality, "`.github/workflows/ai-fix-requested.yml`") {
+		t.Error("docs/quality.md does not document the AI-fix-requested workflow")
+	}
 }

--- a/internal/installcheck/installcheck.go
+++ b/internal/installcheck/installcheck.go
@@ -1,18 +1,13 @@
-// Package installcheck contains headless, gate-enforced regression tests
-// that verify the repository's two installation paths — a source `make
-// install` and the packaged nFPM (deb/rpm/apk) layout produced from
-// .goreleaser.yaml — stay in agreement with each other and with
-// internal/updex.HelperPath, the fixed absolute path PolicyKit's
-// org.freedesktop.policykit.exec.path annotation requires (see
-// internal/updex/updex.go and data/org.frostyard.ChairLift.updex.policy).
+// Package installcheck contains headless, gate-enforced regression tests for
+// repository-level documentation, workflow, installation, packaging, and
+// PolicyKit contracts.
 //
 // This package holds no logic reachable from cmd/ or any other internal/
-// package — only shared test-time helpers used by makefile_test.go and
-// goreleaser_test.go. It imports no GTK bindings, directly or transitively,
-// so a _test.go living here never trips the gtk-headless-tests.md constraint
-// (docs/agents/skills/gtk-headless-tests.md), and it lives under
-// internal/... so it is actually exercised by gates_chunk, make ci, and CI's
-// `go test ./internal/...` filter, per
+// package, only shared test-time helpers. It imports no GTK bindings, directly
+// or transitively, so a _test.go living here never trips the
+// gtk-headless-tests.md constraint (docs/agents/skills/gtk-headless-tests.md),
+// and it lives under internal/... so it is actually exercised by gates_chunk,
+// make ci, and CI's `go test ./internal/...` filter, per
 // docs/agents/skills/gate-test-scope-is-internal-only.md.
 package installcheck
 


### PR DESCRIPTION
## Summary

- Add a recognized `ai-fix-requested` workflow that turns the explicit issue label into one deduplicated `@copilot` implementation request.
- Limit the workflow to open labeled issues with only `issues: write`; it never checks out or executes repository code.
- Document the automation boundary and add a CI-enforced YAML/security contract test.

## Related issue

Closes #152

## Validation

- [x] `make ci`
- [x] `actionlint .github/workflows/*.yml`
- [x] `go test ./internal/installcheck`

## Tests and documentation

- Tests: Added `TestAIFixRequestedWorkflowIsLabelScoped` to parse the workflow and enforce its trigger, permissions, deduplication marker, pinned action, and forbidden unsafe surfaces.
- Documentation: Updated `docs/quality.md` with the issue-label feedback loop and its permission/execution boundary.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.