### PR TITLE
ci: add adaptive Auto-QA tuning

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -1,0 +1,166 @@
+name: Adaptive Auto-QA
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: auto-qa-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tune:
+    name: Tune QA intensity
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    outputs:
+      repetitions: ${{ steps.policy.outputs.repetitions }}
+      reason: ${{ steps.policy.outputs.reason }}
+    steps:
+      - name: Derive bounded QA policy from recent outcomes
+        id: policy
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const defaultBranch = context.payload.repository.default_branch;
+
+            const response = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'test.yml',
+              branch: defaultBranch,
+              status: 'completed',
+              per_page: 20,
+            });
+            const runs = response.data.workflow_runs.filter(
+              (run) => run.event === 'push',
+            );
+            const failures = runs.filter(
+              (run) => run.conclusion === 'failure',
+            ).length;
+            const failureRate = runs.length === 0 ? null : failures / runs.length;
+
+            // Never tune below one uncached run. With no history, start at the
+            // conservative middle tier rather than assuming a perfect signal.
+            let repetitions = 2;
+            let outcomeReason = 'no completed default-branch history';
+            if (failureRate !== null && failureRate < 0.05) {
+              repetitions = 1;
+              outcomeReason = `${failures}/${runs.length} recent runs failed`;
+            } else if (failureRate !== null && failureRate < 0.20) {
+              repetitions = 2;
+              outcomeReason = `${failures}/${runs.length} recent runs failed`;
+            } else if (failureRate !== null) {
+              repetitions = 3;
+              outcomeReason = `${failures}/${runs.length} recent runs failed`;
+            }
+
+            let sensitiveFiles = [];
+            if (context.eventName === 'pull_request') {
+              const files = await github.paginate(
+                github.rest.pulls.listFiles,
+                {
+                  owner,
+                  repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                },
+              );
+              const sensitivePrefixes = [
+                '.github/workflows/',
+                'cmd/chairlift-updex-helper/',
+                'internal/bootc/',
+                'internal/config/',
+                'internal/installcheck/',
+                'internal/updex/',
+                'internal/updexhelper/',
+              ];
+              const sensitiveExact = new Set([
+                '.goreleaser.yaml',
+                'Makefile',
+                'data/org.frostyard.ChairLift.bootc.policy',
+                'data/org.frostyard.ChairLift.updex.policy',
+                'go.mod',
+                'go.sum',
+              ]);
+              sensitiveFiles = files
+                .map((file) => file.filename)
+                .filter(
+                  (name) => sensitiveExact.has(name) ||
+                    sensitivePrefixes.some((prefix) => name.startsWith(prefix)),
+                );
+            }
+
+            if (sensitiveFiles.length > 0) {
+              repetitions = 3;
+            }
+
+            // Bound both the shell-facing count and attacker-controlled file
+            // names copied into output. Every file affects the decision, but a
+            // very large PR cannot overflow the job-output limit.
+            repetitions = Math.max(1, Math.min(3, repetitions));
+            const sensitiveSample = sensitiveFiles.slice(0, 20).join(', ');
+            const sensitiveSummary = sensitiveFiles.length > 20
+              ? `${sensitiveSample} (+${sensitiveFiles.length - 20} more)`
+              : sensitiveSample;
+            const reason = sensitiveFiles.length > 0
+              ? `${outcomeReason}; sensitive paths changed: ${sensitiveSummary}`
+              : outcomeReason;
+            core.setOutput('repetitions', String(repetitions));
+            core.setOutput('reason', reason);
+            await core.summary
+              .addHeading('Adaptive Auto-QA policy')
+              .addTable([
+                [{ data: 'Input', header: true }, { data: 'Value', header: true }],
+                ['Completed default-branch runs', String(runs.length)],
+                ['Failed default-branch runs', String(failures)],
+                ['Sensitive changed paths', sensitiveSummary || 'none'],
+                ['Selected repetitions', String(repetitions)],
+              ])
+              .addParagraph(reason)
+              .write();
+
+  adaptive-tests:
+    name: Adaptive tests (${{ needs.tune.outputs.repetitions }}x)
+    needs: tune
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout tested revision
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tuned uncached test repetitions
+        env:
+          REPETITIONS: ${{ needs.tune.outputs.repetitions }}
+          TUNING_REASON: ${{ needs.tune.outputs.reason }}
+        run: |
+          if [[ ! "$REPETITIONS" =~ ^[1-3]$ ]]; then
+            echo "Invalid repetition count: $REPETITIONS" >&2
+            exit 1
+          fi
+          echo "Auto-QA selected ${REPETITIONS} run(s): ${TUNING_REASON}"
+          for attempt in $(seq 1 "$REPETITIONS"); do
+            echo "==> adaptive test run ${attempt}/${REPETITIONS}"
+            CGO_ENABLED=0 go test ./internal/... \
+              -count=1 \
+              -shuffle=on \
+              -run "^Test[^I]" \
+              -skip "Integration"
+          done

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -12,6 +12,7 @@ that would immediately become stale.
 | Signal | What it reports | Source |
 |---|---|---|
 | Tests workflow | Latest lint, unit-test, race-detection, verification, and cross-architecture build results | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/test.yml) |
+| Adaptive Auto-QA | Outcome- and risk-tuned uncached test repetitions for pull requests | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/auto-qa.yml) |
 | Nightly compliance | Daily full CI, E2E, and known-vulnerability scan results for the default branch | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/nightly-compliance.yml) |
 | Pull request checks | Gate results attached to each proposed change, including reruns and logs | Open a pull request and select its **Checks** tab |
 | PR acceptance | Accepted and closed pull request counts over a rolling 90-day cohort | [Metric definition and reproducible query](metrics.md) |
@@ -62,6 +63,34 @@ The test-name filters are significant: ordinary unit tests must not begin with
 `TestI` or contain `Integration`, because the gated command excludes them.
 Tests for packages that import puregotk also cannot run headlessly; decidable
 logic belongs in a pure package under `internal/`, as required by `AGENTS.md`.
+
+## Adaptive Auto-QA
+
+`.github/workflows/auto-qa.yml` adjusts additional QA intensity from observed
+outcomes without weakening the required Tests workflow. For each non-draft
+pull request, it reads up to 20 completed default-branch push runs of
+`test.yml` and selects a bounded number of uncached, shuffled internal test
+runs:
+
+| Recent default-branch failure rate | Repetitions |
+|---|---:|
+| No history | 2 |
+| Below 5% | 1 |
+| 5% to below 20% | 2 |
+| 20% or higher | 3 |
+
+Changes to workflows, dependency manifests, packaging/install files,
+PolicyKit policies, configuration validation, bootc, or updex raise the result
+to the maximum three repetitions regardless of recent success. The selected
+history inputs, sensitive-path count/sample, repetition count, and reason are
+recorded in the workflow summary so the tuning decision is auditable.
+
+The range is deliberately fixed at one through three: missing history fails
+conservatively to the middle tier, a healthy period cannot remove the extra
+uncached run, and bad outcomes can increase cost only to a known bound. The
+workflow has read-only API/repository permissions, uses commit-pinned actions,
+persists no checkout credentials, and receives no secrets. It supplements but
+never changes, skips, approves, or merges around the ordinary quality gates.
 
 ## Nightly compliance
 


### PR DESCRIPTION
## Summary

- derive bounded QA intensity from the last 20 completed default-branch Tests runs
- tune uncached, shuffled internal test repetitions from one to three based on observed failure rate
- force the maximum tier for security-, privilege-, configuration-, dependency-, packaging-, or workflow-sensitive paths
- expose the inputs and decision in the job summary while retaining read-only permissions and bounded untrusted filename output
- document the policy table, safeguards, and relationship to required checks

## Related issue

Closes #148

## Validation

- [x] `make ci`
- [x] `actionlint .github/workflows/auto-qa.yml`
- [x] `yq eval` YAML validation
- [x] `node --check` on the wrapped `github-script` body
- [x] Ran the tuned test command for the expected sensitive-path tier (three uncached shuffled repetitions)
- [x] Queried current default-branch history (2 failures in 20 runs, selecting the middle outcome tier before this workflow change raises it to three)

## Tests and documentation

- Tests: static workflow/JavaScript validation plus all three adaptive test repetitions locally
- Documentation: added the Auto-QA signal, decision table, sensitive-path escalation, audit output, and security bounds to `docs/quality.md`

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Auto-QA can never reduce or bypass the required Tests workflow.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.