### PR TITLE
docs: add change risk classification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,13 @@
 
 Closes #
 
+## Change classification
+
+<!-- Select the highest applicable tier from docs/risk-tiers.md. -->
+
+- Risk tier:
+- Rationale:
+
 ## Validation
 
 <!-- List exact commands and results. Explain any check that could not run. -->

--- a/docs/review-rubric.md
+++ b/docs/review-rubric.md
@@ -9,6 +9,7 @@ code in context rather than reviewing the diff alone.
 | Area | Approval standard |
 |---|---|
 | Scope | The change satisfies the linked issue, contains no unrelated refactors or generated artifacts, and preserves behavior outside the requested scope. |
+| Risk classification | The pull request selects the highest applicable [change risk tier](risk-tiers.md), and its review and validation evidence meet that tier's requirements. |
 | Correctness | Success, failure, dry-run, retry, and disabled-feature paths behave consistently. Errors remain visible instead of being silently converted into success or invented state. |
 | Repository invariants | The privilege boundary, GTK main-thread rule, async generation guards, config-driven visibility, navigation authority, and known-state ownership rules in `AGENTS.md` remain intact. |
 | Tests | Changed behavior has regression coverage in a CI-enforced scope. Tests avoid puregotk packages, do not begin with `TestI` or contain `Integration` unless they intentionally require the separately enforced environment, and cover the reported failure mode rather than only a happy path. |

--- a/docs/risk-tiers.md
+++ b/docs/risk-tiers.md
@@ -1,0 +1,25 @@
+# Change risk tiers
+
+Classify every pull request before review by choosing the highest tier that
+matches any part of the change. The tier reflects potential impact rather than
+diff size or author: a one-line permission change can be more consequential
+than a large documentation update.
+
+| Tier | Typical changes | Required handling |
+|---|---|---|
+| **Tier 1 - Low** | Documentation, comments, test fixtures, or metadata that cannot change executable, build, release, configuration, or workflow behavior | Normal review and the relevant repository checks |
+| **Tier 2 - Moderate** | Routine implementation, tests, or configuration changes that stay outside security-sensitive and operational boundaries | Required CI, regression coverage for changed behavior, and normal code review |
+| **Tier 3 - High** | Build or CI behavior, packaging, dependency additions or major upgrades, configuration schemas, external command execution, concurrency, persistent state, or broad validation changes | Tier 2 controls plus targeted failure-path validation, a reviewer familiar with the affected area, and deployment or rollback notes when applicable |
+| **Tier 4 - Critical** | PolicyKit or root operations, destructive system mutations, release publication or signing, secrets and token permissions, execution derived from untrusted input, or automation that can approve or merge changes | Tier 3 controls plus explicit maintainer security review, threat or abuse-case analysis, a rollback plan, and confirmation that permissions remain least-privilege |
+
+## Classification rules
+
+- Choose the highest applicable tier; do not average multiple kinds of change.
+- Treat changes to a safeguard at the same tier as the behavior it protects.
+- Raise the tier when impact is uncertain until the uncertainty is resolved.
+- Update the pull request classification if its scope changes during review.
+- Never lower a tier to bypass required review or validation.
+
+Record the selected tier and a short rationale in the pull request template.
+Reviewers confirm that the classification and evidence match the final diff
+before approval.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Home: "index.md"
   - Reference: "reference.md"
   - Quality dashboard: "quality.md"
+  - Change risk tiers: "risk-tiers.md"
   - Pull request review rubric: "review-rubric.md"
   - Agent prompts:
       - Catalog: "prompts/index.md"


### PR DESCRIPTION
## Summary

- Add a four-tier change risk classification policy with handling requirements.
- Record classification in the pull request template and enforce it in the review rubric.
- Add the policy to the documentation navigation.

## Related issue

Closes #153

## Change classification

- Risk tier: Tier 1 - Low
- Rationale: This changes documentation and pull request metadata only; it does not alter executable, build, release, configuration, or workflow behavior.

## Validation

- [x] `make ci`
- [x] Additional relevant checks: `git diff --cached --check`

## Tests and documentation

- Tests: No regression tests needed because behavior is unchanged.
- Documentation: Added `docs/risk-tiers.md` and linked it from the site navigation, pull request template, and review rubric.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does
      not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.
