### PR TITLE
ci: add automated issue labeling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,105 @@
+name: Automated issue triage
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply deterministic issue labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Classify structured issue shapes
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+            const title = (issue.title ?? '').trim();
+            // GitHub bounds issue bodies, but keep the automation's own input
+            // limit explicit. Content is matched as data and never executed.
+            const body = (issue.body ?? '').slice(0, 100000);
+            const labels = new Set();
+
+            const acmmTitle = /^\[ACMM L\d+\]\s+/i.test(title);
+            const acmmCriterion = /\*\*Criterion ID:\*\*\s*`acmm:[^`]+`/i.test(body);
+            if (acmmTitle && acmmCriterion) {
+              labels.add('acmm');
+              labels.add('ai-fix-requested');
+            }
+
+            const guideIssue = /^\[guide\]\s+/i.test(title) ||
+              /Filed by guide agent/i.test(body);
+            if (guideIssue) {
+              labels.add('documentation');
+              labels.add('agent/guide');
+            }
+
+            const qualityIssue = /^\[quality\]\s+/i.test(title) ||
+              /Filed by quality agent/i.test(body);
+            if (qualityIssue) {
+              labels.add('agent/quality');
+            }
+
+            if (/^(bug:|fix:|\[bug\])\s*/i.test(title)) {
+              labels.add('bug');
+            }
+            if (/^(docs?:|documentation:|\[(docs?|documentation)\])\s*/i.test(title) ||
+                /^## Documentation Gap\s*$/im.test(body)) {
+              labels.add('documentation');
+            }
+            if (/^(feat(ure)?:|enhancement:|\[(feature|enhancement)\])\s*/i.test(title) ||
+                /^## Feature Request\s*$/im.test(body)) {
+              labels.add('enhancement');
+            }
+            if (/^(question:|\[question\])\s*/i.test(title)) {
+              labels.add('question');
+            }
+
+            if (labels.size === 0) {
+              core.notice(`Issue #${issue.number} matched no automatic labels.`);
+              return;
+            }
+
+            // Apply only labels that still exist in the repository. A renamed
+            // label should not make all otherwise-valid triage fail.
+            const repositoryLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              { owner, repo, per_page: 100 },
+            );
+            const available = new Set(repositoryLabels.map((label) => label.name));
+            const selected = [...labels].filter((label) => available.has(label));
+            const missing = [...labels].filter((label) => !available.has(label));
+            if (missing.length > 0) {
+              core.warning(`Configured labels are unavailable: ${missing.join(', ')}`);
+            }
+            if (selected.length === 0) {
+              return;
+            }
+
+            const existing = new Set(
+              issue.labels.map((label) => typeof label === 'string' ? label : label.name),
+            );
+            const toAdd = selected.filter((label) => !existing.has(label));
+            if (toAdd.length === 0) {
+              core.notice(`Issue #${issue.number} already has: ${selected.join(', ')}`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: issue.number,
+              labels: toAdd,
+            });
+            core.notice(`Added to issue #${issue.number}: ${toAdd.join(', ')}`);

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -13,6 +13,7 @@ that would immediately become stale.
 |---|---|---|
 | Tests workflow | Latest lint, unit-test, race-detection, verification, and cross-architecture build results | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/test.yml) |
 | Nightly compliance | Daily full CI, E2E, and known-vulnerability scan results for the default branch | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/nightly-compliance.yml) |
+| Issue triage | Deterministic labels applied from structured issue titles and bodies | [GitHub Actions](https://github.com/frostyard/chairlift/actions/workflows/triage.yml) |
 | Pull request checks | Gate results attached to each proposed change, including reruns and logs | Open a pull request and select its **Checks** tab |
 | PR acceptance | Accepted and closed pull request counts over a rolling 90-day cohort | [Metric definition and reproducible query](metrics.md) |
 | Coverage | Line coverage produced by tests under `internal/...` | [Codecov](https://app.codecov.io/gh/frostyard/chairlift) |
@@ -107,6 +108,26 @@ does not check out or execute pull request code, interpolate review text into a
 shell, approve, merge, or bypass required checks. Copilot's resulting changes
 must still pass the ordinary quality gates and human review; findings that
 should not be applied must be explained on the pull request.
+
+## Automated issue triage
+
+`.github/workflows/triage.yml` applies conservative, additive labels when an
+issue is opened or edited. Its deterministic rules are:
+
+| Structured input | Labels |
+|---|---|
+| An `[ACMM L…]` title plus an `acmm:` criterion field | `acmm`, `ai-fix-requested` |
+| A `[guide]` title or guide-agent filing marker | `documentation`, `agent/guide` |
+| A `[quality]` title or quality-agent filing marker | `agent/quality` |
+| Explicit bug, documentation, feature/enhancement, or question title prefixes | The matching standard category label |
+| A `Documentation Gap` or `Feature Request` body heading | `documentation` or `enhancement` |
+
+Triage never removes a label, so an edit cannot erase a maintainer decision. It
+checks that configured labels still exist, skips labels already present, and
+leaves ambiguous issues for humans. Issue text is bounded and matched only as
+data by a commit-pinned API action: the workflow checks out and executes no
+issue-controlled code, receives no secrets, and has only read-only contents
+plus issue-label write permission.
 
 Reusable implementation and review prompts are available in the
 [agent prompt catalog](prompts/index.md). They are aids only; repository


### PR DESCRIPTION
## Summary

- add deterministic issue labeling for structured ACMM, guide, quality, bug, documentation, enhancement, and question inputs
- keep triage additive so automation never removes maintainer-selected labels
- verify labels still exist, skip labels already present, and leave ambiguous issues for human triage
- process bounded issue text only through a commit-pinned API action with no checkout, secrets, or shell interpolation
- document the rules and security boundary in the quality dashboard

## Related issue

Closes #151

## Validation

- [x] `make ci`
- [x] `actionlint .github/workflows/triage.yml`
- [x] `yq eval` YAML validation
- [x] `node --check` on the wrapped `github-script` body
- [x] Exercised the actual script with mocked ACMM, guide, and ambiguous issue scenarios

## Tests and documentation

- Tests: static workflow/JavaScript validation and scenario harness against the extracted workflow script
- Documentation: added the issue-triage signal, rule table, additive behavior, and least-privilege model to `docs/quality.md`

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Issue-controlled content is treated only as bounded data and is never executed.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.