### PR TITLE
docs: add cross-session knowledge index

### DIFF
--- a/.knowledge/README.md
+++ b/.knowledge/README.md
@@ -1,0 +1,29 @@
+# `.knowledge/` - cross-session knowledge index
+
+This directory is ChairLift's stable discovery point for knowledge that should
+survive an individual agent session. It indexes the repository's canonical
+artifacts instead of copying their contents, which prevents guidance from
+drifting between stores.
+
+## Read before working
+
+1. Read `AGENTS.md` for current repository invariants and required workflows.
+2. Read every file in `docs/agents/skills/` for durable lessons from prior
+   automated runs.
+3. Read `.memory/README.md` and `.memory/corrections.jsonl`, when present, for
+   verified corrections.
+4. Read `.claude/session-summary.md` for the latest in-progress handoff.
+5. Read `yeti/OVERVIEW.md` and the relevant `yeti/` subsystem documents for
+   architecture and decision rationale.
+
+## Record knowledge in its canonical location
+
+- Put verified corrections in `.memory/corrections.jsonl`.
+- Replace `.claude/session-summary.md` when another session must continue
+  active work.
+- Promote stable operating rules to `AGENTS.md`, reusable lessons to
+  `docs/agents/skills/`, and architecture or rationale to `yeti/`.
+
+Keep this file as an index rather than a duplicate knowledge store. Record only
+verified repository context, and never commit secrets, credentials, personal
+data, or unverified speculation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,11 @@ before working. Write content there to be maximally useful to an AI agent
 understanding the codebase — detailed architecture and rationale rather than
 user-facing guides.
 
+**.knowledge/ directory** is the repository's cross-session knowledge index.
+Read `.knowledge/README.md` before working so prior corrections, handoffs,
+durable lessons, and architecture guidance are discovered from their canonical
+locations instead of duplicated into competing stores.
+
 **.memory/ directory** is the repository's committed correction store for AI
 agents. Read `.memory/README.md` and any learning artifacts in that directory
 before working. Record verified corrections there when a session establishes


### PR DESCRIPTION
## Summary

- add a tracked `.knowledge/` discovery point for cross-session knowledge
- index existing correction, handoff, durable-skill, and architecture stores without duplicating their contents
- direct future agents to the knowledge index from `AGENTS.md`

## Related issue

Closes #156

## Change classification

- Risk tier: Tier 1 - Low
- Rationale: Documentation-only metadata that does not alter executable, build, release, configuration, or workflow behavior.

## Validation

- [x] `make ci`
- [x] Additional relevant checks: `git diff --check`; confirmed `.knowledge/README.md` is tracked and present.

## Tests and documentation

- Tests: No new regression test is needed because this change adds documentation metadata only; the full CI mirror passes.
- Documentation: Added the cross-session knowledge index and documented its required discovery step in `AGENTS.md`.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.
