### PR TITLE
ci: pin repogen release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Publish to frostyard repo
-        uses: frostyard/repogen/.github/actions/publish-to-r2@main
+        uses: frostyard/repogen/.github/actions/publish-to-r2@6648671cec7015231fac1f278f09ee5799281bc9 # main
         with:
           r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
           r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/internal/installcheck/workflow_test.go
+++ b/internal/installcheck/workflow_test.go
@@ -1,0 +1,21 @@
+package installcheck
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+func TestReleasePublisherUsesImmutableCommit(t *testing.T) {
+	workflow := readRepoFile(t, filepath.Join(".github", "workflows", "release.yml"))
+	actionPattern := regexp.MustCompile(`(?m)^\s*uses:\s+frostyard/repogen/\.github/actions/publish-to-r2@([^\s#]+)`)
+	matches := actionPattern.FindAllStringSubmatch(workflow, -1)
+	if len(matches) != 1 {
+		t.Fatalf("release workflow has %d repogen publisher references, want 1", len(matches))
+	}
+
+	ref := matches[0][1]
+	if !regexp.MustCompile(`^[0-9a-f]{40}$`).MatchString(ref) {
+		t.Errorf("repogen publisher ref %q is mutable; want a full commit SHA", ref)
+	}
+}


### PR DESCRIPTION
## Summary

- pin the secret-bearing `publish-to-r2` action to the reviewed `repogen` commit already used by `frostyard/updex`
- prevent changes to `repogen:main` from changing the code that receives ChairLift's release credentials
- add a gate-enforced regression test requiring the publisher reference to remain a full 40-character commit SHA

## Related issue

Closes #163

## Change classification

- Risk tier: Tier 4 - Critical
- Rationale: This changes a release-publication safeguard around Cloudflare credentials, the package-signing key, and repository write access.

## Security analysis

- Threat/abuse case: With `@main`, a compromised or mistaken push to `frostyard/repogen` could execute arbitrary action code during a tagged ChairLift release, exfiltrate six cloud/signing secrets, or publish malicious packages. The full SHA fixes the executed action code to commit `6648671cec7015231fac1f278f09ee5799281bc9`.
- Least privilege: No permissions, secret inputs, or publication scope are added or broadened. The change narrows which action code can receive the existing secrets.
- Required review: A maintainer security review is required before merge because this workflow signs and publishes release artifacts.
- Deployment: The pin takes effect on the next tag-triggered release; there is no data migration.
- Rollback: If this commit is incompatible, replace it with another reviewed, known-good full commit SHA. Do not restore the mutable branch reference.

## Validation

- [x] `make ci`
- [x] `CGO_ENABLED=0 go test ./internal/installcheck -run '^TestReleasePublisherUsesImmutableCommit$'`
- [x] Verified the pinned commit and action path through the GitHub API and confirmed the same SHA is used by `frostyard/updex`.
- A live release was not run because it would consume production secrets and publish artifacts.

## Tests and documentation

- Tests: Added `TestReleasePublisherUsesImmutableCommit`, which reads the real release workflow and rejects missing, duplicate, mutable, tag, or abbreviated publisher refs.
- Documentation: The inline `# main` annotation preserves the upstream update channel for intentional SHA updates; no user-facing behavior or configuration changed.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.
