### PR TITLE
docs: add public metrics catalog

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,8 @@ one.
 
 The [quality dashboard](quality.md) links to live CI, coverage, build-artifact,
 and release signals and explains how to reproduce the enforced checks locally.
+The [public metrics catalog](metrics/) collects the public, read-only sources
+and documents their interpretation and agent-provenance boundaries.
 
 ```bash
 make run      # Build and run with --dry-run

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -1,0 +1,33 @@
+# Public metrics catalog
+
+ChairLift publishes its engineering and contribution signals through public,
+read-only services. This catalog points to live sources and reproducible metric
+definitions instead of committing snapshots that become stale.
+
+| Signal | Public source | Interpretation |
+|---|---|---|
+| Pull request acceptance | [Definition and reproducible 90-day query](../metrics.md) | Accepted and closed counts plus their ratio. It is descriptive, not a target. |
+| CI results | [Tests workflow](https://github.com/frostyard/chairlift/actions/workflows/test.yml) | Lint, unit tests, race detection, verification, and cross-architecture builds for each run. |
+| Nightly compliance | [Nightly workflow](https://github.com/frostyard/chairlift/actions/workflows/nightly-compliance.yml) | Default-branch CI, E2E, and vulnerability checks run on a schedule. |
+| Test coverage | [Codecov](https://app.codecov.io/gh/frostyard/chairlift) | Coverage for the tested `internal/...` scope; consult the upload status before interpreting missing data. |
+| Releases | [GitHub Releases](https://github.com/frostyard/chairlift/releases) | Published versions, timestamps, and release assets. |
+| Review activity | [Pull requests](https://github.com/frostyard/chairlift/pulls) | Public review discussions, outcomes, checks, and merge history. |
+
+The [quality dashboard](../quality.md) explains what each signal establishes,
+which checks are enforced, and the limitations of the coverage and artifact
+feeds. GitHub also exposes the underlying public repository data through its
+[REST API](https://api.github.com/repos/frostyard/chairlift); authenticated
+queries are recommended for higher rate limits.
+
+## Agent observability boundary
+
+These repository-wide signals include human, dependency-bot, and
+agent-assisted contributions. ChairLift does not currently attach a reliable
+provenance marker to every agent-assisted pull request, so account names,
+branch names, and issue labels must not be used to manufacture an agent-only
+metric. If explicit provenance is introduced, publish that segment alongside
+the repository-wide result and document its collection rules here.
+
+ChairLift does not collect application usage telemetry. This catalog describes
+public development and quality signals only; it does not imply collection from
+installed systems.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -2,7 +2,8 @@
 
 This page is the entry point for auditing ChairLift's current quality signals.
 It links to live reports rather than copying pass rates or coverage percentages
-that would immediately become stale.
+that would immediately become stale. The [public metrics catalog](metrics/)
+collects those read-only sources and their interpretation boundaries.
 
 [![Tests](https://github.com/frostyard/chairlift/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/frostyard/chairlift/actions/workflows/test.yml?query=branch%3Amain)
 [![Codecov](https://codecov.io/gh/frostyard/chairlift/branch/main/graph/badge.svg)](https://app.codecov.io/gh/frostyard/chairlift)

--- a/internal/installcheck/documentation_test.go
+++ b/internal/installcheck/documentation_test.go
@@ -82,6 +82,22 @@ func TestCurrentDocumentationMatchesSourceFacts(t *testing.T) {
 		}
 	})
 
+	t.Run("public metrics catalog stays auditable", func(t *testing.T) {
+		catalog := strings.Join(strings.Fields(readRepoFile(t, filepath.Join("docs", "metrics", "README.md"))), " ")
+		for _, required := range []string{
+			"../metrics.md",
+			"actions/workflows/test.yml",
+			"actions/workflows/nightly-compliance.yml",
+			"app.codecov.io/gh/frostyard/chairlift",
+			"does not currently attach a reliable provenance marker",
+			"does not collect application usage telemetry",
+		} {
+			if !strings.Contains(catalog, required) {
+				t.Errorf("docs/metrics/README.md does not contain %q", required)
+			}
+		}
+	})
+
 	t.Run("known stale claims stay removed", func(t *testing.T) {
 		current := strings.Join([]string{
 			readRepoFile(t, "README.md"),


### PR DESCRIPTION
## Summary

- add the ACMM-recognized `docs/metrics/` public metrics entry point
- catalog live CI, nightly compliance, coverage, release, review, and PR-acceptance signals without committing stale snapshots
- document interpretation limits, agent-provenance limitations, and the absence of application telemetry
- link the catalog from the documentation index and quality dashboard
- add a gated documentation contract test so the catalog and its core public sources cannot silently disappear

## Related issue

Closes #175

## Change classification

- Risk tier: Low
- Rationale: Documentation and a documentation-contract test only; no application, privilege boundary, workflow, packaging, or runtime behavior changes.

## Validation

- [x] `make ci`
- [x] Additional relevant checks: `go test ./internal/installcheck -run 'TestCurrentDocumentationMatchesSourceFacts/public_metrics_catalog_stays_auditable'`; `git diff --check`

## Tests and documentation

- Tests: Added a CI-gated `internal/installcheck` assertion for the catalog, canonical public sources, provenance warning, and no-telemetry statement.
- Documentation: Added `docs/metrics/README.md` and linked it from `docs/index.md` and `docs/quality.md`. Existing `docs/metrics.md` remains the canonical reproducible PR-acceptance definition.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.
