### PR TITLE
test: skip install invariant without make

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,11 @@ Libadwaita, `dbus-run-session`, and Xvfb to execute the built application's
 help path, start its dry-run window in a private headless session, poll bounded
 startup readiness, stage the complete install layout, and exercise the installed
 privileged helper's argument rejection. The hosted E2E job installs those
-runtime dependencies and runs the same target. The unit gate also scans every
-workflow and rejects external GitHub Actions references that are not pinned to
-full commit SHAs.
+runtime dependencies and runs the same target. Direct Go test runs on a minimal
+host skip the Makefile install-layout consistency check when GNU make is absent;
+when make is present, any dry-run or layout mismatch remains a hard failure. The
+unit gate also scans every workflow and rejects external GitHub Actions
+references that are not pinned to full commit SHAs.
 
 Codecov rejects project coverage regressions greater than one percentage point.
 Coverage expectations otherwise remain risk-based, not a repository-wide

--- a/internal/installcheck/makefile_test.go
+++ b/internal/installcheck/makefile_test.go
@@ -30,6 +30,10 @@ const (
 func runMakeInstallDryRun(t *testing.T, destDir string, extraArgs ...string) string {
 	t.Helper()
 
+	if _, err := exec.LookPath("make"); err != nil {
+		t.Skip("GNU make not installed; skipping Makefile install-layout consistency check")
+	}
+
 	args := append([]string{"-n", "install", "DESTDIR=" + destDir}, extraArgs...)
 	cmd := exec.Command("make", args...)
 	cmd.Dir = RepoRoot()
@@ -41,6 +45,19 @@ func runMakeInstallDryRun(t *testing.T, destDir string, extraArgs ...string) str
 		t.Fatalf("make %s failed: %v\noutput:\n%s", strings.Join(args, " "), err, out.String())
 	}
 	return out.String()
+}
+
+func TestRunMakeInstallDryRunSkipsWithoutMake(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	returned := false
+	t.Run("missing make", func(t *testing.T) {
+		runMakeInstallDryRun(t, t.TempDir())
+		returned = true
+	})
+	if returned {
+		t.Fatal("runMakeInstallDryRun returned when make was unavailable")
+	}
 }
 
 // assertInstallsPackageLayout checks that a `make -n install` dry-run's

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -675,7 +675,10 @@ installed layout itself:
   be a second, divergence-prone implementation of `make`'s own substitution
   rules, and would stop being a regression test for the exact thing that
   broke (the *installed* path) the moment it disagreed with real `make`
-  output.
+  output. If GNU make is not installed, the check skips with an explicit
+  diagnostic so a minimal Go environment does not resemble an invariant
+  regression; when make is available, command and layout failures remain hard
+  failures.
 - **`TestGoreleaserNfpmLayoutMatchesUsrPrefix`** parses the real, repo-root
   `.goreleaser.yaml` (not a fixture) with the already-vendored
   `gopkg.in/yaml.v3` and, iterating **every** `nfpms[]` entry (not just


### PR DESCRIPTION
## Summary

- detect GNU make with `exec.LookPath` before running the Makefile install-layout dry run
- skip with an explicit diagnostic only when the tool is unavailable
- retain hard failures for every real `make -n install` command or layout mismatch
- add a regression subtest that removes make from `PATH` and proves the helper exits through `t.Skip`
- document the minimal-Go-environment behavior in README and package-manager architecture guidance

Closes #177

PR #187 independently addresses the same finding. This fork PR includes the same core behavior plus the user-facing testing contract in README; only one should merge.

## Change classification

- Risk tier: Tier 1 — Low
- Rationale: Test harness and documentation only; production and packaging behavior are unchanged.

## Validation

- focused installcheck tests with make available
- `TestMakefileInstallUsesUsrPrefix` under an empty `PATH`: both layout cases report `SKIP` and the package passes
- `make ci`
- `git diff --check`

## Tests and documentation

The regression test directly exercises `runMakeInstallDryRun` with no executable search path. Existing layout tests continue exercising genuine GNU make output and preserving the privilege-boundary path invariant.
