### PR TITLE
docs: explain release package selection

### DIFF
--- a/README-go-port.md
+++ b/README-go-port.md
@@ -89,4 +89,4 @@ puregotk is experimental and some APIs may not work correctly. Known issues:
 
 ## License
 
-GPL-3.0 - see [LICENSE](../LICENSE)
+GPL-3.0 - see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,37 @@
 
 ## Installation
 
+### Installing a Release
+
+Each [ChairLift release](https://github.com/frostyard/chairlift/releases)
+provides ready-to-install packages for 64-bit Intel/AMD and Arm systems.
+Choose the package format for your distribution:
+
+| Distribution family | Full-package filename | Install command |
+|---|---|---|
+| Debian/Ubuntu | `frostyard-chairlift_<version>_<arch>.deb` (`amd64` or `arm64`) | `sudo apt install ./<downloaded-filename>` |
+| Fedora/RHEL | `frostyard-chairlift-<version>-1.<arch>.rpm` (`x86_64` or `aarch64`) | `sudo dnf install ./<downloaded-filename>` |
+| Alpine | `frostyard-chairlift_<version>_<arch>.apk` (`x86_64` or `aarch64`) | `sudo apk add --allow-untrusted ./<downloaded-filename>` |
+
+For a normal system installation, download the full `frostyard-chairlift`
+package. It includes the GUI, privileged helper, desktop assets, PolicyKit
+policies, and package-maintainer configuration.
+
+Use the similarly named `frostyard-chairlift-system-integration` package
+**only** when the ChairLift GUI is already delivered through a user-scoped
+mechanism such as the Homebrew cask. That package supplies only the root-owned
+helper, policies, and configuration needed by such an installation; it does
+not include the GUI. Never install both packages: they intentionally conflict
+because they own the same system-integration files.
+
+Download `checksums.txt` from the same release and verify the selected package
+before installing it:
+
+```bash
+package='<downloaded-package-filename>'
+grep -F "  $package" checksums.txt | sha256sum --check -
+```
+
 ### Building from Source
 
 ChairLift is written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO required):


### PR DESCRIPTION
## Summary

- document the published deb, rpm, and apk artifacts and their install commands
- explain when to choose the full package versus the system-integration companion
- add checksum verification and repair the historical Go port's LICENSE link

## Related issue

Closes #193

## Change classification

- Risk tier: Tier 1 - Low
- Rationale: Documentation-only changes that do not alter executable, build, release, configuration, or workflow behavior.

## Validation

- [ ] `make ci` (not run; documentation-only change)
- [x] Additional relevant checks (including `make e2e` when applicable): `git diff --check`; compared documented package names and contents with `.goreleaser.yaml` and the current v0.10.1 release assets.

## Tests and documentation

- Tests: Not needed; no executable behavior changed.
- Documentation: Added release installation, package-selection, and checksum guidance to `README.md`; fixed the root-relative LICENSE link in `README-go-port.md`.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.
