### PR TITLE
Add native A/B (systemd-sysupdate) update support to the Updates page

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,6 +77,7 @@ archives:
       - data/icons/**/*
       - data/org.frostyard.ChairLift.bootc.policy
       - data/org.frostyard.ChairLift.updex.policy
+      - data/org.frostyard.ChairLift.sysupdate.policy
 
 
 checksum:
@@ -159,6 +160,11 @@ nfpms:
         dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.updex.policy
         file_info:
           mode: 0644
+      # PolicyKit policy for native A/B sysupdate staging
+      - src: ./data/org.frostyard.ChairLift.sysupdate.policy
+        dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.sysupdate.policy
+        file_info:
+          mode: 0644
     formats:
       - deb
       - rpm
@@ -167,7 +173,8 @@ nfpms:
   # Root-owned companion for a user-scoped app installation such as the
   # Homebrew cask. It intentionally retains ChairLift's fixed helper and
   # PolicyKit paths. Distros enabling bootc staging must separately provide
-  # /usr/libexec/bootc-update-stage.
+  # /usr/libexec/bootc-update-stage; native A/B hosts ship
+  # /usr/libexec/snosi-sysupdate-stage with the OS image.
   - id: chairlift-system-integration
     ids:
       - chairlift-updex-helper
@@ -191,6 +198,10 @@ nfpms:
           mode: 0644
       - src: ./data/org.frostyard.ChairLift.updex.policy
         dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.updex.policy
+        file_info:
+          mode: 0644
+      - src: ./data/org.frostyard.ChairLift.sysupdate.policy
+        dst: /usr/share/polkit-1/actions/org.frostyard.ChairLift.sysupdate.policy
         file_info:
           mode: 0644
     formats:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,10 @@ An agent must not break these:
 - **Privilege boundary.** State-changing operations that require root go
   through `pkexec` (PolicyKit) with fixed, installed polkit policies and fixed
   helper binaries only: `pkexec /usr/libexec/bootc-update-stage` (action
-  `org.frostyard.ChairLift.bootc.stage`) and `pkexec
-  /usr/bin/chairlift-updex-helper` (`internal/updex.HelperPath`, actions
+  `org.frostyard.ChairLift.bootc.stage`), `pkexec
+  /usr/libexec/snosi-sysupdate-stage` (`internal/sysupdate.StageScriptPath`,
+  action `org.frostyard.ChairLift.sysupdate.stage`, native A/B hosts), and
+  `pkexec /usr/bin/chairlift-updex-helper` (`internal/updex.HelperPath`, actions
   `org.frostyard.ChairLift.updex.{enable-feature,disable-feature,update}`) —
   always that fixed absolute path, matching the
   `org.freedesktop.policykit.exec.path` annotation, with the updex subcommand
@@ -84,12 +86,14 @@ An agent must not break these:
   mutations around the fixed helper/policy pair.
 - **System-integration split.** The
   `frostyard-chairlift-system-integration` nFPM package contains the fixed-path
-  updex helper, both PolicyKit policies, and package-maintainer config, but not
-  the GUI or a bootc staging implementation. Distributions pairing it with a
-  user-scoped ChairLift install must provide their trusted stage helper at
-  `/usr/libexec/bootc-update-stage` before enabling `bootc_updates_group`.
-  Do not make the privileged path configurable from ChairLift's user-writable
-  configuration.
+  updex helper, all three PolicyKit policies, and package-maintainer config,
+  but not the GUI or an OS staging implementation. Distributions pairing it
+  with a user-scoped ChairLift install must provide their trusted stage helper
+  at `/usr/libexec/bootc-update-stage` before enabling `bootc_updates_group`;
+  native A/B hosts ship `/usr/libexec/snosi-sysupdate-stage` (and the
+  `/usr/lib/snosi/native-ab` marker) with the OS image, which
+  `sysupdate_updates_group` requires. Do not make the privileged path
+  configurable from ChairLift's user-writable configuration.
 - **GTK main-thread safety.** All external tool calls run in goroutines; every
   UI update marshals back to the GTK main thread via
   `snowkit`'s `sgtk.RunOnMainThread(...)`. Never touch a widget directly from a
@@ -126,11 +130,11 @@ An agent must not break these:
   pin/unpin, and every row shares one gate across its mutation controls so
   actions cannot overlap. A live success completes the old controls and starts
   a generation-guarded inventory refresh; failure or dry-run restores them.
-- **Update badge counts have one state owner.** Bootc, Flatpak, and Homebrew
-  counts live in the pure `internal/views/badgestate` package. Refreshes
-  replace a provider's count, successful row removals decrement without going
-  negative, and the displayed total is always the sum of all three providers.
-  Do not restore independent integer fields in `UserHome`.
+- **Update badge counts have one state owner.** Bootc, sysupdate, Flatpak,
+  and Homebrew counts live in the pure `internal/views/badgestate` package.
+  Refreshes replace a provider's count, successful row removals decrement
+  without going negative, and the displayed total is always the sum of all
+  four providers. Do not restore independent integer fields in `UserHome`.
 - **Config-driven visibility is real.** Any group can be disabled in config
   (`config.IsGroupEnabled(page, group)`), so its widgets may never be
   constructed. Code that runs after an async action must not assume a widget

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -55,6 +55,7 @@ valid page.
 ### Updates Page (`updates_page`)
 
 - `bootc_updates_group`: System-wide bootc updates
+- `sysupdate_updates_group`: System-wide native A/B (systemd-sysupdate) updates; shown only on native A/B installs
 - `flatpak_updates_group`: Available Flatpak application updates (user and system)
 - `brew_updates_group`: Homebrew package updates and outdated packages
 - `brew_trust_group`: Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); only shown when there is something to trust

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,8 @@ install: build
 	install -Dm644 data/org.frostyard.ChairLift.bootc.policy $(DESTDIR)$(POLKITACTIONSDIR)/org.frostyard.ChairLift.bootc.policy
 	# Install PolicyKit policy for updex
 	install -Dm644 data/org.frostyard.ChairLift.updex.policy $(DESTDIR)$(POLKITACTIONSDIR)/org.frostyard.ChairLift.updex.policy
+	# Install PolicyKit policy for native A/B sysupdate staging
+	install -Dm644 data/org.frostyard.ChairLift.sysupdate.policy $(DESTDIR)$(POLKITACTIONSDIR)/org.frostyard.ChairLift.sysupdate.policy
 
 # Uninstall the application
 uninstall:
@@ -138,6 +140,7 @@ uninstall:
 	rm -f $(DESTDIR)$(POLKITRULESDIR)/org.frostyard.ChairLift.bootc.rules
 	rm -f $(DESTDIR)$(POLKITACTIONSDIR)/org.frostyard.ChairLift.updex.policy
 	rm -f $(DESTDIR)$(POLKITRULESDIR)/org.frostyard.ChairLift.updex.rules
+	rm -f $(DESTDIR)$(POLKITACTIONSDIR)/org.frostyard.ChairLift.sysupdate.policy
 
 # One command mirrors CI's host-independent gates (verify → lint → unit → race
 # → build), in fail-fast order. The GTK/Xvfb-dependent E2E job runs separately

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ### 🔧 Updates & Maintenance
 
-- **System Updates**: On bootc-based systems, download and stage the next OS image update (applied on restart) and view booted/staged/rollback deployment status
+- **System Updates**: On bootc-based systems, download and stage the next OS image update (applied on restart) and view booted/staged/rollback deployment status; on native A/B (systemd-sysupdate) installs, stage the next image the same way and see the previous version available for boot-menu rollback
 - **Homebrew Updates**: Check for and install package updates; actions show
   progress, reject repeated clicks, and refresh the outdated rows and sidebar
   badge after successful live operations
@@ -124,7 +124,7 @@ administrator-owned `/etc/chairlift/config.yml` override.
 Releases also publish a small
 `frostyard-chairlift-system-integration` deb/rpm/apk for distributions that
 deliver the GUI through a user-scoped mechanism such as the Homebrew cask. It
-installs only the fixed `/usr/bin/chairlift-updex-helper`, both PolicyKit
+installs only the fixed `/usr/bin/chairlift-updex-helper`, all three PolicyKit
 policies, and `/usr/share/chairlift/config.yml`; it does not install the GUI.
 The integration and full packages conflict intentionally because they own the
 same privileged files.
@@ -133,7 +133,10 @@ The bootc policy deliberately retains the fixed
 `/usr/libexec/bootc-update-stage` path. A distribution must provide a trusted
 stage helper at exactly that path before enabling `bootc_updates_group`; the
 integration package does not provide a distro-specific staging implementation.
-ChairLift hides the group when the helper is absent.
+ChairLift hides the group when the helper is absent. The sysupdate policy
+likewise retains the fixed `/usr/libexec/snosi-sysupdate-stage` path used by
+`sysupdate_updates_group` on native A/B installs; that helper (and the
+`/usr/lib/snosi/native-ab` marker gating the group) ship with the OS image.
 
 `PREFIX` can still be overridden (e.g. `make install PREFIX=$HOME/.local`)
 for a non-privileged, non-PolicyKit-integrated install — but the updex
@@ -156,7 +159,8 @@ Other useful targets: `make dev` (CGO-enabled build with `-race` for development
 - GTK 4 and libadwaita 1 (shared libraries, loaded at runtime by puregotk — no GTK dev headers or CGO needed to build)
 - Homebrew (optional, for package management features and tap trust)
 - Flatpak (optional)
-- `bootc` and the snow `/usr/libexec/bootc-update-stage` script (optional; enables staged system updates)
+- `bootc` and the snow `/usr/libexec/bootc-update-stage` script (optional; enables staged system updates on bootc installs)
+- The snow `/usr/libexec/snosi-sysupdate-stage` script and `/usr/lib/snosi/native-ab` marker (optional; enables staged system updates on native A/B installs)
 - `updex` features configured on the system (optional; toggled via the Features page)
 - Mission Center (optional, for system performance monitoring)
 
@@ -176,7 +180,7 @@ chairlift
    and casks, install curated bundles, and launch the configured external
    Flatpak manager
 2. **Maintenance**: System cleanup and maintenance tools (Homebrew, Flatpak, custom scripts)
-3. **Updates**: Stage bootc system updates, manage Homebrew updates and outdated packages, apply Flatpak updates, and trust Homebrew taps
+3. **Updates**: Stage bootc or native A/B system updates, manage Homebrew updates and outdated packages, apply Flatpak updates, and trust Homebrew taps
 4. **System**: Monitor deployment, health, and performance information
 5. **Features**: Enable, disable, and update configured system features
 6. **Help**: Documentation and support resources
@@ -278,6 +282,7 @@ chairlift/
 │   ├── homebrew/  # Homebrew CLI wrapper (incl. tap trust)
 │   ├── flatpak/   # Flatpak CLI wrapper
 │   ├── bootc/     # bootc wrapper (status reads, pkexec stage script)
+│   ├── sysupdate/ # Native A/B wrapper (state-file reads, pkexec stage script)
 │   ├── updex/     # Updex feature manager
 │   └── version/   # Build metadata (ldflags injection)
 ├── data/          # Desktop file, icons, and PolicyKit policies
@@ -290,6 +295,7 @@ See [yeti/OVERVIEW.md](yeti/OVERVIEW.md) and [yeti/package-managers.md](yeti/pac
 
 - **`internal/homebrew`**: Homebrew CLI wrapper — package listing/searching, install/uninstall, pin/unpin, bundles, updates, and Homebrew 6 tap-trust detection/management
 - **`internal/bootc`**: bootc status reads and pkexec-driven update staging via the snow `bootc-update-stage` script
+- **`internal/sysupdate`**: native A/B (systemd-sysupdate) status reads from the `/run/snosi` state files, rollback-candidate discovery from partition labels, and pkexec-driven update staging via the snow `snosi-sysupdate-stage` script
 - **`internal/views`**: GTK4/Adwaita UI — async operations dispatched via `sgtk.RunOnMainThread`, toast notifications for user feedback
 - **`internal/views/pageview`**: pure-Go row text, page status, os-release parsing, help-link ordering, and maintenance-command selection shared by all six page builders
 

--- a/config.bootc-example.yml
+++ b/config.bootc-example.yml
@@ -21,6 +21,8 @@ system_page:
 updates_page:
   bootc_updates_group:
     enabled: true  # Requires /usr/libexec/bootc-update-stage
+  sysupdate_updates_group:
+    enabled: false  # Native A/B (systemd-sysupdate) hosts only; requires /usr/libexec/snosi-sysupdate-stage
   brew_updates_group:
     enabled: false  # Hide Homebrew updates (not typically used on other distros)
   brew_trust_group:

--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,8 @@ system_page:
 updates_page:
   bootc_updates_group:
     enabled: true
+  sysupdate_updates_group:
+    enabled: true
   flatpak_updates_group:
     enabled: true
   brew_updates_group:

--- a/data/org.frostyard.ChairLift.sysupdate.policy
+++ b/data/org.frostyard.ChairLift.sysupdate.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+
+<policyconfig>
+  <vendor>Frostyard</vendor>
+  <vendor_url>https://github.com/frostyard/chairlift</vendor_url>
+  <icon_name>org.frostyard.ChairLift</icon_name>
+
+  <action id="org.frostyard.ChairLift.sysupdate.stage">
+    <description>Download and stage a system image update</description>
+    <message>Authentication is required to stage a system update</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/snosi-sysupdate-stage</annotate>
+  </action>
+
+</policyconfig>

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ ChairLift provides six configurable pages:
 |------|-------------|
 | **Applications** | Search/install Homebrew formulae and casks; uninstall installed formulae/casks; pin/unpin formulae; install curated Brewfile bundles. List/uninstall Flatpaks and launch the configured external manager for Flatpak discovery and installation. |
 | **Maintenance** | Run cleanup tasks for Homebrew and Flatpak, and execute custom maintenance scripts. |
-| **Updates** | Stage bootc system updates, apply Flatpak updates, upgrade Homebrew packages, and trust Homebrew taps. |
+| **Updates** | Stage bootc or native A/B (systemd-sysupdate) system updates, apply Flatpak updates, upgrade Homebrew packages, and trust Homebrew taps. |
 | **System** | View OS information, bootc deployment status, and launch a system health monitor. |
 | **Features** | Toggle system features managed by updex. |
 | **Help** | Links to the project website, issue tracker, and community chat. |
@@ -39,8 +39,9 @@ always retained so the window always has a valid destination.
 
 Runtime visibility depends on the group:
 
-- bootc status/staging groups and unavailable Homebrew/Flatpak maintenance
-  groups are hidden when their tool-specific runtime gates fail;
+- bootc status/staging groups, the native A/B staging group, and unavailable
+  Homebrew/Flatpak maintenance groups are hidden when their tool-specific
+  runtime gates fail;
 - the Homebrew untrusted-taps group stays hidden unless actionable taps exist;
 - Features replaces its main group with an explicit unavailable message when
   Updex is not configured;
@@ -55,6 +56,7 @@ groups configuration enables, not on runtime tool availability.
 | Homebrew | Package management (formulae, casks, bundles) |
 | Flatpak | Installed-application listing/uninstall and updates; new installs are delegated to the configured external manager |
 | bootc + `/usr/libexec/bootc-update-stage` | Staged bootc system updates |
+| `/usr/lib/snosi/native-ab` marker + `/usr/libexec/snosi-sysupdate-stage` | Staged native A/B (systemd-sysupdate) system updates |
 | Updex | System feature toggles |
 
 ## Building
@@ -90,7 +92,8 @@ configuration without installing the GUI. It intentionally conflicts with the
 self-contained `frostyard-chairlift` package. Bootc staging additionally
 requires the distribution to provide its trusted implementation at
 `/usr/libexec/bootc-update-stage`; the integration package does not supply
-one.
+one. Native A/B staging uses `/usr/libexec/snosi-sysupdate-stage`, which
+ships with the OS image itself.
 
 ### Development
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -61,6 +61,7 @@ order below. Help is always retained.
 | Group | Key | Description |
 |-------|-----|-------------|
 | bootc Updates | `bootc_updates_group` | Download and stage the next bootc system image update (applies on restart); shown only when bootc-booted and the fixed `/usr/libexec/bootc-update-stage` helper is present. Non-Snow distributions must provide a trusted implementation there before enabling this group; ChairLift's system-integration package does not supply one. |
+| Native A/B Updates | `sysupdate_updates_group` | Download and stage the next native A/B (systemd-sysupdate) system image update (applies on restart), plus a read-only previous-version rollback row; shown only when the `/usr/lib/snosi/native-ab` marker and the fixed `/usr/libexec/snosi-sysupdate-stage` helper are present. The OS image ships both; ChairLift's system-integration package supplies only the PolicyKit policy. |
 | Flatpak Updates | `flatpak_updates_group` | Pending Flatpak application updates |
 | Homebrew Updates | `brew_updates_group` | Outdated Homebrew packages with upgrade buttons |
 | Untrusted Taps | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); trust a tap to resume its updates. Shown only when there is something to trust |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/frostyard/chairlift/internal/flatpak"
 	"github.com/frostyard/chairlift/internal/homebrew"
 	"github.com/frostyard/chairlift/internal/navigation"
+	"github.com/frostyard/chairlift/internal/sysupdate"
 	"github.com/frostyard/chairlift/internal/updex"
 	"github.com/frostyard/chairlift/internal/views"
 	"github.com/frostyard/chairlift/internal/window"
@@ -84,6 +85,7 @@ func New() *Application {
 			flatpak.SetDryRun(true)
 			homebrew.SetDryRun(true)
 			bootc.SetDryRun(true)
+			sysupdate.SetDryRun(true)
 			updex.SetDryRun(true)
 			views.SetDryRun(true)
 			break

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,10 +238,11 @@ func defaultConfig() *Config {
 			},
 		},
 		UpdatesPage: PageConfig{
-			"bootc_updates_group":   GroupConfig{Enabled: true},
-			"flatpak_updates_group": GroupConfig{Enabled: true},
-			"brew_updates_group":    GroupConfig{Enabled: true},
-			"brew_trust_group":      GroupConfig{Enabled: true},
+			"bootc_updates_group":     GroupConfig{Enabled: true},
+			"sysupdate_updates_group": GroupConfig{Enabled: true},
+			"flatpak_updates_group":   GroupConfig{Enabled: true},
+			"brew_updates_group":      GroupConfig{Enabled: true},
+			"brew_trust_group":        GroupConfig{Enabled: true},
 		},
 		ApplicationsPage: PageConfig{
 			"applications_installed_group": GroupConfig{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -402,17 +402,18 @@ func repoRoot() string {
 }
 
 // TestUpdatesPageDefaultGroupSetIsExact asserts that defaultConfig()'s
-// updates_page group set is exactly the four groups the Updates page view
+// updates_page group set is exactly the five groups the Updates page view
 // still builds. This is an exact-set equality check (length plus every
 // expected key present), not a single named-key absence lookup, so it fails
 // loudly whether a formerly-shipped, now-removed group is silently
 // re-added under its old name or under any new one.
 func TestUpdatesPageDefaultGroupSetIsExact(t *testing.T) {
 	want := map[string]bool{
-		"bootc_updates_group":   true,
-		"flatpak_updates_group": true,
-		"brew_updates_group":    true,
-		"brew_trust_group":      true,
+		"bootc_updates_group":     true,
+		"sysupdate_updates_group": true,
+		"flatpak_updates_group":   true,
+		"brew_updates_group":      true,
+		"brew_trust_group":        true,
 	}
 
 	got := defaultConfig().UpdatesPage

--- a/internal/installcheck/goreleaser_test.go
+++ b/internal/installcheck/goreleaser_test.go
@@ -120,6 +120,7 @@ func TestGoreleaserNfpmLayoutMatchesUsrPrefix(t *testing.T) {
 		{"maintainer config", "config.yml", "/usr/share/chairlift/config.yml"},
 		{"updex policy", "org.frostyard.ChairLift.updex.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy")},
 		{"bootc policy", "org.frostyard.ChairLift.bootc.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy")},
+		{"sysupdate policy", "org.frostyard.ChairLift.sysupdate.policy", filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.sysupdate.policy")},
 	}
 
 	for i, nfpm := range cfg.Nfpms {
@@ -179,9 +180,10 @@ func TestGoreleaserPublishesSystemIntegrationPackage(t *testing.T) {
 	}
 
 	wantIntegrationContents := map[string]string{
-		"config.yml":                           "/usr/share/chairlift/config.yml",
-		"org.frostyard.ChairLift.bootc.policy": filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy"),
-		"org.frostyard.ChairLift.updex.policy": filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy"),
+		"config.yml":                               "/usr/share/chairlift/config.yml",
+		"org.frostyard.ChairLift.bootc.policy":     filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy"),
+		"org.frostyard.ChairLift.updex.policy":     filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy"),
+		"org.frostyard.ChairLift.sysupdate.policy": filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.sysupdate.policy"),
 	}
 	if len(integration.Contents) != len(wantIntegrationContents) {
 		t.Errorf("%s contents has %d entries, want %d", integrationPackageName, len(integration.Contents), len(wantIntegrationContents))

--- a/internal/installcheck/makefile_test.go
+++ b/internal/installcheck/makefile_test.go
@@ -80,6 +80,7 @@ func assertInstallsPackageLayout(t *testing.T, output, destDir string) {
 	for _, rel := range []string{
 		filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.updex.policy"),
 		filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.bootc.policy"),
+		filepath.Join(polkitActionsDir, "org.frostyard.ChairLift.sysupdate.policy"),
 	} {
 		want := filepath.Join(destDir, rel)
 		if !strings.Contains(output, want) {

--- a/internal/installcheck/polkit_test.go
+++ b/internal/installcheck/polkit_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/frostyard/chairlift/internal/bootc"
+	"github.com/frostyard/chairlift/internal/sysupdate"
 	"github.com/frostyard/chairlift/internal/updex"
 	"github.com/frostyard/chairlift/internal/updexhelper"
 )
@@ -166,12 +167,22 @@ func TestPolkitPoliciesMatchPrivilegedHelpers(t *testing.T) {
 			Path:        bootc.StageScriptPath,
 		},
 	})
+
+	assertPolicyActions(t, "org.frostyard.ChairLift.sysupdate.policy", []expectedPolicyAction{
+		{
+			ID:          "org.frostyard.ChairLift.sysupdate.stage",
+			Description: "Download and stage a system image update",
+			Message:     "Authentication is required to stage a system update",
+			Path:        sysupdate.StageScriptPath,
+		},
+	})
 }
 
 func TestPolkitPasswordlessRulesAreAbsent(t *testing.T) {
 	for _, name := range []string{
 		"org.frostyard.ChairLift.updex.rules",
 		"org.frostyard.ChairLift.bootc.rules",
+		"org.frostyard.ChairLift.sysupdate.rules",
 	} {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join(RepoRoot(), "data", name)

--- a/internal/navigation/navigation.go
+++ b/internal/navigation/navigation.go
@@ -79,6 +79,7 @@ var items = []Item{
 		ConfigPage: "updates_page",
 		Groups: []string{
 			"bootc_updates_group",
+			"sysupdate_updates_group",
 			"flatpak_updates_group",
 			"brew_updates_group",
 			"brew_trust_group",

--- a/internal/navigation/navigation_test.go
+++ b/internal/navigation/navigation_test.go
@@ -162,6 +162,7 @@ func TestPageMetadataCoversEveryBuilderBackedGroup(t *testing.T) {
 		},
 		"updates": {
 			"bootc_updates_group",
+			"sysupdate_updates_group",
 			"flatpak_updates_group",
 			"brew_updates_group",
 			"brew_trust_group",

--- a/internal/sysupdate/rollback.go
+++ b/internal/sysupdate/rollback.go
@@ -1,0 +1,125 @@
+package sysupdate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// osReleasePath is where snosi tooling reads the image identity; unlike
+// /etc/os-release it is guaranteed present on the read-only root.
+const osReleasePath = "/usr/lib/os-release"
+
+const lsblkCommand = "lsblk"
+
+// imageIdentity extracts IMAGE_ID and IMAGE_VERSION from os-release
+// contents. Values may be optionally double-quoted (both forms ship).
+func imageIdentity(data []byte) (imageID, version string) {
+	for line := range strings.SplitSeq(string(data), "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		value = strings.Trim(value, `"`)
+		switch key {
+		case "IMAGE_ID":
+			imageID = value
+		case "IMAGE_VERSION":
+			version = value
+		}
+	}
+	return imageID, version
+}
+
+// lsblkNode is the subset of `lsblk -J` output needed for slot discovery.
+// lsblk nests partitions under each disk's "children" array, so the walk
+// must recurse rather than scan only the top-level list.
+type lsblkNode struct {
+	PartLabel string      `json:"partlabel"`
+	Children  []lsblkNode `json:"children"`
+}
+
+type lsblkOutput struct {
+	BlockDevices []lsblkNode `json:"blockdevices"`
+}
+
+// otherSlotFromLsblk returns the version label of the inactive root slot:
+// the partition labeled "<imageID>_<version>_r" that is not the running
+// slot. The running slot is excluded by its PARTLABEL, never by comparing
+// mount sources: on a dm-verity root the source is /dev/mapper/root, which
+// never equals the partition's /dev path. A fresh install's unused slot is
+// labeled "_empty", which the "<imageID>_" prefix filter excludes.
+func otherSlotFromLsblk(data []byte, imageID, runningVersion string) (string, bool) {
+	if imageID == "" {
+		return "", false
+	}
+	var parsed lsblkOutput
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", false
+	}
+	runningLabel := imageID + "_" + runningVersion + "_r"
+	prefix := imageID + "_"
+	var walk func(nodes []lsblkNode) (string, bool)
+	walk = func(nodes []lsblkNode) (string, bool) {
+		for _, node := range nodes {
+			label := node.PartLabel
+			if label != runningLabel && strings.HasPrefix(label, prefix) && strings.HasSuffix(label, "_r") {
+				return strings.TrimSuffix(strings.TrimPrefix(label, prefix), "_r"), true
+			}
+			if version, ok := walk(node.Children); ok {
+				return version, ok
+			}
+		}
+		return "", false
+	}
+	return walk(parsed.BlockDevices)
+}
+
+// RollbackCandidate reports whether the inactive slot's version is a
+// rollback target. Only an older version qualifies: after a stage the
+// inactive slot holds the newer pending version, which is not a rollback.
+// The 14-digit grammar makes lexicographic comparison numeric.
+func RollbackCandidate(other, running string) (string, bool) {
+	if !ValidVersion(other) || !ValidVersion(running) {
+		return "", false
+	}
+	if other >= running {
+		return "", false
+	}
+	return other, true
+}
+
+// RollbackVersion returns the version in the inactive root slot when it is
+// older than the running version (a genuine rollback target), or ("",
+// false) when the other slot is empty, holds a staged newer version, or
+// discovery fails. Runs unprivileged: partition labels come from lsblk and
+// the running identity from os-release.
+func RollbackVersion(ctx context.Context) (string, bool) {
+	osRelease, err := os.ReadFile(osReleasePath)
+	if err != nil {
+		return "", false
+	}
+	imageID, runningVersion := imageIdentity(osRelease)
+	output, err := runLsblk(ctx)
+	if err != nil {
+		return "", false
+	}
+	other, ok := otherSlotFromLsblk(output, imageID, runningVersion)
+	if !ok {
+		return "", false
+	}
+	return RollbackCandidate(other, runningVersion)
+}
+
+// runLsblk captures `lsblk -J -o PATH,PARTLABEL`. Separated so tests can
+// exercise the parse pipeline without a real block layout.
+func runLsblk(ctx context.Context) ([]byte, error) {
+	output, err := exec.CommandContext(ctx, lsblkCommand, "-J", "-o", "PATH,PARTLABEL").Output()
+	if err != nil {
+		return nil, &Error{Message: fmt.Sprintf("lsblk failed: %v", err), Err: err}
+	}
+	return output, nil
+}

--- a/internal/sysupdate/rollback_test.go
+++ b/internal/sysupdate/rollback_test.go
@@ -1,0 +1,144 @@
+package sysupdate
+
+import "testing"
+
+func TestImageIdentityParsing(t *testing.T) {
+	data := `PRETTY_NAME="Snow Linux"
+NAME="Snow Linux"
+ID="snow"
+IMAGE_ID="snow"
+IMAGE_VERSION="20260810191856"
+`
+	imageID, version := imageIdentity([]byte(data))
+	if imageID != "snow" || version != "20260810191856" {
+		t.Errorf("imageIdentity = (%q, %q), want (snow, 20260810191856)", imageID, version)
+	}
+}
+
+func TestImageIdentityUnquotedValues(t *testing.T) {
+	imageID, version := imageIdentity([]byte("IMAGE_ID=cayo\nIMAGE_VERSION=20260101000000\n"))
+	if imageID != "cayo" || version != "20260101000000" {
+		t.Errorf("imageIdentity = (%q, %q), want (cayo, 20260101000000)", imageID, version)
+	}
+}
+
+// lsblkFixture builds lsblk -J output with partitions nested under a disk's
+// children array, the shape real lsblk emits.
+func lsblkFixture(labels ...string) []byte {
+	out := `{"blockdevices":[{"path":"/dev/nvme0n1","partlabel":null,"children":[`
+	for i, label := range labels {
+		if i > 0 {
+			out += ","
+		}
+		out += `{"path":"/dev/nvme0n1p` + string(rune('1'+i)) + `","partlabel":"` + label + `"}`
+	}
+	return []byte(out + `]}]}`)
+}
+
+func TestOtherSlotFromLsblk(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         []string
+		imageID        string
+		runningVersion string
+		want           string
+		wantOK         bool
+	}{
+		{
+			name:           "older version in other slot",
+			labels:         []string{"esp", "snow_20260810191856_r", "snow_20260810191856_v", "snow_20260801000000_r", "snow_20260801000000_v", "var"},
+			imageID:        "snow",
+			runningVersion: "20260810191856",
+			want:           "20260801000000",
+			wantOK:         true,
+		},
+		{
+			name:           "fresh install other slot empty",
+			labels:         []string{"esp", "snow_20260810191856_r", "snow_20260810191856_v", "_empty", "_empty", "var"},
+			imageID:        "snow",
+			runningVersion: "20260810191856",
+			wantOK:         false,
+		},
+		{
+			name:           "running slot excluded by label not mount source",
+			labels:         []string{"snow_20260810191856_r"},
+			imageID:        "snow",
+			runningVersion: "20260810191856",
+			wantOK:         false,
+		},
+		{
+			name:           "verity slots never match",
+			labels:         []string{"snow_20260810191856_r", "snow_20260801000000_v"},
+			imageID:        "snow",
+			runningVersion: "20260810191856",
+			wantOK:         false,
+		},
+		{
+			name:           "empty image id yields nothing",
+			labels:         []string{"snow_20260801000000_r"},
+			imageID:        "",
+			runningVersion: "20260810191856",
+			wantOK:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := otherSlotFromLsblk(lsblkFixture(tt.labels...), tt.imageID, tt.runningVersion)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("otherSlotFromLsblk = (%q, %v), want (%q, %v)", got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestOtherSlotFromLsblkMalformedJSON(t *testing.T) {
+	if _, ok := otherSlotFromLsblk([]byte("not json"), "snow", "20260810191856"); ok {
+		t.Error("otherSlotFromLsblk accepted malformed JSON")
+	}
+}
+
+func TestRollbackCandidateRule(t *testing.T) {
+	tests := []struct {
+		name           string
+		other, running string
+		want           string
+		wantOK         bool
+	}{
+		{
+			name:  "older other slot is a rollback candidate",
+			other: "20260801000000", running: "20260810191856",
+			want: "20260801000000", wantOK: true,
+		},
+		{
+			// After a stage the inactive slot holds the newer pending
+			// version; that is not a rollback target.
+			name:  "newer other slot is pending not rollback",
+			other: "20260811000000", running: "20260810191856",
+			wantOK: false,
+		},
+		{
+			name:  "equal versions never qualify",
+			other: "20260810191856", running: "20260810191856",
+			wantOK: false,
+		},
+		{
+			name:  "invalid other version",
+			other: "", running: "20260810191856",
+			wantOK: false,
+		},
+		{
+			name:  "invalid running version",
+			other: "20260801000000", running: "",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := RollbackCandidate(tt.other, tt.running)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("RollbackCandidate(%q, %q) = (%q, %v), want (%q, %v)",
+					tt.other, tt.running, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/sysupdate/rollback_test.go
+++ b/internal/sysupdate/rollback_test.go
@@ -2,7 +2,7 @@ package sysupdate
 
 import "testing"
 
-func TestImageIdentityParsing(t *testing.T) {
+func TestOsReleaseImageIdentityParsing(t *testing.T) {
 	data := `PRETTY_NAME="Snow Linux"
 NAME="Snow Linux"
 ID="snow"
@@ -15,7 +15,7 @@ IMAGE_VERSION="20260810191856"
 	}
 }
 
-func TestImageIdentityUnquotedValues(t *testing.T) {
+func TestOsReleaseImageIdentityUnquotedValues(t *testing.T) {
 	imageID, version := imageIdentity([]byte("IMAGE_ID=cayo\nIMAGE_VERSION=20260101000000\n"))
 	if imageID != "cayo" || version != "20260101000000" {
 		t.Errorf("imageIdentity = (%q, %q), want (cayo, 20260101000000)", imageID, version)

--- a/internal/sysupdate/stage.go
+++ b/internal/sysupdate/stage.go
@@ -1,0 +1,133 @@
+package sysupdate
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// StageScriptPath is the snosi-shipped native A/B stager. It checks the
+// image's sysupdate target for a newer version and downloads it into the
+// inactive root/verity slots via systemd-sysupdate; it never reboots, and
+// it is idempotent (exits 0 without staging when already current or when
+// the candidate is already in the inactive slot).
+const StageScriptPath = "/usr/libexec/snosi-sysupdate-stage"
+
+// EventType classifies a ProgressEvent.
+type EventType string
+
+const (
+	EventMessage  EventType = "message"
+	EventComplete EventType = "complete"
+)
+
+// ProgressEvent is a single line of progress from the stage script.
+type ProgressEvent struct {
+	Type    EventType
+	Message string
+}
+
+// StageScriptAvailable reports whether the stage script is installed.
+func StageScriptAvailable() bool {
+	_, err := os.Stat(StageScriptPath)
+	return err == nil
+}
+
+// StageUpdate checks for and stages a system update by running the stage
+// script via pkexec. Output lines stream to progressCh as EventMessage
+// events; EventComplete is sent on success. progressCh is closed when done.
+func StageUpdate(ctx context.Context, progressCh chan<- ProgressEvent) error {
+	if dryRun {
+		log.Printf("[DRY-RUN] would execute: pkexec %s", StageScriptPath)
+		progressCh <- ProgressEvent{Type: EventMessage, Message: "[DRY-RUN] would run " + StageScriptPath}
+		progressCh <- ProgressEvent{Type: EventComplete, Message: "Dry run complete"}
+		close(progressCh)
+		return nil
+	}
+	return runStageStreaming(ctx, progressCh, pkexecCommand, StageScriptPath)
+}
+
+// runStageStreaming runs a command, streaming stdout+stderr lines to
+// progressCh. It closes progressCh before returning. Separated from
+// StageUpdate so tests can run a local fake script without pkexec.
+//
+// Failures classify into three mutually exclusive outcomes: deadline
+// (*Error unwrapping to context.DeadlineExceeded), cancellation (*Error
+// unwrapping to context.Canceled, or a bare context.Canceled when the stream
+// send loses the race), and a non-zero exit (*Error carrying the last output
+// line, matching neither context sentinel). A missing executable yields a
+// *NotFoundError.
+func runStageStreaming(ctx context.Context, progressCh chan<- ProgressEvent, name string, args ...string) error {
+	defer close(progressCh)
+
+	cmd := exec.CommandContext(ctx, name, args...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return &Error{Message: fmt.Sprintf("failed to create stdout pipe: %v", err)}
+	}
+	// Merge stderr into the same stream so systemd-sysupdate's progress
+	// output (which the script passes through on stderr) surfaces.
+	cmd.Stderr = cmd.Stdout
+
+	if err := cmd.Start(); err != nil {
+		// exec.ErrNotFound covers a bare name missing from $PATH;
+		// fs.ErrNotExist covers an explicit path that does not exist.
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+			return &NotFoundError{Message: name + " not found"}
+		}
+		return &Error{Message: fmt.Sprintf("failed to start %s: %v", name, err)}
+	}
+
+	var lastLine string
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		lastLine = line
+		select {
+		case progressCh <- ProgressEvent{Type: EventMessage, Message: line}:
+		case <-ctx.Done():
+			// Direct kill of the child only, deliberately: StageUpdate runs
+			// through pkexec, so the child is root-owned and this
+			// unprivileged process cannot signal it as a process group the
+			// way the homebrew and flatpak runners do (making the privileged
+			// path group-killable is a privilege-model change).
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait() // reap the killed child; error is expected here
+			return ctx.Err()
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		// Classify the context outcome first: the child is killed when the
+		// context ends, so the raw wait error would otherwise read
+		// "signal: killed".
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+			return &Error{Message: "Update staging timed out", Err: context.DeadlineExceeded}
+		}
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(err, context.Canceled) {
+			return &Error{Message: "Update staging was canceled", Err: context.Canceled}
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			msg := fmt.Sprintf("update staging failed (exit %d)", exitErr.ExitCode())
+			if lastLine != "" {
+				msg += ": " + lastLine
+			}
+			return &Error{Message: msg, Err: err}
+		}
+		return &Error{Message: err.Error(), Err: err}
+	}
+
+	progressCh <- ProgressEvent{Type: EventComplete, Message: "Staging complete"}
+	return nil
+}

--- a/internal/sysupdate/stage_test.go
+++ b/internal/sysupdate/stage_test.go
@@ -1,0 +1,246 @@
+package sysupdate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeScript writes an executable shell script and returns its path.
+func writeScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-stage")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func collectEvents(ch <-chan ProgressEvent) []ProgressEvent {
+	var events []ProgressEvent
+	for e := range ch {
+		events = append(events, e)
+	}
+	return events
+}
+
+func TestRunStageStreamingSuccess(t *testing.T) {
+	script := writeScript(t, `echo "Staging update: 20260810200801"
+echo "Update staged; it will apply at the next reboot."`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- runStageStreaming(ctx, ch, script) }()
+
+	events := collectEvents(ch)
+	if err := <-done; err != nil {
+		t.Fatalf("runStageStreaming: %v", err)
+	}
+
+	if len(events) != 3 { // 2 messages + 1 complete
+		t.Fatalf("got %d events %+v, want 3", len(events), events)
+	}
+	if events[0].Type != EventMessage || events[0].Message != "Staging update: 20260810200801" {
+		t.Errorf("event[0] = %+v", events[0])
+	}
+	if events[2].Type != EventComplete {
+		t.Errorf("event[2] = %+v, want EventComplete", events[2])
+	}
+}
+
+func TestRunStageStreamingFailure(t *testing.T) {
+	script := writeScript(t, `echo "about to fail"
+echo "boom" >&2
+exit 3`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- runStageStreaming(ctx, ch, script) }()
+
+	events := collectEvents(ch)
+	err := <-done
+	if err == nil {
+		t.Fatal("runStageStreaming = nil error, want failure")
+	}
+	// stdout and stderr lines both stream as messages
+	var sawStdout, sawStderr bool
+	for _, e := range events {
+		if e.Message == "about to fail" {
+			sawStdout = true
+		}
+		if e.Message == "boom" {
+			sawStderr = true
+		}
+		if e.Type == EventComplete {
+			t.Error("got EventComplete on failure")
+		}
+	}
+	if !sawStdout || !sawStderr {
+		t.Errorf("missing streamed lines; events: %+v", events)
+	}
+}
+
+func TestStageUpdateDryRun(t *testing.T) {
+	SetDryRun(true)
+	defer SetDryRun(false)
+
+	ctx := context.Background()
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- StageUpdate(ctx, ch) }()
+
+	events := collectEvents(ch)
+	if err := <-done; err != nil {
+		t.Fatalf("dry-run StageUpdate: %v", err)
+	}
+	if len(events) == 0 || events[len(events)-1].Type != EventComplete {
+		t.Errorf("dry-run should emit mock events ending in EventComplete; got %+v", events)
+	}
+}
+
+func TestRunStageStreamingDeadline(t *testing.T) {
+	// `exec sleep` replaces the shell, so killing the child kills the sleep
+	// too and no stray process survives the test.
+	script := writeScript(t, "exec sleep 30\n")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- runStageStreaming(ctx, ch, script) }()
+
+	collectEvents(ch)
+	err := waitErr(t, done)
+	if err == nil {
+		t.Fatal("runStageStreaming = nil error, want deadline failure")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, DeadlineExceeded) = false; err = %v", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Errorf("deadline error also matches context.Canceled: %v", err)
+	}
+	if strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("message leaks raw kill signal: %q", err.Error())
+	}
+}
+
+func TestRunStageStreamingCanceled(t *testing.T) {
+	script := writeScript(t, "echo \"downloading image\"\nexec sleep 30\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- runStageStreaming(ctx, ch, script) }()
+
+	first, ok := <-ch
+	if !ok {
+		t.Fatal("channel closed before any progress event")
+	}
+	if first.Message != "downloading image" {
+		t.Fatalf("first event = %+v, want the streamed line", first)
+	}
+	cancel()
+	collectEvents(ch)
+
+	err := waitErr(t, done)
+	if err == nil {
+		t.Fatal("runStageStreaming = nil error, want cancellation failure")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("errors.Is(err, Canceled) = false; err = %v", err)
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("cancellation error also matches context.DeadlineExceeded: %v", err)
+	}
+	if strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("message leaks raw kill signal: %q", err.Error())
+	}
+}
+
+func TestRunStageStreamingNonZeroExitIsNeitherContextOutcome(t *testing.T) {
+	script := writeScript(t, `echo "checking for update"
+echo "signed index cannot be fetched"
+exit 4`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() { done <- runStageStreaming(ctx, ch, script) }()
+
+	collectEvents(ch)
+	err := waitErr(t, done)
+	if err == nil {
+		t.Fatal("runStageStreaming = nil error, want exit failure")
+	}
+	var stageErr *Error
+	if !errors.As(err, &stageErr) {
+		t.Fatalf("errors.As(*Error) = false; err = %T %v", err, err)
+	}
+	if !strings.Contains(stageErr.Message, "exit 4") {
+		t.Errorf("message %q missing exit code", stageErr.Message)
+	}
+	if !strings.Contains(stageErr.Message, "signed index cannot be fetched") {
+		t.Errorf("message %q missing last output line", stageErr.Message)
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Errorf("plain exit failure matches a context sentinel: %v", err)
+	}
+}
+
+func TestRunStageStreamingMissingExecutable(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	ch := make(chan ProgressEvent)
+	done := make(chan error, 1)
+	go func() {
+		done <- runStageStreaming(ctx, ch, filepath.Join(t.TempDir(), "absent-helper"))
+	}()
+
+	collectEvents(ch)
+	err := waitErr(t, done)
+	var notFound *NotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("errors.As(*NotFoundError) = false; err = %T %v", err, err)
+	}
+}
+
+func TestNativeABDetectionUsesMarkerConstant(t *testing.T) {
+	// The gate must key off snosi's published marker contract, not a bootc
+	// probe or an os-release field.
+	if MarkerPath != "/usr/lib/snosi/native-ab" {
+		t.Errorf("MarkerPath = %q, want the snosi native A/B marker", MarkerPath)
+	}
+	if StageScriptPath != "/usr/libexec/snosi-sysupdate-stage" {
+		t.Errorf("StageScriptPath = %q, want the fixed snosi stager path", StageScriptPath)
+	}
+}
+
+// waitErr returns the runner's error, failing the test rather than hanging if
+// the runner never returns.
+func waitErr(t *testing.T, done <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(30 * time.Second):
+		t.Fatal("runStageStreaming did not return")
+		return nil
+	}
+}

--- a/internal/sysupdate/status.go
+++ b/internal/sysupdate/status.go
@@ -1,0 +1,223 @@
+package sysupdate
+
+import (
+	"log"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	// UpdateCheckPath records the outcome of the most recent stager run.
+	// World-readable, root-written, cleared by reboot (/run is tmpfs).
+	UpdateCheckPath = "/run/snosi/update-check"
+	// StagedSemaphorePath is the reboot-pending semaphore: present exactly
+	// while a downloaded update awaits the reboot that applies it.
+	StagedSemaphorePath = "/run/snosi/update-staged"
+)
+
+// CheckOutcome is the outcome field of an update-check state file.
+type CheckOutcome string
+
+const (
+	OutcomeCurrent CheckOutcome = "current"
+	OutcomeStaged  CheckOutcome = "staged"
+	OutcomeFailed  CheckOutcome = "failed"
+	// OutcomeUnknown covers an absent file or an unrecognized outcome value
+	// (held-rollback is bootc-transport-only and never written on native).
+	OutcomeUnknown CheckOutcome = ""
+)
+
+// UpdateCheck is the parsed /run/snosi/update-check state file.
+type UpdateCheck struct {
+	Outcome        CheckOutcome
+	CheckedAt      string
+	Image          string
+	RunningVersion string
+	RemoteVersion  string
+}
+
+// StagedUpdate is the parsed /run/snosi/update-staged semaphore. The file
+// language is shared with the bootc transport: exactly one of Version
+// (native, 14-digit) and Digest (bootc) is present.
+type StagedUpdate struct {
+	Image    string
+	Version  string
+	Digest   string
+	StagedAt string
+}
+
+var versionPattern = regexp.MustCompile(`^[0-9]{14}$`)
+
+// ValidVersion reports whether s matches the frozen native A/B version
+// grammar: exactly 14 ASCII digits (UTC YYYYMMDDHHMMSS). Fixed width means
+// lexicographic comparison equals numeric comparison.
+func ValidVersion(s string) bool {
+	return versionPattern.MatchString(s)
+}
+
+// parseKeyValues splits newline-separated key=value data. The first
+// occurrence of a key wins; blank lines and lines without '=' are ignored.
+func parseKeyValues(data []byte) map[string]string {
+	fields := make(map[string]string)
+	for line := range strings.SplitSeq(string(data), "\n") {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+		if _, seen := fields[key]; !seen {
+			fields[key] = value
+		}
+	}
+	return fields
+}
+
+// ParseUpdateCheck parses update-check state file contents. Unknown keys and
+// unknown outcome values are tolerated: an unrecognized outcome maps to
+// OutcomeUnknown rather than an error, so a future stager field cannot break
+// the status display.
+func ParseUpdateCheck(data []byte) UpdateCheck {
+	fields := parseKeyValues(data)
+	check := UpdateCheck{
+		CheckedAt:      fields["checked_at"],
+		Image:          fields["image"],
+		RunningVersion: fields["running_version"],
+		RemoteVersion:  fields["remote_version"],
+	}
+	switch outcome := CheckOutcome(fields["outcome"]); outcome {
+	case OutcomeCurrent, OutcomeStaged, OutcomeFailed:
+		check.Outcome = outcome
+	default:
+		check.Outcome = OutcomeUnknown
+	}
+	return check
+}
+
+// ParseStagedUpdate parses update-staged semaphore contents.
+func ParseStagedUpdate(data []byte) StagedUpdate {
+	fields := parseKeyValues(data)
+	return StagedUpdate{
+		Image:    fields["image"],
+		Version:  fields["version"],
+		Digest:   fields["digest"],
+		StagedAt: fields["staged_at"],
+	}
+}
+
+// DisplayVersion returns the staged version identifier for presentation:
+// the 14-digit version when valid, else a shortened digest, else "".
+func (s *StagedUpdate) DisplayVersion() string {
+	if s == nil {
+		return ""
+	}
+	if ValidVersion(s.Version) {
+		return s.Version
+	}
+	if s.Digest != "" {
+		digest := strings.TrimPrefix(s.Digest, "sha256:")
+		if len(digest) > 12 {
+			digest = digest[:12]
+		}
+		return digest
+	}
+	return ""
+}
+
+// readUpdateCheckFrom reads and parses an update-check file. An absent file
+// is a normal state (no check has run this boot), reported as (nil, nil).
+func readUpdateCheckFrom(path string) (*UpdateCheck, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	check := ParseUpdateCheck(data)
+	return &check, nil
+}
+
+// readStagedUpdateFrom reads and parses an update-staged semaphore. An
+// absent file is a normal state (nothing staged), reported as (nil, nil).
+func readStagedUpdateFrom(path string) (*StagedUpdate, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	staged := ParseStagedUpdate(data)
+	return &staged, nil
+}
+
+// ReadUpdateCheck reads the fixed update-check state file.
+func ReadUpdateCheck() (*UpdateCheck, error) {
+	return readUpdateCheckFrom(UpdateCheckPath)
+}
+
+// ReadStagedUpdate reads the fixed update-staged semaphore.
+func ReadStagedUpdate() (*StagedUpdate, error) {
+	return readStagedUpdateFrom(StagedSemaphorePath)
+}
+
+// Status is the combined unprivileged update state. Either field may be nil
+// when its file is absent.
+type Status struct {
+	Check  *UpdateCheck
+	Staged *StagedUpdate
+}
+
+// GetStatus reads both state files. It never fails hard: an unreadable file
+// is logged and treated as absent, so the UI degrades to the idle state
+// rather than an error.
+func GetStatus() Status {
+	check, err := ReadUpdateCheck()
+	if err != nil {
+		log.Printf("sysupdate: reading %s: %v", UpdateCheckPath, err)
+	}
+	staged, err := ReadStagedUpdate()
+	if err != nil {
+		log.Printf("sysupdate: reading %s: %v", StagedSemaphorePath, err)
+	}
+	return Status{Check: check, Staged: staged}
+}
+
+// IsStaged reports whether an update is downloaded and pending a reboot.
+// The semaphore is authoritative; outcome=staged covers the anomalous case
+// of a check record without its semaphore.
+func (s Status) IsStaged() bool {
+	if s.Staged != nil {
+		return true
+	}
+	return s.Check != nil && s.Check.Outcome == OutcomeStaged
+}
+
+// Presentation reduces the state files to the scalar inputs of the pure
+// subtitle formatter, one row per distinct outcome:
+//   - staged semaphore present        -> ("staged", staged version, "")
+//   - no semaphore, outcome=staged    -> ("staged", remote_version, "")
+//   - outcome=current                 -> ("current", "", checked_at)
+//   - outcome=failed                  -> ("failed", "", checked_at)
+//   - files absent or outcome unknown -> ("", "", "")   (idle prompt)
+//
+// The semaphore wins over every check outcome: it is the OS's reboot-pending
+// signal and legitimately outlives later "nothing newer" check runs.
+func (s Status) Presentation() (outcome, version, checkedAt string) {
+	if s.Staged != nil {
+		return string(OutcomeStaged), s.Staged.DisplayVersion(), ""
+	}
+	if s.Check == nil {
+		return "", "", ""
+	}
+	switch s.Check.Outcome {
+	case OutcomeStaged:
+		return string(OutcomeStaged), s.Check.RemoteVersion, ""
+	case OutcomeCurrent:
+		return string(OutcomeCurrent), "", s.Check.CheckedAt
+	case OutcomeFailed:
+		return string(OutcomeFailed), "", s.Check.CheckedAt
+	default:
+		return "", "", ""
+	}
+}

--- a/internal/sysupdate/status_test.go
+++ b/internal/sysupdate/status_test.go
@@ -1,0 +1,226 @@
+package sysupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseUpdateCheckOutcomes(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want UpdateCheck
+	}{
+		{
+			name: "current",
+			data: "outcome=current\nchecked_at=2026-08-10T20:08:01-06:00\nimage=snow-ab\nrunning_version=20260810191856\nremote_version=\n",
+			want: UpdateCheck{
+				Outcome:        OutcomeCurrent,
+				CheckedAt:      "2026-08-10T20:08:01-06:00",
+				Image:          "snow-ab",
+				RunningVersion: "20260810191856",
+			},
+		},
+		{
+			name: "staged",
+			data: "outcome=staged\nchecked_at=2026-08-10T20:08:01-06:00\nimage=snow-ab\nrunning_version=20260810191856\nremote_version=20260810200801\n",
+			want: UpdateCheck{
+				Outcome:        OutcomeStaged,
+				CheckedAt:      "2026-08-10T20:08:01-06:00",
+				Image:          "snow-ab",
+				RunningVersion: "20260810191856",
+				RemoteVersion:  "20260810200801",
+			},
+		},
+		{
+			name: "failed",
+			data: "outcome=failed\nchecked_at=2026-08-10T20:08:01-06:00\nimage=snow-ab\nrunning_version=20260810191856\nremote_version=\n",
+			want: UpdateCheck{
+				Outcome:        OutcomeFailed,
+				CheckedAt:      "2026-08-10T20:08:01-06:00",
+				Image:          "snow-ab",
+				RunningVersion: "20260810191856",
+			},
+		},
+		{
+			// held-rollback is bootc-transport-only; on native it must map
+			// to unknown, not crash or masquerade as a real outcome.
+			name: "unknown outcome value",
+			data: "outcome=held-rollback\nchecked_at=t\nimage=i\nrunning_version=\nremote_version=\n",
+			want: UpdateCheck{Outcome: OutcomeUnknown, CheckedAt: "t", Image: "i"},
+		},
+		{
+			name: "empty data",
+			data: "",
+			want: UpdateCheck{Outcome: OutcomeUnknown},
+		},
+		{
+			name: "unknown keys and blank lines ignored, first occurrence wins",
+			data: "\nfuture_field=x\noutcome=current\noutcome=failed\n\n",
+			want: UpdateCheck{Outcome: OutcomeCurrent},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseUpdateCheck([]byte(tt.data)); got != tt.want {
+				t.Errorf("ParseUpdateCheck = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseStagedUpdateTransportShapes(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        string
+		want        StagedUpdate
+		wantDisplay string
+	}{
+		{
+			name:        "native version shape",
+			data:        "image=snow-ab\nversion=20260810200801\nstaged_at=2026-08-10T20:08:01-06:00\n",
+			want:        StagedUpdate{Image: "snow-ab", Version: "20260810200801", StagedAt: "2026-08-10T20:08:01-06:00"},
+			wantDisplay: "20260810200801",
+		},
+		{
+			name:        "bootc digest shape",
+			data:        "image=ghcr.io/frostyard/snow:latest\ndigest=sha256:0123456789abcdef0123\nstaged_at=t\n",
+			want:        StagedUpdate{Image: "ghcr.io/frostyard/snow:latest", Digest: "sha256:0123456789abcdef0123", StagedAt: "t"},
+			wantDisplay: "0123456789ab",
+		},
+		{
+			name:        "empty file",
+			data:        "",
+			want:        StagedUpdate{},
+			wantDisplay: "",
+		},
+		{
+			name:        "malformed version falls back to empty display",
+			data:        "image=snow-ab\nversion=not-a-version\n",
+			want:        StagedUpdate{Image: "snow-ab", Version: "not-a-version"},
+			wantDisplay: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseStagedUpdate([]byte(tt.data))
+			if got != tt.want {
+				t.Errorf("ParseStagedUpdate = %+v, want %+v", got, tt.want)
+			}
+			if display := got.DisplayVersion(); display != tt.wantDisplay {
+				t.Errorf("DisplayVersion = %q, want %q", display, tt.wantDisplay)
+			}
+		})
+	}
+}
+
+func TestValidVersionGrammar(t *testing.T) {
+	valid := []string{"20260810200801", "00000000000000"}
+	invalid := []string{"", "2026081020080", "202608102008011", "2026081020080a", "sha256:abc", "20260810 20080"}
+	for _, v := range valid {
+		if !ValidVersion(v) {
+			t.Errorf("ValidVersion(%q) = false, want true", v)
+		}
+	}
+	for _, v := range invalid {
+		if ValidVersion(v) {
+			t.Errorf("ValidVersion(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestStatusPresentationDecisionTable(t *testing.T) {
+	check := func(outcome CheckOutcome, remote string) *UpdateCheck {
+		return &UpdateCheck{Outcome: outcome, CheckedAt: "2026-08-10T20:08:01-06:00", RemoteVersion: remote}
+	}
+	staged := &StagedUpdate{Image: "snow-ab", Version: "20260810200801"}
+
+	tests := []struct {
+		name                         string
+		status                       Status
+		wantOutcome, wantVer, wantAt string
+		wantStaged                   bool
+	}{
+		{
+			name:        "semaphore present wins",
+			status:      Status{Check: check(OutcomeCurrent, ""), Staged: staged},
+			wantOutcome: "staged", wantVer: "20260810200801", wantStaged: true,
+		},
+		{
+			name:        "semaphore only",
+			status:      Status{Staged: staged},
+			wantOutcome: "staged", wantVer: "20260810200801", wantStaged: true,
+		},
+		{
+			name:        "outcome staged without semaphore uses remote version",
+			status:      Status{Check: check(OutcomeStaged, "20260810200801")},
+			wantOutcome: "staged", wantVer: "20260810200801", wantStaged: true,
+		},
+		{
+			name:        "current",
+			status:      Status{Check: check(OutcomeCurrent, "")},
+			wantOutcome: "current", wantAt: "2026-08-10T20:08:01-06:00",
+		},
+		{
+			name:        "failed",
+			status:      Status{Check: check(OutcomeFailed, "")},
+			wantOutcome: "failed", wantAt: "2026-08-10T20:08:01-06:00",
+		},
+		{
+			name:   "both files absent is idle",
+			status: Status{},
+		},
+		{
+			name:   "unknown outcome is idle",
+			status: Status{Check: check(OutcomeUnknown, "")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outcome, version, checkedAt := tt.status.Presentation()
+			if outcome != tt.wantOutcome || version != tt.wantVer || checkedAt != tt.wantAt {
+				t.Errorf("Presentation() = (%q, %q, %q), want (%q, %q, %q)",
+					outcome, version, checkedAt, tt.wantOutcome, tt.wantVer, tt.wantAt)
+			}
+			if got := tt.status.IsStaged(); got != tt.wantStaged {
+				t.Errorf("IsStaged() = %v, want %v", got, tt.wantStaged)
+			}
+		})
+	}
+}
+
+func TestReadUpdateCheckFromMissingFileIsNotAnError(t *testing.T) {
+	check, err := readUpdateCheckFrom(filepath.Join(t.TempDir(), "absent"))
+	if err != nil {
+		t.Fatalf("readUpdateCheckFrom(absent) error = %v, want nil", err)
+	}
+	if check != nil {
+		t.Errorf("readUpdateCheckFrom(absent) = %+v, want nil", check)
+	}
+}
+
+func TestReadStagedUpdateFromMissingFileIsNotAnError(t *testing.T) {
+	staged, err := readStagedUpdateFrom(filepath.Join(t.TempDir(), "absent"))
+	if err != nil {
+		t.Fatalf("readStagedUpdateFrom(absent) error = %v, want nil", err)
+	}
+	if staged != nil {
+		t.Errorf("readStagedUpdateFrom(absent) = %+v, want nil", staged)
+	}
+}
+
+func TestReadUpdateCheckFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "update-check")
+	data := "outcome=staged\nchecked_at=t\nimage=snow-ab\nrunning_version=20260810191856\nremote_version=20260810200801\n"
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	check, err := readUpdateCheckFrom(path)
+	if err != nil {
+		t.Fatalf("readUpdateCheckFrom: %v", err)
+	}
+	if check == nil || check.Outcome != OutcomeStaged || check.RemoteVersion != "20260810200801" {
+		t.Errorf("readUpdateCheckFrom = %+v", check)
+	}
+}

--- a/internal/sysupdate/sysupdate.go
+++ b/internal/sysupdate/sysupdate.go
@@ -1,0 +1,95 @@
+// Package sysupdate provides an interface to Snow Linux native A/B
+// (systemd-sysupdate) OS updates. Status reads parse the world-readable
+// state files under /run/snosi written by the OS-shipped stager
+// (unprivileged). Update staging is delegated to the snosi-shipped script
+// /usr/libexec/snosi-sysupdate-stage via pkexec; the script checks for and
+// downloads a newer image into the inactive root/verity slots in one
+// idempotent run and never reboots — the staged version applies at the next
+// natural reboot via systemd-boot entry selection.
+package sysupdate
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	// MarkerPath is snosi's canonical native A/B marker. Its presence is the
+	// OS's own published contract for "this host updates via
+	// systemd-sysupdate": every snosi unit and script gates on it
+	// (ConditionPathExists=/usr/lib/snosi/native-ab). The bootc binary is
+	// absent on native A/B hosts, so this marker — not a bootc probe — is
+	// the host-type gate.
+	MarkerPath = "/usr/lib/snosi/native-ab"
+
+	pkexecCommand  = "pkexec"
+	DefaultTimeout = 30 * time.Minute
+)
+
+var dryRun = false
+
+// SetDryRun enables/disables dry-run mode
+func SetDryRun(mode bool) {
+	dryRun = mode
+	log.Printf("sysupdate dry-run mode: %v", mode)
+}
+
+// IsDryRun returns whether dry-run mode is enabled
+func IsDryRun() bool {
+	return dryRun
+}
+
+// DefaultContext returns a context with the default 30-minute timeout
+func DefaultContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), DefaultTimeout)
+}
+
+// Error represents a sysupdate-related error. Err, when non-nil, carries the
+// underlying cause (for example context.DeadlineExceeded or
+// context.Canceled) so callers can classify it with errors.Is.
+type Error struct {
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Unwrap exposes the underlying cause to errors.Is/errors.As.
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+// NotFoundError is returned when a required executable is not installed
+type NotFoundError struct {
+	Message string
+}
+
+func (e *NotFoundError) Error() string {
+	return e.Message
+}
+
+// IsNativeAB reports whether this host is a native A/B (systemd-sysupdate)
+// install, by the presence of snosi's marker file.
+func IsNativeAB() bool {
+	_, err := os.Stat(MarkerPath)
+	return err == nil
+}
+
+var (
+	nativeABOnce   sync.Once
+	nativeABResult bool
+)
+
+// IsNativeABCached returns a cached result of IsNativeAB, running the check
+// at most once. Safe to call from view goroutines during async startup.
+func IsNativeABCached() bool {
+	nativeABOnce.Do(func() {
+		nativeABResult = IsNativeAB()
+	})
+	return nativeABResult
+}

--- a/internal/views/actionmsg/actionmsg.go
+++ b/internal/views/actionmsg/actionmsg.go
@@ -181,6 +181,23 @@ func BootcStage(dryRun bool, staged bool) string {
 	return "System is up to date"
 }
 
+// SysupdateStage returns the toast text for a click of the Updates page's
+// native A/B "Check for Updates" stage button, after sysupdate.StageUpdate's
+// wg.Wait() returns. It follows BootcStage's contract exactly: under
+// dry-run, sysupdate.StageUpdate never invokes pkexec and staged reflects a
+// re-read of real system state rather than anything this click did, so the
+// dry-run branch returns a single unambiguous preview string regardless of
+// staged.
+func SysupdateStage(dryRun bool, staged bool) string {
+	if dryRun {
+		return "[DRY-RUN] Preview: no changes made — system state was not checked or modified by this click"
+	}
+	if staged {
+		return "System update staged. Restart to apply."
+	}
+	return "System is up to date"
+}
+
 // TapTrustDecision is the result of deciding whether trusting a Homebrew tap
 // should mutate the Untrusted Homebrew Taps UI (remove the tap's row, hide
 // the group when empty, refresh outdated packages), and what toast to show

--- a/internal/views/actionmsg/actionmsg_test.go
+++ b/internal/views/actionmsg/actionmsg_test.go
@@ -444,6 +444,74 @@ func TestBootcStage(t *testing.T) {
 	}
 }
 
+// TestSysupdateStage mirrors TestBootcStage: the native A/B stage toast has
+// the identical dry-run contract (a preview string that never claims a
+// completed or verified state, because staged reflects real system state, not
+// this click's work).
+func TestSysupdateStage(t *testing.T) {
+	const stagedMsg = "System update staged. Restart to apply."
+	const upToDateMsg = "System is up to date"
+
+	tests := []struct {
+		name         string
+		dryRun       bool
+		staged       bool
+		wantExact    string
+		wantContains []string
+	}{
+		{
+			name:      "live run, staged reports the fixed staged message",
+			dryRun:    false,
+			staged:    true,
+			wantExact: stagedMsg,
+		},
+		{
+			name:      "live run, not staged reports the fixed up-to-date message",
+			dryRun:    false,
+			staged:    false,
+			wantExact: upToDateMsg,
+		},
+		{
+			name:         "dry-run, staged previews without claiming completion",
+			dryRun:       true,
+			staged:       true,
+			wantContains: []string{"no changes made"},
+		},
+		{
+			name:         "dry-run, not staged previews without claiming completion",
+			dryRun:       true,
+			staged:       false,
+			wantContains: []string{"no changes made"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SysupdateStage(tt.dryRun, tt.staged)
+
+			if tt.wantExact != "" && got != tt.wantExact {
+				t.Errorf("SysupdateStage(%v, %v) = %q, want %q", tt.dryRun, tt.staged, got, tt.wantExact)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("SysupdateStage(%v, %v) = %q, want it to contain %q", tt.dryRun, tt.staged, got, want)
+				}
+			}
+			if tt.dryRun {
+				if !strings.Contains(got, "Preview") && !strings.Contains(got, "[DRY-RUN]") {
+					t.Errorf("SysupdateStage(%v, %v) = %q, want it to contain %q or %q", tt.dryRun, tt.staged, got, "Preview", "[DRY-RUN]")
+				}
+				if strings.Contains(got, stagedMsg) {
+					t.Errorf("SysupdateStage(%v, %v) = %q, must not contain the non-dry-run staged completion string %q", tt.dryRun, tt.staged, got, stagedMsg)
+				}
+				if strings.Contains(got, upToDateMsg) {
+					t.Errorf("SysupdateStage(%v, %v) = %q, must not contain the non-dry-run up-to-date completion string %q", tt.dryRun, tt.staged, got, upToDateMsg)
+				}
+			}
+		})
+	}
+}
+
 // TestTapTrust covers both dry-run states for Homebrew tap trust, asserting
 // both the UI-mutation gate (MutateUI) and the Toast text. MutateUI is the
 // criterion that directly proves the Untrusted Homebrew Taps UI does not

--- a/internal/views/badgestate/badgestate.go
+++ b/internal/views/badgestate/badgestate.go
@@ -11,6 +11,7 @@ const (
 	Bootc Source = iota
 	Flatpak
 	Homebrew
+	Sysupdate
 	sourceCount
 )
 
@@ -21,7 +22,8 @@ type Snapshot struct {
 }
 
 // Counts stores update counts by provider. Its methods are safe for the
-// independent bootc, Flatpak, and Homebrew worker goroutines to call.
+// independent bootc, Flatpak, Homebrew, and sysupdate worker goroutines to
+// call.
 type Counts struct {
 	mu     sync.Mutex
 	values [sourceCount]int

--- a/internal/views/badgestate/badgestate_test.go
+++ b/internal/views/badgestate/badgestate_test.go
@@ -20,10 +20,13 @@ func TestCountsReplaceRepeatedRefreshState(t *testing.T) {
 	if got := counts.Set(Homebrew, 3); got != (Snapshot{Count: 3, Total: 8}) {
 		t.Fatalf("Set(Homebrew, 3) = %#v", got)
 	}
+	if got := counts.Set(Sysupdate, 1); got != (Snapshot{Count: 1, Total: 9}) {
+		t.Fatalf("Set(Sysupdate, 1) = %#v", got)
+	}
 
 	// A second provider refresh replaces its previous count; it must not
 	// accumulate duplicate rows into the badge total.
-	if got := counts.Set(Flatpak, 2); got != (Snapshot{Count: 2, Total: 6}) {
+	if got := counts.Set(Flatpak, 2); got != (Snapshot{Count: 2, Total: 7}) {
 		t.Fatalf("second Set(Flatpak, 2) = %#v, want replacement total", got)
 	}
 	if got := counts.Get(Flatpak); got != 2 {
@@ -65,7 +68,7 @@ func TestCountsRejectUnknownSourceWithoutChangingTotal(t *testing.T) {
 func TestCountsConcurrentProviderUpdates(t *testing.T) {
 	var counts Counts
 	var wg sync.WaitGroup
-	for _, source := range []Source{Bootc, Flatpak, Homebrew} {
+	for _, source := range []Source{Bootc, Flatpak, Homebrew, Sysupdate} {
 		source := source
 		wg.Add(1)
 		go func() {
@@ -77,10 +80,10 @@ func TestCountsConcurrentProviderUpdates(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := counts.Total(); got != 300 {
-		t.Fatalf("Total() after concurrent updates = %d, want 300", got)
+	if got := counts.Total(); got != 400 {
+		t.Fatalf("Total() after concurrent updates = %d, want 400", got)
 	}
-	for _, source := range []Source{Bootc, Flatpak, Homebrew} {
+	for _, source := range []Source{Bootc, Flatpak, Homebrew, Sysupdate} {
 		if got := counts.Get(source); got != 100 {
 			t.Errorf("Get(%d) = %d, want 100", source, got)
 		}

--- a/internal/views/badgestate/wiring_test.go
+++ b/internal/views/badgestate/wiring_test.go
@@ -23,6 +23,8 @@ func TestViewsUseSharedBadgeCounts(t *testing.T) {
 		filepath.Join(viewsDir, "updates_page.go"): {
 			`uh.updateCounts.Set(badgestate.Bootc, 1)`,
 			`uh.updateCounts.Set(badgestate.Bootc, 0)`,
+			`uh.updateCounts.Set(badgestate.Sysupdate, 1)`,
+			`uh.updateCounts.Set(badgestate.Sysupdate, 0)`,
 			`uh.updateCounts.Set(badgestate.Flatpak, len(allUpdates))`,
 			`uh.updateCounts.Set(badgestate.Homebrew, refresh.Count)`,
 			`uh.updateCounts.Add(badgestate.Homebrew, -1)`,

--- a/internal/views/pageview/pageview.go
+++ b/internal/views/pageview/pageview.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -117,6 +118,64 @@ func BootcStageResultSubtitle(staged bool, version, lastMessage string) string {
 		return lastMessage
 	}
 	return "System is up to date"
+}
+
+// SysupdateUpdateSubtitle returns the native A/B system-update expander
+// subtitle from the /run/snosi state-file presentation (the outcome grammar
+// is internal/sysupdate.Status.Presentation's): "staged" shows the pending
+// version, "current" shows the last check time, "failed" prompts a retry,
+// and anything else — including the fresh-boot no-files state — is the
+// neutral idle prompt.
+func SysupdateUpdateSubtitle(outcome, version, checkedAt string) string {
+	switch outcome {
+	case "staged":
+		if version == "" {
+			return "Update staged — restart to apply"
+		}
+		return fmt.Sprintf("Update %s staged — restart to apply", version)
+	case "current":
+		if formatted := formatCheckedAt(checkedAt); formatted != "" {
+			return fmt.Sprintf("System is up to date (checked %s)", formatted)
+		}
+		return "System is up to date"
+	case "failed":
+		return "Last update check failed — use Check for Updates to retry"
+	default:
+		return "Check for and download the latest system image"
+	}
+}
+
+// formatCheckedAt renders a stager ISO-8601 timestamp as a local wall-clock
+// time, or "" when unparseable.
+func formatCheckedAt(checkedAt string) string {
+	parsed, err := time.Parse(time.RFC3339, checkedAt)
+	if err != nil {
+		return ""
+	}
+	return parsed.Local().Format("15:04")
+}
+
+// SysupdateStageResultSubtitle returns the subtitle after a native A/B
+// staging action completes.
+func SysupdateStageResultSubtitle(staged bool, version, lastMessage string) string {
+	if staged {
+		return SysupdateUpdateSubtitle("staged", version, "")
+	}
+	if lastMessage != "" {
+		return lastMessage
+	}
+	return "System is up to date"
+}
+
+// SysupdateRollbackSubtitle returns the read-only rollback row subtitle.
+// version is the inactive slot's version only when it is older than the
+// running one (internal/sysupdate.RollbackCandidate); a staged-but-newer
+// slot or an empty slot both present as no rollback.
+func SysupdateRollbackSubtitle(version string) string {
+	if version == "" {
+		return "No previous version on disk"
+	}
+	return fmt.Sprintf("Version %s is on the inactive slot — choose it in the boot menu at restart to roll back", version)
 }
 
 // Feature returns the initial row text for an updex feature.

--- a/internal/views/pageview/pageview_test.go
+++ b/internal/views/pageview/pageview_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestApplicationRowsCoverEveryPresentation(t *testing.T) {
@@ -196,6 +197,118 @@ func TestBootcUpdateSubtitlesCoverEveryState(t *testing.T) {
 					got,
 					tt.want,
 				)
+			}
+		})
+	}
+}
+
+func TestSysupdateSubtitlesCoverEveryOutcome(t *testing.T) {
+	// The expected checked-time rendering is derived through the same
+	// time.Parse/Local path the formatter uses, so the assertion is
+	// timezone-independent without weakening to a substring match.
+	checkedAt := "2026-08-10T20:08:01-06:00"
+	parsed, err := time.Parse(time.RFC3339, checkedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkedClock := parsed.Local().Format("15:04")
+
+	tests := []struct {
+		name                        string
+		outcome, version, checkedAt string
+		want                        string
+	}{
+		{
+			name:    "staged with version",
+			outcome: "staged", version: "20260810200801",
+			want: "Update 20260810200801 staged — restart to apply",
+		},
+		{
+			name:    "staged without version",
+			outcome: "staged",
+			want:    "Update staged — restart to apply",
+		},
+		{
+			name:    "current with check time",
+			outcome: "current", checkedAt: checkedAt,
+			want: "System is up to date (checked " + checkedClock + ")",
+		},
+		{
+			name:    "current with unparseable check time",
+			outcome: "current", checkedAt: "not-a-time",
+			want: "System is up to date",
+		},
+		{
+			name:    "failed",
+			outcome: "failed", checkedAt: checkedAt,
+			want: "Last update check failed — use Check for Updates to retry",
+		},
+		{
+			name: "idle fresh boot",
+			want: "Check for and download the latest system image",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SysupdateUpdateSubtitle(tt.outcome, tt.version, tt.checkedAt)
+			if got != tt.want {
+				t.Fatalf("SysupdateUpdateSubtitle(%q, %q, %q) = %q, want %q",
+					tt.outcome, tt.version, tt.checkedAt, got, tt.want)
+			}
+		})
+	}
+
+	resultTests := []struct {
+		name        string
+		staged      bool
+		version     string
+		lastMessage string
+		want        string
+	}{
+		{
+			name:   "staged with version",
+			staged: true, version: "20260810200801", lastMessage: "ignored",
+			want: "Update 20260810200801 staged — restart to apply",
+		},
+		{
+			name:        "current with script message",
+			lastMessage: "No newer version available.",
+			want:        "No newer version available.",
+		},
+		{
+			name: "current without script message",
+			want: "System is up to date",
+		},
+	}
+	for _, tt := range resultTests {
+		t.Run("stage result/"+tt.name, func(t *testing.T) {
+			got := SysupdateStageResultSubtitle(tt.staged, tt.version, tt.lastMessage)
+			if got != tt.want {
+				t.Fatalf("SysupdateStageResultSubtitle(%v, %q, %q) = %q, want %q",
+					tt.staged, tt.version, tt.lastMessage, got, tt.want)
+			}
+		})
+	}
+
+	rollbackTests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "older slot version available",
+			version: "20260801000000",
+			want:    "Version 20260801000000 is on the inactive slot — choose it in the boot menu at restart to roll back",
+		},
+		{
+			name: "no rollback candidate",
+			want: "No previous version on disk",
+		},
+	}
+	for _, tt := range rollbackTests {
+		t.Run("rollback/"+tt.name, func(t *testing.T) {
+			if got := SysupdateRollbackSubtitle(tt.version); got != tt.want {
+				t.Fatalf("SysupdateRollbackSubtitle(%q) = %q, want %q", tt.version, got, tt.want)
 			}
 		})
 	}

--- a/internal/views/pageview/wiring_test.go
+++ b/internal/views/pageview/wiring_test.go
@@ -41,6 +41,9 @@ func TestPageBuildersUsePurePresentations(t *testing.T) {
 				"pageview.FlatpakUpdate(",
 				"pageview.BootcUpdateSubtitle(",
 				"pageview.BootcStageResultSubtitle(",
+				"pageview.SysupdateUpdateSubtitle(",
+				"pageview.SysupdateStageResultSubtitle(",
+				"pageview.SysupdateRollbackSubtitle(",
 			},
 			retired: []string{
 				"strings.LastIndex(",

--- a/internal/views/updates_page.go
+++ b/internal/views/updates_page.go
@@ -10,6 +10,7 @@ import (
 	"github.com/frostyard/chairlift/internal/bootc"
 	"github.com/frostyard/chairlift/internal/flatpak"
 	"github.com/frostyard/chairlift/internal/homebrew"
+	"github.com/frostyard/chairlift/internal/sysupdate"
 	"github.com/frostyard/chairlift/internal/views/actionmsg"
 	"github.com/frostyard/chairlift/internal/views/actionstate"
 	"github.com/frostyard/chairlift/internal/views/badgestate"
@@ -55,6 +56,42 @@ func (uh *UserHome) buildUpdatesPage() {
 		page.Add(group)
 
 		go uh.loadBootcUpdateStatus(group)
+	}
+
+	// Native A/B (systemd-sysupdate) System Updates group - built hidden,
+	// shown asynchronously on native A/B hosts that ship the snosi stager.
+	// Mutually exclusive with the bootc group at runtime: the bootc gate
+	// requires the bootc binary (absent on native A/B images) and this gate
+	// requires the native-ab marker (absent on bootc images), so at most one
+	// "System Updates" group ever becomes visible.
+	if uh.config.IsGroupEnabled("updates_page", "sysupdate_updates_group") {
+		group := adw.NewPreferencesGroup()
+		group.SetTitle("System Updates")
+		group.SetDescription("Download and stage system image updates; staged updates apply on restart")
+		group.SetVisible(false)
+
+		uh.sysupdateStageExpander = adw.NewExpanderRow()
+		uh.sysupdateStageExpander.SetTitle("System Update")
+		uh.sysupdateStageExpander.SetSubtitle("Checking status...")
+
+		uh.sysupdateStageBtn = gtk.NewButtonWithLabel("Check for Updates")
+		uh.sysupdateStageBtn.SetValign(gtk.AlignCenterValue)
+		uh.sysupdateStageBtn.AddCssClass("suggested-action")
+		sysupdateClickedCb := func(btn gtk.Button) {
+			uh.onSysupdateStageClicked()
+		}
+		uh.sysupdateStageBtn.ConnectClicked(&sysupdateClickedCb)
+		uh.sysupdateStageExpander.AddSuffix(&uh.sysupdateStageBtn.Widget)
+
+		uh.sysupdateRollbackRow = adw.NewActionRow()
+		uh.sysupdateRollbackRow.SetTitle("Previous Version")
+		uh.sysupdateRollbackRow.SetSubtitle("Checking status...")
+
+		group.Add(&uh.sysupdateStageExpander.Widget)
+		group.Add(&uh.sysupdateRollbackRow.Widget)
+		page.Add(group)
+
+		go uh.loadSysupdateUpdateStatus(group)
 	}
 
 	// Flatpak Updates group
@@ -630,6 +667,146 @@ func (uh *UserHome) onBootcStageClicked() {
 			}
 			expander.SetSubtitle(pageview.BootcStageResultSubtitle(staged, version, lastMessage))
 			uh.toastAdder.ShowToast(actionmsg.BootcStage(bootc.IsDryRun(), staged))
+		})
+	}()
+}
+
+// loadSysupdateUpdateStatus gates the native A/B updates group and reflects
+// the /run/snosi state files in the expander subtitle, rollback row, and
+// update badge. The reads are unprivileged: the stager's state files are
+// world-readable and the rollback candidate comes from partition labels.
+func (uh *UserHome) loadSysupdateUpdateStatus(group *adw.PreferencesGroup) {
+	if !sysupdate.IsNativeABCached() || !sysupdate.StageScriptAvailable() {
+		return // group stays hidden
+	}
+
+	ctx, cancel := sysupdate.DefaultContext()
+	defer cancel()
+
+	status := sysupdate.GetStatus()
+	rollbackVersion, _ := sysupdate.RollbackVersion(ctx)
+
+	if status.IsStaged() {
+		uh.updateCounts.Set(badgestate.Sysupdate, 1)
+	} else {
+		uh.updateCounts.Set(badgestate.Sysupdate, 0)
+	}
+	uh.updateBadgeCount()
+
+	outcome, version, checkedAt := status.Presentation()
+	sgtk.RunOnMainThread(func() {
+		group.SetVisible(true)
+		uh.sysupdateStageExpander.SetSubtitle(pageview.SysupdateUpdateSubtitle(outcome, version, checkedAt))
+		uh.sysupdateRollbackRow.SetSubtitle(pageview.SysupdateRollbackSubtitle(rollbackVersion))
+	})
+}
+
+// onSysupdateStageClicked runs the snosi stager with streamed log output.
+// The script checks, downloads, and stages in one idempotent operation; the
+// staged version applies at the next reboot.
+func (uh *UserHome) onSysupdateStageClicked() {
+	button := uh.sysupdateStageBtn
+	expander := uh.sysupdateStageExpander
+
+	button.SetSensitive(false)
+	button.SetLabel("Working...")
+	expander.SetExpanded(true)
+	expander.SetSubtitle("Checking for updates...")
+
+	// Remove rows from any previous run before adding new ones, otherwise
+	// repeated clicks stack duplicate Progress/Details rows.
+	if uh.sysupdateActivityRow != nil {
+		expander.Remove(&uh.sysupdateActivityRow.Widget)
+	}
+	if uh.sysupdateLogExpander != nil {
+		expander.Remove(&uh.sysupdateLogExpander.Widget)
+	}
+
+	// Activity row with a spinner (the stage script emits no percentages,
+	// so progress is indeterminate).
+	activityRow := adw.NewActionRow()
+	activityRow.SetTitle("Progress")
+	activityRow.SetSubtitle("Running...")
+	spinner := gtk.NewSpinner()
+	spinner.Start()
+	activityRow.AddSuffix(&spinner.Widget)
+	expander.AddRow(&activityRow.Widget)
+	uh.sysupdateActivityRow = activityRow
+
+	logExpander := adw.NewExpanderRow()
+	logExpander.SetTitle("Details")
+	logExpander.SetSubtitle("View output")
+	expander.AddRow(&logExpander.Widget)
+	uh.sysupdateLogExpander = logExpander
+
+	go func() {
+		ctx, cancel := sysupdate.DefaultContext()
+		defer cancel()
+
+		progressCh := make(chan sysupdate.ProgressEvent)
+
+		var stageErr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stageErr = sysupdate.StageUpdate(ctx, progressCh)
+		}()
+
+		var lastMessage string
+		for event := range progressCh {
+			evt := event
+			if evt.Type == sysupdate.EventMessage {
+				lastMessage = evt.Message
+			}
+			sgtk.RunOnMainThread(func() {
+				switch evt.Type {
+				case sysupdate.EventMessage:
+					msgRow := adw.NewActionRow()
+					msgRow.SetTitle(evt.Message)
+					msgRow.SetSubtitle(time.Now().Format("15:04:05"))
+					logExpander.AddRow(&msgRow.Widget)
+					activityRow.SetSubtitle(evt.Message)
+				case sysupdate.EventComplete:
+					activityRow.SetSubtitle("Complete")
+				}
+			})
+		}
+
+		wg.Wait()
+
+		// Re-read the state files so the subtitle, rollback row, and badge
+		// reflect reality (staged vs already-current) rather than guessing
+		// from output. A stage fills the inactive slot with the newer
+		// version, so the rollback candidate must be recomputed too.
+		status := sysupdate.GetStatus()
+		rollbackCtx, rollbackCancel := sysupdate.DefaultContext()
+		rollbackVersion, _ := sysupdate.RollbackVersion(rollbackCtx)
+		rollbackCancel()
+
+		staged := status.IsStaged()
+		if staged {
+			uh.updateCounts.Set(badgestate.Sysupdate, 1)
+		} else {
+			uh.updateCounts.Set(badgestate.Sysupdate, 0)
+		}
+		uh.updateBadgeCount()
+
+		_, version, _ := status.Presentation()
+		sgtk.RunOnMainThread(func() {
+			spinner.Stop()
+			button.SetSensitive(true)
+			button.SetLabel("Check for Updates")
+			uh.sysupdateRollbackRow.SetSubtitle(pageview.SysupdateRollbackSubtitle(rollbackVersion))
+
+			if stageErr != nil {
+				expander.SetSubtitle(fmt.Sprintf("Update failed: %v", stageErr))
+				uh.toastAdder.ShowErrorToast(fmt.Sprintf("Update failed: %v", stageErr))
+				return
+			}
+
+			expander.SetSubtitle(pageview.SysupdateStageResultSubtitle(staged, version, lastMessage))
+			uh.toastAdder.ShowToast(actionmsg.SysupdateStage(sysupdate.IsDryRun(), staged))
 		})
 	}()
 }

--- a/internal/views/views.go
+++ b/internal/views/views.go
@@ -70,6 +70,13 @@ type UserHome struct {
 	bootcActivityRow   *adw.ActionRow
 	bootcLogExpander   *adw.ExpanderRow
 
+	// native A/B (sysupdate) update references
+	sysupdateStageExpander *adw.ExpanderRow
+	sysupdateStageBtn      *gtk.Button
+	sysupdateActivityRow   *adw.ActionRow
+	sysupdateLogExpander   *adw.ExpanderRow
+	sysupdateRollbackRow   *adw.ActionRow
+
 	// Features page references
 	featuresGroup            *adw.PreferencesGroup
 	featuresUnavailableGroup *adw.PreferencesGroup

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -152,6 +152,7 @@ func TestInstalledBundleAndHelperBoundary(t *testing.T) {
 		"usr/share/icons/hicolor/symbolic/apps/org.frostyard.ChairLift-symbolic.svg",
 		"usr/share/polkit-1/actions/org.frostyard.ChairLift.bootc.policy",
 		"usr/share/polkit-1/actions/org.frostyard.ChairLift.updex.policy",
+		"usr/share/polkit-1/actions/org.frostyard.ChairLift.sysupdate.policy",
 	} {
 		if info, err := os.Stat(filepath.Join(stage, path)); err != nil {
 			t.Errorf("staged install is missing %s: %v", path, err)

--- a/yeti/OVERVIEW.md
+++ b/yeti/OVERVIEW.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snosi), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, bootc system updates (staged via the snow `bootc-update-stage` script), system features (via updex), and maintenance tasks. The UI is YAML-configuration-driven, making it portable to other Linux distributions by toggling feature groups on/off.
+ChairLift is a GTK4/Libadwaita system management GUI for [Snow Linux](https://github.com/frostyard/snosi), written in Go using [puregotk](https://codeberg.org/puregotk/puregotk) bindings (no CGO). It provides a unified interface for managing Homebrew and Flatpak applications, OS system updates (staged via the snow `bootc-update-stage` script on bootc installs, or the snow `snosi-sysupdate-stage` script on native A/B installs), system features (via updex), and maintenance tasks. The UI is YAML-configuration-driven, making it portable to other Linux distributions by toggling feature groups on/off.
 
 ## Architecture
 
@@ -37,7 +37,7 @@ internal/views/                 Page builders and event handlers (one file per p
 
 ### Dependency flow
 
-`cmd → app → window → views → {config, homebrew, flatpak, bootc, updex}`.
+`cmd → app → window → views → {config, homebrew, flatpak, bootc, sysupdate, updex}`.
 `app` and `window` also depend on the pure `navigation` package.
 
 External shared library: `github.com/frostyard/snowkit` (published module, pinned in go.mod) provides:
@@ -62,7 +62,7 @@ disabled; Help is always retained:
 |------|------|---------|
 | Applications | `applications_page.go` | Manage Homebrew formulae/casks and installed Flatpaks; launch an external manager for new Flatpak installs |
 | Maintenance | `maintenance_page.go` | Homebrew/Flatpak cleanup, configurable maintenance scripts (executed via `exec.Command`/`pkexec`) |
-| Updates | `updates_page.go` | bootc staged system updates, Flatpak updates, Homebrew outdated packages, untrusted-tap trust prompts |
+| Updates | `updates_page.go` | bootc or native A/B (systemd-sysupdate) staged system updates, Flatpak updates, Homebrew outdated packages, untrusted-tap trust prompts |
 | System | `system_page.go` | OS info (`/etc/os-release`), bootc deployment status, health monitor launch |
 | Features | `features_page.go` | Toggle system features via `updex` tool |
 | Help | `help_page.go` | Configurable links to website, issues, chat (opened via `xdg-open`) |
@@ -107,19 +107,24 @@ This applies to: `maintenanceBrewGroup`, `maintenanceFlatpakGroup`, `featuresGro
 
 bootc-related UI groups (system page's `bootc_status_group` and updates page's `bootc_updates_group`) are gated on `bootc.IsBootcBootedCached()`, which runs `bootc status --format json` once (via `sync.Once`) and reports true only when the parsed `status.booted` field is non-null. This is deliberately not a sentinel-file check: `/run/ostree-booted` is absent on snow's composefs-based deployments, so relying on it would hide the groups on every snow bootc host. `bootc status` itself exits 0 with a null `booted` entry on non-bootc hosts, so the gate must inspect the JSON body rather than the exit code.
 
+### Native A/B gate
+
+The updates page's `sysupdate_updates_group` is gated on `sysupdate.IsNativeABCached()` (an `os.Stat` of `/usr/lib/snosi/native-ab`, cached via `sync.Once`) plus `sysupdate.StageScriptAvailable()` (`/usr/libexec/snosi-sysupdate-stage` exists). Unlike the bootc case, a marker-file check is correct here: the marker is snosi's own published contract for "this host updates via systemd-sysupdate" — every snosi unit and script gates on it (`ConditionPathExists=/usr/lib/snosi/native-ab`) — whereas `/run/ostree-booted` was a foreign sentinel that snow's bootc deployments never wrote. The `bootc` binary is absent on native A/B images and `os-release`'s `IMAGE_ID` is identical across both variants, so neither is usable for this gate. The two OS-update gates are mutually exclusive at runtime: at most one "System Updates" group ever becomes visible even though both may be config-enabled and built.
+
 ### Dry-run mode
 
-The `--dry-run` / `-d` flag is propagated to wrapper packages via `SetDryRun(true)`, set once at startup in `app.New()` for homebrew, flatpak, bootc, updex, and `internal/views` itself (`internal/views/dryrun.go` — for configured custom maintenance scripts, which have no wrapper package of their own).
+The `--dry-run` / `-d` flag is propagated to wrapper packages via `SetDryRun(true)`, set once at startup in `app.New()` for homebrew, flatpak, bootc, sysupdate, updex, and `internal/views` itself (`internal/views/dryrun.go` — for configured custom maintenance scripts, which have no wrapper package of their own).
 
 **The general rule, applied uniformly:** every state-changing view handler branches on the relevant wrapper's `IsDryRun()` (or `views.IsDryRun()` for custom scripts) to show an explicit preview toast instead of a completed/saved/installed message. Anywhere that same handler would *also* mutate a row, a group's visibility, or a switch on success, that mutation decision is pulled out of the view and expressed as a small struct or an `actionstate.Decision` — `ScriptDecision.Execute`, `BundleInstallDecision.Complete`, `TapTrustDecision.MutateUI`, `FeatureToggleDecision.Confirm`, `PackageInstall`, `PackageUninstall`, or `PackagePin`. The view computes `IsDryRun()` exactly once, builds the decision, and branches solely on it for both the mutation *and* the toast, so a table-driven test proves the mutation gate and the toast cannot drift from it (see [package-managers.md](./package-managers.md#view-layer-toast-and-decision-helpers-internalviewsactionmsg-internalviewstrustmsg) for the full function/type list). Sites with no second UI mutation to gate (package upgrade/update/self-update, Flatpak uninstall, cleanup, Brewfile dump, bootc stage, and feature-update toasts) get a plain string function instead.
 
-**Intentional exception:** bootc staging's completion **toast** is dry-run-aware (`actionmsg.BootcStage`), but its expander **subtitle** deliberately is not. The subtitle is a persistent status readout of live `bootc.GetStatus()` — what deployment is actually staged/booted right now — not a per-click completion claim, so it stays accurate and unchanged in both dry-run and live mode. Only the toast, which inherently answers "what did this click just do," needed dry-run-specific wording; there is no mutation left to gate once the subtitle is deliberately excluded, which is why `BootcStage` is string-only rather than a decision struct.
+**Intentional exception:** bootc staging's completion **toast** is dry-run-aware (`actionmsg.BootcStage`), but its expander **subtitle** deliberately is not. The subtitle is a persistent status readout of live `bootc.GetStatus()` — what deployment is actually staged/booted right now — not a per-click completion claim, so it stays accurate and unchanged in both dry-run and live mode. Only the toast, which inherently answers "what did this click just do," needed dry-run-specific wording; there is no mutation left to gate once the subtitle is deliberately excluded, which is why `BootcStage` is string-only rather than a decision struct. Native A/B staging follows the identical split: `actionmsg.SysupdateStage` is the dry-run-aware toast, while the subtitle and rollback row re-read the real `/run/snosi` state files and partition labels in both modes.
 
 Per-wrapper mechanics:
 
 - **Homebrew/Flatpak**: state-changing commands are skipped entirely at the wrapper layer (return mock/empty results); ordinary package-action toasts use the plain `actionmsg` string functions (`Install`, `Uninstall`, `Pin`, `Upgrade`, `Update`, `SelfUpdate`, `BundleDump`, `Cleanup`). Homebrew search installs and installed-package uninstall/pin actions pair that text with `actionstate` decisions: live success completes the old row controls and refreshes the installed inventory, while failure or dry-run restores the controls. Brew bundle installation uses `BundleInstallDecision` with the same live-complete/dry-run-reset distinction.
 - **Updex**: `EnableFeature`/`DisableFeature`/`UpdateFeatures` skip their `pkexec` call entirely under dry-run and return empty/nil results; the helper binary itself (`cmd/chairlift-updex-helper`, dispatch logic in `internal/updexhelper`) also honors `--dry-run` for `update`, matching `enable-feature`/`disable-feature`, as defense-in-depth even though it's unreachable from the wrapper today.
 - **bootc**: `StageUpdate` short-circuits before invoking pkexec: it logs the would-be command, emits a synthetic `EventMessage` + `EventComplete` pair on the progress channel, and returns — the stage script is never actually run (see the exception above for the toast/subtitle split).
+- **sysupdate**: `StageUpdate` has the same shape as bootc's — under dry-run it logs the would-be `pkexec /usr/libexec/snosi-sysupdate-stage` command, emits the synthetic `EventMessage` + `EventComplete` pair, and never constructs an `exec.Cmd`. Status reads (`GetStatus`, `RollbackVersion`) are not dry-run-gated: they are unprivileged, side-effect-free reads of real state.
 - **Homebrew tap trust**: `trustTap` (`internal/views/updates_page.go`) computes `decision := actionmsg.TapTrust(homebrew.IsDryRun(), tap.Name)` once, after a successful `homebrew.TrustPackages` call, and gates removing the tap's row, hiding the group, and refreshing outdated packages on `decision.MutateUI`.
 - **views (custom maintenance scripts)**: `runMaintenanceAction` (`internal/views/maintenance_page.go`) calls `actionmsg.MaintenanceScript(IsDryRun(), title)` once, before spawning its goroutine, to get a `ScriptDecision{Execute, Toast}`: when `Execute` is false no `exec.Cmd` is ever constructed (no `pkexec`, no direct script exec) — only a `[DRY-RUN] Would execute: ...` log line.
 - **Features page switch confirmation**: `onFeatureToggled` (`internal/views/features_page.go`) computes `decision := actionmsg.FeatureToggle(updex.IsDryRun(), enabled, name)` once, after a successful `updex.EnableFeature`/`DisableFeature` call, and branches solely on `decision.Confirm` to decide whether the switch confirms the flip (`toggle.SetActive(enabled)`) or reverts to its pre-click state (`toggle.SetActive(!enabled)`).
@@ -1008,10 +1013,15 @@ The deadline and cancellation messages differ in both functions, and neither eve
 
 ### Update badge tracking
 
-The updates page stores bootc, Flatpak, and Homebrew counts in the mutex-backed
-`badgestate.Counts` value on `UserHome`. The bootc provider is 1 when
-`bootc.GetStatus()` reports a staged deployment and 0 otherwise — a boolean
-folded into the total, not a count of available images. Provider refreshes use
+The updates page stores bootc, sysupdate, Flatpak, and Homebrew counts in the
+mutex-backed `badgestate.Counts` value on `UserHome`. The bootc provider is 1
+when `bootc.GetStatus()` reports a staged deployment and 0 otherwise — a
+boolean folded into the total, not a count of available images. The sysupdate
+provider follows the same boolean rule: 1 when `sysupdate.GetStatus().IsStaged()`
+(the `/run/snosi/update-staged` semaphore exists, or the last check recorded
+`outcome=staged`) and 0 otherwise, including after a failed check — there is
+no persistent "available but unstaged" state because the snosi stager checks
+and stages in one run. Provider refreshes use
 `Set`, so a repeated load replaces rather than accumulates; successful
 row-level Homebrew upgrades use `Add(Homebrew, -1)`, which cannot go below
 zero. `updateBadgeCount` reads the aggregate `Total` and pushes it through
@@ -1025,7 +1035,7 @@ rows), while dry-run previews restore their controls without changing either.
 
 ### Privileged operations
 
-bootc staging and updex require root for state-changing operations. They invoke commands through `pkexec` (PolicyKit). bootc runs `pkexec /usr/libexec/bootc-update-stage` directly (polkit action id `org.frostyard.ChairLift.bootc.stage`), while updex delegates to the fixed absolute path `internal/updex.HelperPath` (`/usr/bin/chairlift-updex-helper`) via `pkexec`. Polkit policy files are installed for both: `data/org.frostyard.ChairLift.bootc.policy` and `data/org.frostyard.ChairLift.updex.policy`. ChairLift deliberately ships no `.rules` files: the policies require normal administrator authentication (`auth_admin`, with `auth_admin_keep` for an active local session) rather than granting blanket passwordless access to a login group. Source installation removes the two legacy ChairLift `.rules` files so an older passwordless rule cannot survive an upgrade. Homebrew tap trust (`brew trust`) is explicitly per-user and does *not* go through pkexec — see [package-managers.md](./package-managers.md).
+bootc staging, native A/B staging, and updex require root for state-changing operations. They invoke commands through `pkexec` (PolicyKit). bootc runs `pkexec /usr/libexec/bootc-update-stage` directly (polkit action id `org.frostyard.ChairLift.bootc.stage`), native A/B staging runs `pkexec /usr/libexec/snosi-sysupdate-stage` directly (`internal/sysupdate.StageScriptPath`, action id `org.frostyard.ChairLift.sysupdate.stage`), and updex delegates to the fixed absolute path `internal/updex.HelperPath` (`/usr/bin/chairlift-updex-helper`) via `pkexec`. Polkit policy files are installed for all three: `data/org.frostyard.ChairLift.bootc.policy`, `data/org.frostyard.ChairLift.sysupdate.policy`, and `data/org.frostyard.ChairLift.updex.policy`. ChairLift deliberately ships no `.rules` files: the policies require normal administrator authentication (`auth_admin`, with `auth_admin_keep` for an active local session) rather than granting blanket passwordless access to a login group. Source installation removes the two legacy ChairLift `.rules` files so an older passwordless rule cannot survive an upgrade. Homebrew tap trust (`brew trust`) is explicitly per-user and does *not* go through pkexec — see [package-managers.md](./package-managers.md).
 
 **Why the helper path must be absolute, and why `PREFIX=/usr`:** `pkexec`
 resolves the program it's asked to run to an absolute path and compares it
@@ -1062,14 +1072,17 @@ contains only `chairlift-updex-helper`, and its contents contain the two
 policies plus `/usr/share/chairlift/config.yml`. The packages declare conflicts
 because they intentionally own the same privileged files.
 
-The integration package does **not** ship `bootc-update-stage`. That operation
-is distro policy, so an image that enables `bootc_updates_group` must provide a
-trusted implementation at the existing fixed
-`/usr/libexec/bootc-update-stage` path. Keeping the path fixed preserves the
-PolicyKit executable boundary; making it a user-writable config value would
-allow the GUI configuration to redirect a root execution. The page already
-gates the group on `bootc.StageScriptAvailable`, so an absent distro helper
-hides the operation.
+The integration package does **not** ship `bootc-update-stage` or
+`snosi-sysupdate-stage`. Those operations are distro policy, so an image that
+enables `bootc_updates_group` must provide a trusted implementation at the
+existing fixed `/usr/libexec/bootc-update-stage` path, and native A/B images
+ship `/usr/libexec/snosi-sysupdate-stage` (plus the `/usr/lib/snosi/native-ab`
+marker) themselves. Keeping the paths fixed preserves the PolicyKit executable
+boundary; making either a user-writable config value would allow the GUI
+configuration to redirect a root execution. The page already gates each group
+on its script-availability check (`bootc.StageScriptAvailable`,
+`sysupdate.StageScriptAvailable`), so an absent distro helper hides the
+operation.
 
 ### Maintenance action execution
 
@@ -1167,6 +1180,7 @@ page_name:
 | `system_page` | `bootc_status_group` | bootc deployment status display (gated on `bootc.IsBootcBootedCached()`) |
 | `system_page` | `health_group` | System monitor launcher (configurable `app_id`, default: Mission Center) |
 | `updates_page` | `bootc_updates_group` | bootc system updates — stage via `bootc-update-stage`, apply on restart (gated on `bootc.IsBootcBootedCached()` and stage script availability) |
+| `updates_page` | `sysupdate_updates_group` | native A/B system updates — stage via `snosi-sysupdate-stage`, apply on restart, with a read-only previous-version rollback row (gated on `sysupdate.IsNativeABCached()` and stage script availability) |
 | `updates_page` | `flatpak_updates_group` | Flatpak pending updates |
 | `updates_page` | `brew_updates_group` | Homebrew outdated packages |
 | `updates_page` | `brew_trust_group` | Untrusted Homebrew taps with installed packages (Homebrew 6 tap trust); hidden unless there is something to trust |
@@ -1200,6 +1214,7 @@ page_name:
 - Homebrew (optional)
 - Flatpak (optional)
 - `bootc` + `/usr/libexec/bootc-update-stage` (both optional; UI gated on `bootc.IsBootcBootedCached()`, i.e. `bootc status` reporting a non-null `booted` deployment — not on any sentinel file)
+- `/usr/lib/snosi/native-ab` marker + `/usr/libexec/snosi-sysupdate-stage` (both optional, shipped by native A/B OS images; UI gated on `sysupdate.IsNativeABCached()` and `sysupdate.StageScriptAvailable()`)
 - Updex features configured on the system (optional; read via Go library, writes via `chairlift-updex-helper`)
 
 ### Key external Go dependencies

--- a/yeti/package-managers.md
+++ b/yeti/package-managers.md
@@ -269,7 +269,7 @@ clear/add bookkeeping; no `_test.go` is added to `internal/views`.
 `internal/views/badgestate` is one of the nine puregotk-free leaf packages
 under `internal/views`. `Counts` replaces the three independent integer fields
 that previously lived on `UserHome` with one mutex-protected owner for Bootc,
-Flatpak, and Homebrew update counts. `Set(source, count)` models a completed
+Sysupdate, Flatpak, and Homebrew update counts. `Set(source, count)` models a completed
 provider refresh and replaces that provider's prior value; `Add(source,
 delta)` models an immediate row-level change such as a successful Homebrew
 upgrade. Both clamp negative results to zero and return an atomic
@@ -280,7 +280,7 @@ leaf package owns only integers and synchronization. `badgestate_test.go`
 proves the zero value, multi-provider totals, replacement rather than
 accumulation across repeated refreshes, decrement/clamping behavior, unknown
 source rejection, and concurrent changes under the race detector.
-`wiring_test.go` verifies `views.go` and `updates_page.go` route all three
+`wiring_test.go` verifies `views.go` and `updates_page.go` route all four
 providers and the displayed total through this owner, and rejects the retired
 independent count fields.
 
@@ -528,6 +528,143 @@ for event := range progressCh {
 
 `onBootcStageClicked()` drives the updates page's "System Update" expander directly (there is a single staging operation, so no shared cross-operation helper is needed) — it disables the button, spawns `bootc.StageUpdate` in a goroutine, and processes events on a second goroutine, restoring button state and showing a toast on completion. The system page's `loadBootcStatus()` is a separate, read-only path: it calls `bootc.GetStatus` to display the booted/staged/rollback deployment images, versions, and digests, with no staging controls — staging only happens from the Updates page.
 
+## snosi sysupdate (`internal/sysupdate/`)
+
+The native A/B (systemd-sysupdate) OS-update wrapper, mirroring
+`internal/bootc`'s split: `sysupdate.go` (detection, dry-run, errors,
+context), `status.go` (unprivileged state-file reads and the presentation
+decision), `rollback.go` (unprivileged previous-version discovery), and
+`stage.go` (privileged staging via pkexec). Everything is puregotk-free and
+gate-tested.
+
+### Host detection
+
+`IsNativeAB()` is an `os.Stat` of `MarkerPath`
+(`/usr/lib/snosi/native-ab`); `IsNativeABCached()` memoizes it via
+`sync.Once`. The marker is snosi's own published contract — every snosi unit
+gates on `ConditionPathExists=/usr/lib/snosi/native-ab` — and is the only
+reliable signal: the `bootc` binary is absent on native A/B images (so a
+bootc probe would hard-fail rather than return false cleanly), and
+`os-release`'s `IMAGE_ID` is identical across the bootc and native A/B
+variants of the same product. The updates-page group additionally requires
+`StageScriptAvailable()` (`os.Stat` of
+`StageScriptPath = /usr/libexec/snosi-sysupdate-stage`).
+
+### Status reads (unprivileged)
+
+The snosi stager writes two world-readable state files under `/run/snosi`
+(tmpfs — both are cleared by the reboot that applies an update):
+
+- `UpdateCheckPath` (`/run/snosi/update-check`), written on every stager run:
+  `outcome=(current|staged|failed)`, `checked_at=<ISO-8601>`,
+  `image=<channel>`, `running_version=`, `remote_version=`. The bootc-only
+  `held-rollback` outcome never occurs on native; `ParseUpdateCheck` maps it
+  (and any unknown value) to `OutcomeUnknown` rather than erroring.
+- `StagedSemaphorePath` (`/run/snosi/update-staged`), present exactly while a
+  downloaded update awaits its applying reboot: `image=`, `staged_at=`, and
+  exactly one of `version=<14-digit>` (native) or `digest=sha256:...`
+  (bootc transport — the file language is shared, so `ParseStagedUpdate`
+  reads both and `DisplayVersion()` prefers the valid version, then a
+  shortened digest).
+
+`GetStatus()` reads both via unexported per-path seams
+(`readUpdateCheckFrom`/`readStagedUpdateFrom`); an absent file is a normal
+state reported as nil, and a read error is logged and treated as absent, so
+the UI degrades to the idle prompt rather than an error.
+`Status.Presentation()` reduces the pair to `(outcome, version, checkedAt)`
+scalars for `pageview.SysupdateUpdateSubtitle`, one row per outcome:
+semaphore present → staged with the semaphore's version (the semaphore wins
+over every check outcome — it legitimately outlives later "nothing newer"
+check runs); no semaphore but `outcome=staged` → staged with
+`remote_version`; `outcome=current` → current with the check time;
+`outcome=failed` → failed; absent/unknown → idle. `Status.IsStaged()` is the
+badge rule: true iff the semaphore exists or the check recorded
+`outcome=staged`. Versions follow the frozen native grammar `ValidVersion`
+(`^[0-9]{14}$`, UTC `YYYYMMDDHHMMSS`) whose fixed width makes lexicographic
+comparison numeric.
+
+### Rollback discovery (unprivileged, read-only)
+
+`RollbackVersion(ctx)` runs `lsblk -J -o PATH,PARTLABEL` and reads
+`IMAGE_ID`/`IMAGE_VERSION` from `/usr/lib/os-release`. `otherSlotFromLsblk`
+walks the JSON recursively (lsblk nests partitions under each disk's
+`children`) selecting labels `<IMAGE_ID>_<version>_r` and excluding the
+running slot **by its PARTLABEL** — never by comparing mount sources,
+because a dm-verity root mounts from `/dev/mapper/root`, which never equals
+a partition path. A fresh install's `_empty` label fails the prefix filter
+naturally. `RollbackCandidate(other, running)` then accepts the other slot's
+version only when it is **older** than the running one: after a stage the
+inactive slot holds the newer pending version, which is not a rollback
+target. The Updates page renders the result as a read-only "Previous
+Version" row (`pageview.SysupdateRollbackSubtitle`); actual rollback is a
+systemd-boot menu selection at restart, deliberately outside ChairLift's
+privilege boundary. `/boot` is never read (the ESP mounts `umask=0077`,
+root-only).
+
+### StageUpdate (privileged)
+
+`StageUpdate(ctx, progressCh)` runs `pkexec /usr/libexec/snosi-sysupdate-stage`
+(polkit action `org.frostyard.ChairLift.sysupdate.stage`,
+`data/org.frostyard.ChairLift.sysupdate.policy`, exec.path annotation, no
+argv). The script — shipped by the OS image, not ChairLift — checks the
+sysupdate target for a newer version, downloads it into the inactive
+root/verity slots via `systemd-sysupdate update`, verifies the result
+against the signed index, and writes both state files; it never reboots and
+is idempotent (exits 0 without staging when already current or when the
+candidate already sits in the inactive slot). Output streams line-by-line
+through the same `runStageStreaming` shape as bootc's, with the same
+direct-child-kill rationale (the pkexec child is root-owned, so no
+process-group signaling). The stager takes no flock; ChairLift's
+button-disable prevents UI-origin overlap, and the OS's
+`snosi-sysupdate-stage.timer` is inert by default, but a concurrent
+timer-driven run is a residual (currently theoretical) race that belongs to
+the OS-owned helper to close.
+
+### Event types
+
+`ProgressEvent{Type, Message}` with `EventMessage` (one output line) and
+`EventComplete` (success). Same enumeration as bootc's; failures are
+returned as the function error, never as an event.
+
+### Error classification (`runStageStreaming` / `StageUpdate`)
+
+| Outcome | Returned type | `errors.Is` sentinel |
+|---------|---------------|----------------------|
+| Deadline | `*Error` "Update staging timed out" | `context.DeadlineExceeded` |
+| Canceled | `*Error` "Update staging was canceled" (or bare `ctx.Err()` when the stream send loses the race) | `context.Canceled` |
+| Missing executable | `*NotFoundError` | — (`exec.ErrNotFound` or `fs.ErrNotExist` at start) |
+| Non-zero exit | `*Error` carrying exit code + last output line | neither context sentinel |
+
+### Dry-run behavior
+
+`StageUpdate` short-circuits before constructing any `exec.Cmd`: logs the
+would-be command, emits the synthetic `EventMessage`+`EventComplete` pair,
+closes the channel, returns nil — pkexec is never invoked and no auth
+dialog appears. Status and rollback reads are **not** dry-run-gated (they
+are side-effect-free reads of real state), matching the bootc toast/subtitle
+split: only the toast (`actionmsg.SysupdateStage`) is dry-run-aware.
+
+### Operations
+
+| Function | Command | Privilege | Timeout | Notes |
+|----------|---------|-----------|---------|-------|
+| `GetStatus()` | reads `/run/snosi/update-check` + `/run/snosi/update-staged` | none | — (local file reads) | Absent files are normal states, not errors |
+| `IsNativeAB()` / `IsNativeABCached()` | `os.Stat(MarkerPath)` | none | — | Host-type gate; cached variant memoizes via `sync.Once` |
+| `RollbackVersion(ctx)` | `lsblk -J -o PATH,PARTLABEL` + `/usr/lib/os-release` | none | caller's ctx | Older-only candidate rule |
+| `StageUpdate(ctx, progressCh)` | `pkexec /usr/libexec/snosi-sysupdate-stage` | pkexec (`org.frostyard.ChairLift.sysupdate.stage`) | 30min (`DefaultContext`) | Streaming; idempotent; dry-run aware |
+| `StageScriptAvailable()` | `os.Stat(StageScriptPath)` | none | — | Hides the updates-page group when the script isn't installed |
+
+### Progress UI (`internal/views/updates_page.go`)
+
+`onSysupdateStageClicked()` is a structural clone of `onBootcStageClicked()`:
+disable button, stream events into a spinner activity row and Details log
+expander, then re-read `GetStatus()` and `RollbackVersion()` from real state
+(not stream output) to set the subtitle
+(`pageview.SysupdateStageResultSubtitle`), rollback row, badge
+(`badgestate.Sysupdate`, 1 iff `IsStaged()`), and toast
+(`actionmsg.SysupdateStage`). `loadSysupdateUpdateStatus()` performs the
+initial gate + reveal.
+
 ## Updex (`internal/updex/updex.go`)
 
 Manages system features (add-on software/configuration modules). Unlike other wrappers, updex does **not** shell out to a CLI for reads. It uses the `github.com/frostyard/updex/updex` Go library directly for read operations, with a singleton `*updexapi.Client`. Write operations that require root are delegated via pkexec to the fixed absolute path `internal/updex.HelperPath` (`/usr/bin/chairlift-updex-helper`, built from `cmd/chairlift-updex-helper/main.go`) — never a bare, `$PATH`-resolved name, since `pkexec` matches the resolved absolute path against `data/org.frostyard.ChairLift.updex.policy`'s `org.freedesktop.policykit.exec.path` annotation to select the right action; see [OVERVIEW.md](./OVERVIEW.md#privileged-operations) for the full rationale and the matching `PREFIX=/usr` Makefile requirement.
@@ -586,6 +723,7 @@ Every wrapper has `SetDryRun(bool)` and `IsDryRun() bool`. Behavior varies by wr
 | Homebrew | Skips state-changing commands, returns mock message | Yes |
 | Flatpak | Skips state-changing commands, returns mock message | Yes |
 | bootc | `StageUpdate` never invokes pkexec; emits synthetic `EventMessage`+`EventComplete` and returns. The Updates page's stage button shows an explicit `actionmsg.BootcStage(bootc.IsDryRun(), staged)` preview toast, distinct from its normal staged/up-to-date toasts; the expander subtitle intentionally stays live (from `bootc.GetStatus()`) in both modes | Yes |
+| sysupdate | `StageUpdate` never invokes pkexec; emits synthetic `EventMessage`+`EventComplete` and returns. The stage button's toast is `actionmsg.SysupdateStage(sysupdate.IsDryRun(), staged)`; the expander subtitle and rollback row stay live (from the `/run/snosi` state files and partition labels) in both modes | Yes |
 | Updex | Skips helper execution, returns empty results; the helper binary itself (`cmd/chairlift-updex-helper`, via `internal/updexhelper`) also honors `--dry-run` for all three subcommands, defense-in-depth even though `updex.runHelper` never invokes pkexec under dry-run | Yes |
 | views (custom maintenance scripts) | `runMaintenanceAction` never constructs an `exec.Cmd` (no `pkexec`, no direct script exec); logs `[DRY-RUN] Would execute: ...` instead | Yes |
 
@@ -706,8 +844,9 @@ installed layout itself:
   DESTDIR=<t.TempDir()>` — a dry run, so no compilation, no writes outside
   the temp dir, and no root — once with no `PREFIX` override and once with
   `PREFIX=/usr`, and asserts the printed `install -Dm...` lines place the
-  updex helper at `DESTDIR` + `internal/updex.HelperPath` and both policies
-  under the fixed `/usr/share/polkit-1/actions` directory PolicyKit reads,
+  updex helper at `DESTDIR` + `internal/updex.HelperPath` and all three
+  policies under the fixed `/usr/share/polkit-1/actions` directory PolicyKit
+  reads,
   removes both legacy rules from `DESTDIR/usr/share/polkit-1/rules.d`,
   installs maintainer defaults at
   `DESTDIR/usr/share/chairlift/config.yml`, and never targets the


### PR DESCRIPTION
## Summary

Snow Linux's native A/B install variant (GPT root/verity slot pairs + UKI in the ESP, updated by systemd-sysupdate) had no OS-update surface in ChairLift — the Updates page only handled bootc hosts. This adds a `sysupdate_updates_group` that mirrors the existing bootc group, plus a read-only rollback row.

- **New `internal/sysupdate` wrapper** (puregotk-free, fully table-tested): host detection via snosi's canonical `/usr/lib/snosi/native-ab` marker (the OS's own published contract — `IMAGE_ID` is identical across variants and the `bootc` binary is absent on A/B images); unprivileged status from the world-readable `/run/snosi/update-check` / `update-staged` state files (staged semaphore wins; unknown outcomes degrade to the idle prompt); rollback-candidate discovery from partition labels via `lsblk` (running slot excluded by PARTLABEL, and only an **older** other-slot version qualifies — a freshly staged newer image is pending, not a rollback); streaming staging via `pkexec /usr/libexec/snosi-sysupdate-stage` with the same dry-run short-circuit and error classification as `internal/bootc`.
- **Privilege boundary**: new polkit action `org.frostyard.ChairLift.sysupdate.stage` with identical auth defaults and `exec.path` annotation shape to the bootc policy. ChairLift ships only the policy; the OS image ships the stage script. Makefile, both nFPM packages, archives, all installcheck assertions (including the system-integration package's exact-contents count 3→4), and the e2e staged-install file list updated in lockstep.
- **UI**: "System Updates" group built hidden, revealed only when marker + helper exist; check/stage button streams helper output into Progress/Details rows; "Previous Version" rollback row; new `badgestate.Sysupdate` provider (1 iff staged); dry-run-aware toast with the live-subtitle exception matching bootc. The bootc and native A/B runtime gates are mutually exclusive, so at most one System Updates group ever appears.
- **Docs**: AGENTS.md invariants (three fixed pkexec targets now), CONFIG.md, docs/reference.md, docs/index.md, README.md, shipped configs, yeti/OVERVIEW.md (new "Native A/B gate" section), and a full `## snosi sysupdate` section in yeti/package-managers.md.

## Test plan

- `make ci` passes end-to-end (tidy, vet, gofmt, lint, unit tests under CI's `-run "^Test[^I]"` filter, race detector, cross-arch builds).
- `make e2e`'s staged-install/helper-boundary test passes with the new policy in the exact file list (the GTK smoke test needs the hosted job's xvfb).
- Verified live on a native A/B host with a genuinely staged update: the group reveals with "Update 20260810200801 staged — restart to apply", badge increments, and the rollback row correctly reports no candidate while the inactive slot holds the staged newer version.

## Notes

- The snosi stager takes no `flock`; a timer-driven run racing a GUI-triggered one is a theoretical concern documented in yeti/package-managers.md — the fix belongs in the OS-owned helper.
- A System-page A/B status group (sibling of `bootc_status_group`) is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)