### PR TITLE
docs: link org-wide conventions to frostyard/core ADRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,3 +189,9 @@ distilled from a previous automated run of
 here via `.mill.toml`); they are binding guidance, not suggestions. New skills
 are added by the mill's harvest step and reviewed like any other change in the
 PR that carries them.
+
+## Org-wide decisions
+
+Org-level conventions this repo follows are recorded as ADRs in
+frostyard/core — see [docs/org-adrs.md](docs/org-adrs.md) for the list that
+binds this repo. Change the ADR (in core) before changing behavior it covers.

--- a/docs/org-adrs.md
+++ b/docs/org-adrs.md
@@ -1,0 +1,23 @@
+# Org-wide decisions (frostyard/core ADRs)
+
+Conventions this repository follows that are decided at the org level are
+recorded as ADRs in
+[frostyard/core](https://github.com/frostyard/core/tree/main/docs/adr).
+The ones that bind ChairLift:
+
+- [ADR-0004 — Product-namespaced filesystem paths, split by lifetime tier](https://github.com/frostyard/core/blob/main/docs/adr/0004-product-namespaced-filesystem-tiers.md) — /etc/chairlift vs /usr/share/chairlift config precedence follows this
+- [ADR-0005 — Transport discrimination by marker file and /run update-state contract](https://github.com/frostyard/core/blob/main/docs/adr/0005-native-ab-marker-and-update-state-files.md) — internal/sysupdate consumes /usr/lib/snosi/native-ab and /run/snosi/update-*
+- [ADR-0010 — Publish packages through the shared repogen action](https://github.com/frostyard/core/blob/main/docs/adr/0010-publish-packages-via-repogen-to-r2.md) — release.yml publish step
+- [ADR-0011 — Distro packages are named frostyard-<tool>](https://github.com/frostyard/core/blob/main/docs/adr/0011-frostyard-prefixed-package-names.md) — frostyard-chairlift / frostyard-chairlift-system-integration
+- [ADR-0012 — svu-derived versions, make bump, and the rolling dev prerelease](https://github.com/frostyard/core/blob/main/docs/adr/0012-svu-versioning-and-rolling-dev-prerelease.md) — .svu.yaml, dev tag, snapshot concurrency group
+- [ADR-0013 — Component releases trigger image rebuilds via repository_dispatch](https://github.com/frostyard/core/blob/main/docs/adr/0013-release-fanout-via-repository-dispatch.md) — snapshot.yml dispatches `build` to frostyard/snow
+- [ADR-0015 — os-release is the image identity surface](https://github.com/frostyard/core/blob/main/docs/adr/0015-os-release-image-identity.md) — why transport detection uses the marker file, never IMAGE_ID
+- [ADR-0016 — Reverse-DNS org.frostyard.* identifiers](https://github.com/frostyard/core/blob/main/docs/adr/0016-reverse-dns-org-frostyard-identifiers.md) — org.frostyard.ChairLift app ID, desktop file, polkit actions
+- [ADR-0018 — Org-wide agent instruction and knowledge surfaces](https://github.com/frostyard/core/blob/main/docs/adr/0018-org-wide-agent-instruction-and-knowledge-surfaces.md) — AGENTS.md symlinks, yeti/, docs/agents/skills, .memory/
+- [ADR-0019 — Repository governance as machine-readable policy with risk tiers](https://github.com/frostyard/core/blob/main/docs/adr/0019-governance-as-code-and-risk-tiers.md) — .github/policies/, auto-qa-tuning, risk tiers
+- [ADR-0020 — Trust boundaries for AI automation in CI](https://github.com/frostyard/core/blob/main/docs/adr/0020-ai-automation-trust-boundaries.md) — claude-code-review analyze/publish split, HTML idempotency markers
+- [ADR-0021 — SHA-pinned actions and least-privilege CI workflows](https://github.com/frostyard/core/blob/main/docs/adr/0021-sha-pinned-actions-and-least-privilege-ci.md) — enforced by internal/installcheck/workflows_test.go
+- [ADR-0022 — make ci is the canonical gate; TestI* is reserved](https://github.com/frostyard/core/blob/main/docs/adr/0022-make-ci-gate-and-test-naming-filter.md) — make ci, the Test[^I] filter, internal/installcheck pattern
+
+When changing behavior covered by one of these, update or supersede the ADR
+in frostyard/core first, then change this repo in the same effort.


### PR DESCRIPTION
## Summary

An org-wide sweep extracted chairlift's implicit conventions (filesystem tiers, update-state contract, packaging and release flow, identifiers, CI governance) into ADRs in [frostyard/core](https://github.com/frostyard/core/tree/main/docs/adr). This PR adds the back-links:

- New `docs/org-adrs.md` listing the 13 core ADRs that bind ChairLift, each with a note on where it applies in this repo.
- A short "Org-wide decisions" section at the end of `AGENTS.md` pointing at that list.

## Related issue

None — part of the org-wide ADR back-linking sweep.

## Change classification

- Risk tier: Tier 1 - Low
- Rationale: documentation-only, no code or workflow changes

## Validation

- [x] `go test ./internal/installcheck/` (documentation consistency tests) — pass
- [ ] `make ci`

## Tests and documentation

- Tests: none needed; existing documentation consistency tests pass unchanged.
- Documentation: this change is documentation.

## Review readiness

- [x] The diff contains no unrelated refactors or generated artifacts.
- [x] Changed behavior has CI-enforced regression coverage, or this change does
      not alter behavior.
- [x] Relevant repository invariants in `AGENTS.md` remain intact.
- [x] I reviewed the change against `docs/review-rubric.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)