### PR TITLE
chore: sync agent skills from frostyard/core

### DIFF
--- a/docs/agents/skills/frostyard-go-repo/.synced-from-core
+++ b/docs/agents/skills/frostyard-go-repo/.synced-from-core
@@ -1,3 +1,3 @@
 Managed by frostyard/core — edit there, not here (ADR-0026).
 Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-go-repo
-Synced from: frostyard/core@f7f2284
+Synced from: frostyard/core@a4e2614

--- a/docs/agents/skills/frostyard-repo-docs/.synced-from-core
+++ b/docs/agents/skills/frostyard-repo-docs/.synced-from-core
@@ -1,3 +1,3 @@
 Managed by frostyard/core — edit there, not here (ADR-0026).
 Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-repo-docs
-Synced from: frostyard/core@f7f2284
+Synced from: frostyard/core@a4e2614

--- a/docs/agents/skills/frostyard-repo-docs/SKILL.md
+++ b/docs/agents/skills/frostyard-repo-docs/SKILL.md
@@ -44,6 +44,7 @@ If the repo lacks the shape, or still has a `yeti/`/`cairn/` tree:
      `docs/specs/<name>.md`; other subsystem docs → `docs/design/<name>.md`
    - `learnings/*` → fold each into the right doc now and delete it; a
      learning not yet foldable moves to the `.memory/` inbox.
+
    The old directory must end up gone.
 4. Update **every** reference to the old paths — they are load-bearing.
    Search broadly (`grep -rIn 'yeti\|cairn' . --exclude-dir=.git`) and
@@ -72,6 +73,7 @@ If the repo lacks the shape, or still has a `yeti/`/`cairn/` tree:
    - **Architecture** — key directories, modules, how they fit together
    - **Key Patterns** — important conventions, data flow, design decisions
    - **Configuration** — key config values and environment variables
+
    Keep it 200–500 lines; link out rather than inline detail.
 3. Complex subsystems get dedicated docs — `docs/design/` for how-it-works,
    `docs/specs/` for exact contracts — one subject each, linked from


### PR DESCRIPTION
Automated skill sync from [frostyard/core](https://github.com/frostyard/core) @ a4e2614 per [ADR-0026](https://github.com/frostyard/core/blob/main/docs/adr/0026-distribute-core-skills-via-sync-prs.md).

Synced skills: frostyard-go-repo frostyard-repo-docs

These directories are managed in core — edit them there, not here. Local edits are overwritten by the next sync.

Risk tier: 1 — documentation/skills only, no code or workflow changes.