### PR TITLE
chore: sync agent skills from frostyard/core

### DIFF
--- a/docs/agents/skills/frostyard-go-repo/.synced-from-core
+++ b/docs/agents/skills/frostyard-go-repo/.synced-from-core
@@ -1,3 +1,2 @@
 Managed by frostyard/core — edit there, not here (ADR-0026).
 Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-go-repo
-Synced from: frostyard/core@a4e2614

--- a/docs/agents/skills/frostyard-repo-docs/.synced-from-core
+++ b/docs/agents/skills/frostyard-repo-docs/.synced-from-core
@@ -1,3 +1,2 @@
 Managed by frostyard/core — edit there, not here (ADR-0026).
 Source: https://github.com/frostyard/core/tree/main/.agents/skills/frostyard-repo-docs
-Synced from: frostyard/core@a4e2614


### PR DESCRIPTION
Automated skill sync from [frostyard/core](https://github.com/frostyard/core) @ 02fa3a6 per [ADR-0026](https://github.com/frostyard/core/blob/main/docs/adr/0026-distribute-core-skills-via-sync-prs.md).

Synced skills: frostyard-go-repo frostyard-repo-docs

These directories are managed in core — edit them there, not here. Local edits are overwritten by the next sync.

Risk tier: 1 — documentation/skills only, no code or workflow changes.