### PR TITLE
chore: sync agent skills from frostyard/core

### DIFF
--- a/docs/agents/skills/frostyard-go-repo/SKILL.md
+++ b/docs/agents/skills/frostyard-go-repo/SKILL.md
@@ -74,9 +74,17 @@ Rules:
      to the org apt/rpm repo via `frostyard/repogen`'s `publish-to-r2`
      action (needs the `R2_*` secrets).
    - `snapshot.yml` — nightly GoReleaser `release --nightly --clean` under
-     the `dev` tag after green `main` tests. Keep its concurrency group
-     `cancel-in-progress: true`: overlapping runs recreate the same release
-     and collide uploading identically named assets.
+     the `dev` tag after green `main` tests. Use this exact top-level block:
+
+     ```yaml
+     concurrency:
+       group: goreleaser-nightly
+       cancel-in-progress: true
+     ```
+
+     Concurrency groups are repository-scoped, so do not substitute the
+     project name. Cancelling a stale run selects the newest tested `main`
+     commit and prevents overlapping uploads to the singleton release.
 4. **Write the repo's agent surface** (CLAUDE.md/AGENTS.md per the repo's
    instruction-surface convention): build commands, architecture map,
    code-pattern rules — mirror updex's CLAUDE.md sections.


### PR DESCRIPTION
Automated skill sync from [frostyard/core](https://github.com/frostyard/core) @ 246a0c0 per [ADR-0026](https://github.com/frostyard/core/blob/main/docs/adr/0026-distribute-core-skills-via-sync-prs.md).

Synced skills: frostyard-acmm-conformance frostyard-go-repo frostyard-repo-docs

These directories are managed in core — edit them there, not here. Local edits are overwritten by the next sync.

Risk tier: 1 — documentation/skills only, no code or workflow changes.