### PR TITLE
chore: sync agent skills from frostyard/core

### DIFF
--- a/docs/agents/skills/frostyard-acmm-conformance/SKILL.md
+++ b/docs/agents/skills/frostyard-acmm-conformance/SKILL.md
@@ -9,7 +9,7 @@ The Hive ACMM evaluation grades repositories by checking that fixed paths
 exist. Each generated issue lists acceptable paths and states "the content
 can follow your project's conventions" — satisfying **any one** listed path
 satisfies the criterion, and only existence is checked. The frostyard
-answer ([core ADR-0029](../../../docs/adr/0029-acmm-conformance-via-canonical-aliases.md))
+answer ([core ADR-0029](https://github.com/frostyard/core/blob/main/docs/adr/0029-acmm-conformance-via-canonical-aliases.md))
 is: never create a second copy of anything. Done looks like: every `acmm`
 issue closable by one PR, `scripts/check-docs.mjs` green, zero duplicated
 content, and the alias table registered in a repo-local ADR.
@@ -69,7 +69,7 @@ repogen#37–#55).
    | Session summary | `.claude/session-summary.md` (current state / last landed / next) |
 
 5. **Wire the gate.** Copy core's
-   [`scripts/check-docs.mjs`](../../../scripts/check-docs.mjs) and adapt
+   [`scripts/check-docs.mjs`](https://github.com/frostyard/core/blob/main/scripts/check-docs.mjs) and adapt
    only: the `SKIP_DIRS` set (add the repo's build-output dirs) and the
    link-checked file list. It fails CI on any broken or repo-escaping
    symlink, unindexed doc, or dead relative link. Add a `docs-gate` job

--- a/docs/agents/skills/frostyard-repo-docs/SKILL.md
+++ b/docs/agents/skills/frostyard-repo-docs/SKILL.md
@@ -7,7 +7,7 @@ description: Give a frostyard repo core's four-category docs/ shape (adr/, desig
 
 Every frostyard repo keeps one documentation tree, `docs/`, in the same
 shape as frostyard/core's
-([core ADR-0025](../../../docs/adr/0025-consolidate-repository-docs-into-docs.md)):
+([core ADR-0025](https://github.com/frostyard/core/blob/main/docs/adr/0025-consolidate-repository-docs-into-docs.md)):
 
 | Directory | Question | Contents |
 | --- | --- | --- |


### PR DESCRIPTION
Automated skill sync from [frostyard/core](https://github.com/frostyard/core) @ 451b380 per [ADR-0026](https://github.com/frostyard/core/blob/main/docs/adr/0026-distribute-core-skills-via-sync-prs.md).

Synced skills: frostyard-acmm-conformance frostyard-go-repo frostyard-repo-docs

These directories are managed in core — edit them there, not here. Local edits are overwritten by the next sync.

Risk tier: 1 — documentation/skills only, no code or workflow changes.